### PR TITLE
Add Windows release CI and daemon watchdog

### DIFF
--- a/.github/workflows/basic-unit-tests-linux-arm64.yml
+++ b/.github/workflows/basic-unit-tests-linux-arm64.yml
@@ -1,0 +1,49 @@
+name: Basic unit tests (Linux arm64)
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  basic:
+    name: Go and Python basic unit tests
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install Python tooling
+        run: python -m pip install --upgrade pip uv
+
+      - name: Run Go basic unit tests
+        run: |
+          go test $(go list ./... | grep -v '/internal/hv/kvm$')
+
+      - name: Build ccvm for Python unit tests
+        run: |
+          mkdir -p build
+          go build -o build/ccvm ./cmd/ccvm
+
+      - name: Run Python unit tests
+        working-directory: pyneurodesk
+        env:
+          PYNEURODESK_CCVM: ${{ github.workspace }}/build/ccvm
+        run: uv run pytest

--- a/.github/workflows/basic-unit-tests-linux-arm64.yml
+++ b/.github/workflows/basic-unit-tests-linux-arm64.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Go basic unit tests
         run: |
-          go test $(go list ./... | grep -v '/internal/hv/kvm$')
+          go test -short $(go list ./... | grep -v '/internal/hv/kvm$')
 
       - name: Build ccvm for Python unit tests
         run: |

--- a/.github/workflows/basic-unit-tests-macos-arm64.yml
+++ b/.github/workflows/basic-unit-tests-macos-arm64.yml
@@ -1,0 +1,49 @@
+name: Basic unit tests (macOS arm64)
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  basic:
+    name: Go and Python basic unit tests
+    runs-on: macos-14
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install Python tooling
+        run: python -m pip install --upgrade pip uv
+
+      - name: Run Go basic unit tests
+        run: |
+          go test $(go list ./... | grep -v '/internal/hv/hvf$')
+
+      - name: Build ccvm for Python unit tests
+        run: |
+          mkdir -p build
+          go build -o build/ccvm ./cmd/ccvm
+
+      - name: Run Python unit tests
+        working-directory: pyneurodesk
+        env:
+          PYNEURODESK_CCVM: ${{ github.workspace }}/build/ccvm
+        run: uv run pytest

--- a/.github/workflows/basic-unit-tests-macos-arm64.yml
+++ b/.github/workflows/basic-unit-tests-macos-arm64.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Go basic unit tests
         run: |
-          go test $(go list ./... | grep -v '/internal/hv/hvf$')
+          go test -short $(go list ./... | grep -v '/internal/hv/hvf$')
 
       - name: Build ccvm for Python unit tests
         run: |

--- a/.github/workflows/basic-unit-tests-windows-amd64.yml
+++ b/.github/workflows/basic-unit-tests-windows-amd64.yml
@@ -37,7 +37,7 @@ jobs:
         shell: pwsh
         run: |
           $packages = go list ./... | Where-Object { $_ -notmatch '/internal/hv/whp$' }
-          go test $packages
+          go test -short $packages
 
       - name: Build ccvm for Python unit tests
         shell: pwsh

--- a/.github/workflows/basic-unit-tests-windows-amd64.yml
+++ b/.github/workflows/basic-unit-tests-windows-amd64.yml
@@ -1,0 +1,52 @@
+name: Basic unit tests (Windows amd64)
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  basic:
+    name: Go and Python basic unit tests
+    runs-on: windows-2025
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install Python tooling
+        run: python -m pip install --upgrade pip uv
+
+      - name: Run Go basic unit tests
+        shell: pwsh
+        run: |
+          $packages = go list ./... | Where-Object { $_ -notmatch '/internal/hv/whp$' }
+          go test $packages
+
+      - name: Build ccvm for Python unit tests
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force build | Out-Null
+          go build -o build/ccvm.exe ./cmd/ccvm
+
+      - name: Run Python unit tests
+        working-directory: pyneurodesk
+        env:
+          PYNEURODESK_CCVM: ${{ github.workspace }}/build/ccvm.exe
+        run: uv run pytest

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,16 +25,25 @@ jobs:
             goos: linux
             goarch: amd64
             platform-tag: manylinux_2_28_x86_64
+            binary-name: ccvm
           - name: linux-arm64
             runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             platform-tag: manylinux_2_28_aarch64
+            binary-name: ccvm
           - name: macos-arm64
             runner: macos-14
             goos: darwin
             goarch: arm64
             platform-tag: macosx_14_0_arm64
+            binary-name: ccvm
+          - name: windows-amd64
+            runner: ubuntu-24.04
+            goos: windows
+            goarch: amd64
+            platform-tag: win_amd64
+            binary-name: ccvm.exe
 
     steps:
       - name: Check out repository
@@ -80,7 +89,7 @@ jobs:
           print(wheel)
           with ZipFile(wheel) as zf:
               names = set(zf.namelist())
-              expected = "pyneurodesk/bin/ccvm"
+              expected = "pyneurodesk/bin/${{ matrix.binary-name }}"
               if expected not in names:
                   raise SystemExit(f"{expected} was not included in {wheel.name}")
               wheel_metadata = next(name for name in names if name.endswith(".dist-info/WHEEL"))

--- a/.github/workflows/pyneurodesk-fulltests.yml
+++ b/.github/workflows/pyneurodesk-fulltests.yml
@@ -2,6 +2,8 @@ name: PyNeurodesk fulltests
 
 "on":
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,6 @@ name: Unit tests
   push:
     branches:
       - main
-      - feature/**
   pull_request:
   workflow_dispatch:
 
@@ -81,3 +80,6 @@ jobs:
 
       - name: Compile Darwin arm64 HVF package
         run: GOOS=darwin GOARCH=arm64 go test -c -o /tmp/ccx3-hvf-darwin-arm64.test ./internal/hv/hvf
+
+      - name: Compile Windows amd64 packages
+        run: GOOS=windows GOARCH=amd64 go test -run '^$' -exec /bin/true ./...

--- a/cmd/ccvm/main.go
+++ b/cmd/ccvm/main.go
@@ -77,6 +77,9 @@ func (w *watchdogController) Feed() bool {
 	if !w.active || w.timer == nil {
 		return false
 	}
+	if !w.timer.Stop() {
+		return false
+	}
 	w.timer.Reset(w.timeout)
 	return true
 }

--- a/cmd/ccvm/main.go
+++ b/cmd/ccvm/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/net/websocket"
@@ -40,6 +41,68 @@ type server struct {
 	images        *oci.Store
 	vms           *vm.Manager
 	cvmfsCacheDir string
+}
+
+type watchdogController struct {
+	mu        sync.Mutex
+	timeout   time.Duration
+	timer     *time.Timer
+	active    bool
+	onExpired func()
+}
+
+type watchdogRequest struct {
+	TimeoutSeconds float64 `json:"timeout_seconds,omitempty"`
+}
+
+func newWatchdogController(onExpired func()) *watchdogController {
+	return &watchdogController{onExpired: onExpired}
+}
+
+func (w *watchdogController) Create(timeout time.Duration) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.timeout = timeout
+	w.active = true
+	if w.timer == nil {
+		w.timer = time.AfterFunc(timeout, w.expire)
+		return
+	}
+	w.timer.Reset(timeout)
+}
+
+func (w *watchdogController) Feed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.active || w.timer == nil {
+		return false
+	}
+	w.timer.Reset(w.timeout)
+	return true
+}
+
+func (w *watchdogController) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.active = false
+	if w.timer != nil {
+		w.timer.Stop()
+	}
+}
+
+func (w *watchdogController) expire() {
+	w.mu.Lock()
+	if !w.active {
+		w.mu.Unlock()
+		return
+	}
+	w.active = false
+	onExpired := w.onExpired
+	w.mu.Unlock()
+
+	if onExpired != nil {
+		onExpired()
+	}
 }
 
 func main() {
@@ -80,7 +143,10 @@ func main() {
 	}
 
 	var httpServer http.Server
-	mux := newMux(srvState, &httpServer)
+	shutdown := newServerShutdown(srvState, &httpServer)
+	watchdog := newWatchdogController(shutdown)
+	defer watchdog.Stop()
+	mux := newMux(srvState, watchdog, shutdown)
 
 	httpServer = http.Server{Handler: mux}
 	if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -88,7 +154,23 @@ func main() {
 	}
 }
 
-func newMux(srvState *server, httpServer *http.Server) *http.ServeMux {
+func newServerShutdown(srvState *server, httpServer *http.Server) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if srvState != nil && srvState.vms != nil {
+				_ = srvState.vms.ShutdownAll(ctx)
+			}
+			if httpServer != nil {
+				_ = httpServer.Shutdown(ctx)
+			}
+		})
+	}
+}
+
+func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -103,12 +185,48 @@ func newMux(srvState *server, httpServer *http.Server) *http.ServeMux {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		go func() {
 			time.Sleep(10 * time.Millisecond)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if httpServer != nil {
-				_ = httpServer.Shutdown(ctx)
+			if watchdog != nil {
+				watchdog.Stop()
 			}
+			shutdown()
 		}()
+	})
+
+	mux.HandleFunc("POST /watchdog", func(w http.ResponseWriter, r *http.Request) {
+		if watchdog == nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("watchdog is unavailable"))
+			return
+		}
+		var req watchdogRequest
+		if err := decodeOptionalJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		timeout := 30 * time.Second
+		if req.TimeoutSeconds > 0 {
+			timeout = time.Duration(req.TimeoutSeconds * float64(time.Second))
+		}
+		if timeout <= 0 {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("watchdog timeout must be positive"))
+			return
+		}
+		watchdog.Create(timeout)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":          "watching",
+			"timeout_seconds": timeout.Seconds(),
+		})
+	})
+
+	mux.HandleFunc("POST /watchdog/feed", func(w http.ResponseWriter, r *http.Request) {
+		if watchdog == nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("watchdog is unavailable"))
+			return
+		}
+		if !watchdog.Feed() {
+			writeError(w, http.StatusConflict, fmt.Errorf("watchdog has not been created"))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "fed"})
 	})
 
 	mux.HandleFunc("GET /kernel", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/ccvm/main_test.go
+++ b/cmd/ccvm/main_test.go
@@ -117,7 +117,7 @@ func TestWriteProgressEvent(t *testing.T) {
 
 func TestCapabilitiesEndpoint(t *testing.T) {
 	srv := &server{vms: vm.NewManager()}
-	mux := newMux(srv, nil)
+	mux := newMux(srv, nil, func() {})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/capabilities", nil)
 
@@ -132,6 +132,44 @@ func TestCapabilitiesEndpoint(t *testing.T) {
 	}
 	if caps.Host == "" || caps.Backend == "" || caps.MaxInstances == 0 || !caps.SupportsMultiImageExec {
 		t.Fatalf("capabilities = %#v", caps)
+	}
+}
+
+func TestWatchdogEndpointsCreateAndFeed(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	watchdog := newWatchdogController(func() { expired <- struct{}{} })
+	defer watchdog.Stop()
+	mux := newMux(&server{}, watchdog, func() {})
+
+	createReq := httptest.NewRequest(http.MethodPost, "/watchdog", strings.NewReader(`{"timeout_seconds":10}`))
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("POST /watchdog status = %d, body = %s", createRec.Code, createRec.Body.String())
+	}
+
+	feedReq := httptest.NewRequest(http.MethodPost, "/watchdog/feed", nil)
+	feedRec := httptest.NewRecorder()
+	mux.ServeHTTP(feedRec, feedReq)
+	if feedRec.Code != http.StatusOK {
+		t.Fatalf("POST /watchdog/feed status = %d, body = %s", feedRec.Code, feedRec.Body.String())
+	}
+}
+
+func TestWatchdogExpiresWithoutFeed(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	watchdog := newWatchdogController(func() { expired <- struct{}{} })
+	defer watchdog.Stop()
+
+	watchdog.Create(20 * time.Millisecond)
+
+	select {
+	case <-expired:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not expire")
+	}
+	if watchdog.Feed() {
+		t.Fatal("Feed() after expiry = true, want false")
 	}
 }
 
@@ -222,7 +260,7 @@ func TestPullImageRequestAcceptsStructuredSource(t *testing.T) {
 func TestCVMFSEndpointsSupportCacheDir(t *testing.T) {
 	repoServer := newHTTPTestRepoServer(t)
 	cacheDir := t.TempDir()
-	mux := newMux(&server{}, nil)
+	mux := newMux(&server{}, nil, func() {})
 
 	listBody := `{"mirror":"` + repoServer.URL + `/cvmfs","repo":"test.repo","path":"/containers/niimath","cache_dir":"` + cacheDir + `"}`
 	listReq := httptest.NewRequest(http.MethodPost, "/cvmfs/list", strings.NewReader(listBody))
@@ -278,7 +316,7 @@ func TestCVMFSEndpointsSupportCacheDir(t *testing.T) {
 func TestPostImageImportsDirectoryBackedCVMFSContainer(t *testing.T) {
 	repoServer := newHTTPDirectoryRepoServer(t)
 	srv := &server{images: oci.NewStore(t.TempDir())}
-	mux := newMux(srv, nil)
+	mux := newMux(srv, nil, func() {})
 
 	req := httptest.NewRequest(http.MethodPost, "/image/niimath", strings.NewReader(`{
 		"source": {
@@ -313,7 +351,7 @@ func TestPostImageImportsDirectoryBackedCVMFSContainer(t *testing.T) {
 func TestPostImageStreamsProgressForDirectoryBackedCVMFSContainer(t *testing.T) {
 	repoServer := newHTTPDirectoryRepoServer(t)
 	srv := &server{images: oci.NewStore(t.TempDir())}
-	mux := newMux(srv, nil)
+	mux := newMux(srv, nil, func() {})
 
 	req := httptest.NewRequest(http.MethodPost, "/image/niimath?stream=1", strings.NewReader(`{
 		"source": {

--- a/internal/imagefs/imagefs.go
+++ b/internal/imagefs/imagefs.go
@@ -236,7 +236,7 @@ func (d *hostDir) Lookup(name string) (Entry, error) {
 	if err != nil {
 		return Entry{}, err
 	}
-	guest := fsmeta.Normalize(rel)
+	guest := fsmeta.Normalize(filepath.ToSlash(rel))
 	meta := d.meta[guest]
 	mode := linuxModeToGo(fsmeta.NormalizeLinuxMode(meta.Mode, info.Mode()))
 	modTime := info.ModTime()

--- a/internal/imagefs/imagefs_test.go
+++ b/internal/imagefs/imagefs_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"j5.nz/cc/internal/fsmeta"
+	"j5.nz/cc/internal/linuxabi"
 )
 
 func TestResolveCommandAbsoluteAndPATH(t *testing.T) {
@@ -25,7 +28,10 @@ func TestResolveCommandAbsoluteAndPATH(t *testing.T) {
 		t.Fatalf("Symlink(tool-link) error = %v", err)
 	}
 
-	fs := NewHostFS(root, nil)
+	fs := NewHostFS(root, map[string]fsmeta.Entry{
+		"/bin/tool":  {Mode: linuxabi.SIFREG | 0o755},
+		"/bin/plain": {Mode: linuxabi.SIFREG | 0o644},
+	})
 
 	got, err := ResolveCommand(fs, []string{"/bin/tool", "arg"}, nil)
 	if err != nil {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sort"
@@ -231,6 +232,26 @@ func (m *Manager) StartBlankInstanceStream(
 
 func (m *Manager) Shutdown(ctx context.Context) error {
 	return m.ShutdownInstance(ctx, DefaultInstanceID)
+}
+
+func (m *Manager) ShutdownAll(ctx context.Context) error {
+	_ = ctx
+	m.mu.Lock()
+	running := m.running
+	m.running = nil
+	m.mu.Unlock()
+
+	var errs []error
+	for id, machine := range running {
+		close(machine.shutdownCh)
+		if err := machine.instance.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("shutdown VM %q: %w", id, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }
 
 func (m *Manager) ShutdownInstance(ctx context.Context, id string) error {

--- a/pyneurodesk/src/pyneurodesk/api.py
+++ b/pyneurodesk/src/pyneurodesk/api.py
@@ -1033,7 +1033,7 @@ def _feed_daemon_watchdog(base_url: str, stop: threading.Event) -> None:
                 response = client.post("/watchdog/feed")
                 response.raise_for_status()
         except httpx.HTTPError:
-            break
+            continue
     with _WATCHDOG_THREADS_LOCK:
         existing = _WATCHDOG_THREADS.get(base_url)
         if existing is not None and existing[0] is stop:

--- a/pyneurodesk/src/pyneurodesk/api.py
+++ b/pyneurodesk/src/pyneurodesk/api.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import subprocess
 import sys
+import threading
 import uuid
 import base64
 from collections.abc import Callable
@@ -36,6 +37,10 @@ SINGULARITY_ENV_FILES = (
     "10-docker2singularity.sh",
     "90-environment.sh",
 )
+WATCHDOG_TIMEOUT_SECONDS = 30.0
+WATCHDOG_FEED_INTERVAL_SECONDS = 10.0
+_WATCHDOG_THREADS: dict[str, tuple[threading.Event, threading.Thread]] = {}
+_WATCHDOG_THREADS_LOCK = threading.Lock()
 
 
 class ProgressReporter(Protocol):
@@ -240,6 +245,7 @@ class NeurodeskContainer:
                 except httpx.HTTPError:
                     pass
                 try:
+                    _stop_daemon_watchdog(self._owned_daemon.base_url)
                     with httpx.Client(base_url=self._owned_daemon.base_url, timeout=2.0) as http_client:
                         http_client.post("/shutdown")
                 except httpx.HTTPError:
@@ -796,6 +802,7 @@ def start_default_daemon() -> DaemonState:
         state = DaemonState.from_file(state_path)
         if _health_check(state.base_url):
             if _supports_vm_start(state.base_url):
+                _ensure_daemon_watchdog(state.base_url)
                 return state
             _shutdown_daemon_server(state.base_url)
             state_path.unlink(missing_ok=True)
@@ -851,6 +858,7 @@ def start_daemon_for_cache_dir(cache_root: Path) -> DaemonState:
     if not _health_check(state.base_url):
         state_path.unlink(missing_ok=True)
         raise RuntimeError(f"started ccvm at {state.base_url}, but health check failed")
+    _ensure_daemon_watchdog(state.base_url)
     return state
 
 
@@ -988,7 +996,59 @@ def _supports_vm_start(base_url: str) -> bool:
         return False
 
 
+def _ensure_daemon_watchdog(base_url: str) -> None:
+    base_url = base_url.rstrip("/")
+    with _WATCHDOG_THREADS_LOCK:
+        existing = _WATCHDOG_THREADS.get(base_url)
+        if existing is not None and existing[1].is_alive():
+            return
+
+    try:
+        with httpx.Client(base_url=base_url, timeout=2.0) as client:
+            response = client.post("/watchdog", json={"timeout_seconds": WATCHDOG_TIMEOUT_SECONDS})
+            response.raise_for_status()
+    except httpx.HTTPError:
+        return
+
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=_feed_daemon_watchdog,
+        args=(base_url, stop),
+        name=f"pyneurodesk-watchdog-{base_url}",
+        daemon=True,
+    )
+    with _WATCHDOG_THREADS_LOCK:
+        existing = _WATCHDOG_THREADS.get(base_url)
+        if existing is not None and existing[1].is_alive():
+            stop.set()
+            return
+        _WATCHDOG_THREADS[base_url] = (stop, thread)
+    thread.start()
+
+
+def _feed_daemon_watchdog(base_url: str, stop: threading.Event) -> None:
+    while not stop.wait(WATCHDOG_FEED_INTERVAL_SECONDS):
+        try:
+            with httpx.Client(base_url=base_url, timeout=2.0) as client:
+                response = client.post("/watchdog/feed")
+                response.raise_for_status()
+        except httpx.HTTPError:
+            break
+    with _WATCHDOG_THREADS_LOCK:
+        existing = _WATCHDOG_THREADS.get(base_url)
+        if existing is not None and existing[0] is stop:
+            _WATCHDOG_THREADS.pop(base_url, None)
+
+
+def _stop_daemon_watchdog(base_url: str) -> None:
+    with _WATCHDOG_THREADS_LOCK:
+        existing = _WATCHDOG_THREADS.pop(base_url.rstrip("/"), None)
+    if existing is not None:
+        existing[0].set()
+
+
 def _shutdown_daemon_server(base_url: str) -> None:
+    _stop_daemon_watchdog(base_url)
     try:
         with httpx.Client(base_url=base_url, timeout=2.0) as client:
             client.post("/shutdown")

--- a/pyneurodesk/src/pyneurodesk/client.py
+++ b/pyneurodesk/src/pyneurodesk/client.py
@@ -305,6 +305,14 @@ class PyNeurodeskClient:
         payload = self._decode_json(response)
         return VMState.from_payload(payload)
 
+    def create_watchdog(self, *, timeout_seconds: float = 30.0) -> dict[str, Any]:
+        response = self._client.post("/watchdog", json={"timeout_seconds": timeout_seconds})
+        return self._decode_json(response)
+
+    def feed_watchdog(self) -> dict[str, Any]:
+        response = self._client.post("/watchdog/feed")
+        return self._decode_json(response)
+
     def ensure_instance(
         self,
         image: str,

--- a/pyneurodesk/tests/test_client.py
+++ b/pyneurodesk/tests/test_client.py
@@ -231,6 +231,31 @@ def test_run_command_request_serializes_runtime_shares() -> None:
     assert result.output == "ok"
 
 
+def test_watchdog_client_endpoints() -> None:
+    seen: list[tuple[str, str, Optional[str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.read().decode() or None
+        seen.append((request.method, request.url.path, body))
+        if request.url.path == "/watchdog":
+            return httpx.Response(200, json={"status": "watching", "timeout_seconds": 30})
+        if request.url.path == "/watchdog/feed":
+            return httpx.Response(200, json={"status": "fed"})
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    client = make_client(httpx.MockTransport(handler))
+    try:
+        assert client.create_watchdog(timeout_seconds=30)["status"] == "watching"
+        assert client.feed_watchdog()["status"] == "fed"
+    finally:
+        client.close()
+
+    assert seen == [
+        ("POST", "/watchdog", '{"timeout_seconds":30}'),
+        ("POST", "/watchdog/feed", None),
+    ]
+
+
 def test_create_instance_uses_boot_timeout() -> None:
     seen: dict[str, object] = {}
 
@@ -904,6 +929,7 @@ def test_start_default_daemon_writes_state(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("pyneurodesk.api.default_cache_root", lambda: cache_root)
     monkeypatch.setattr("pyneurodesk.api.resolve_ccvm_binary_path", lambda: ccvm_path)
     monkeypatch.setattr("pyneurodesk.api._health_check", lambda base_url: base_url == "http://127.0.0.1:3456")
+    monkeypatch.setattr("pyneurodesk.api._ensure_daemon_watchdog", lambda base_url: seen.setdefault("watchdog", base_url))
     monkeypatch.setattr("pyneurodesk.api.subprocess.Popen", fake_popen)
 
     state = start_default_daemon()
@@ -912,7 +938,29 @@ def test_start_default_daemon_writes_state(monkeypatch, tmp_path: Path) -> None:
     assert state.cache_dir == str(cache_root)
     assert seen["args"] == [str(ccvm_path), "-cache-dir", str(cache_root)]
     assert seen["kwargs"]["cwd"] == str(Path(__file__).resolve().parents[2])
+    assert seen["watchdog"] == "http://127.0.0.1:3456"
     assert (cache_root / "ccvm.json").read_text() == '{\n  "addr": "127.0.0.1:3456"\n}'
+
+
+def test_start_default_daemon_feeds_watchdog_for_existing_daemon(monkeypatch, tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir(parents=True)
+    (cache_root / "ccvm.json").write_text('{"addr":"127.0.0.1:3456"}')
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr("pyneurodesk.api.default_cache_root", lambda: cache_root)
+    monkeypatch.setattr("pyneurodesk.api._health_check", lambda base_url: calls.append(("health", base_url)) or True)
+    monkeypatch.setattr("pyneurodesk.api._supports_vm_start", lambda base_url: calls.append(("supports", base_url)) or True)
+    monkeypatch.setattr("pyneurodesk.api._ensure_daemon_watchdog", lambda base_url: calls.append(("watchdog", base_url)))
+
+    state = start_default_daemon()
+
+    assert state.base_url == "http://127.0.0.1:3456"
+    assert calls == [
+        ("health", "http://127.0.0.1:3456"),
+        ("supports", "http://127.0.0.1:3456"),
+        ("watchdog", "http://127.0.0.1:3456"),
+    ]
 
 
 def test_start_default_daemon_restarts_incompatible_running_daemon(monkeypatch, tmp_path: Path) -> None:

--- a/pyneurodesk/tests/test_client.py
+++ b/pyneurodesk/tests/test_client.py
@@ -880,7 +880,7 @@ def test_resolve_base_url_reads_daemon_state(monkeypatch, tmp_path: Path) -> Non
     monkeypatch.setattr("pyneurodesk.api._health_check", lambda base_url: base_url == "http://127.0.0.1:4567")
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / ".cache"))
     state_path = default_daemon_state_path()
-    state_path.parent.mkdir(parents=True)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text('{"addr":"127.0.0.1:4567"}')
 
     assert resolve_base_url() == "http://127.0.0.1:4567"
@@ -1348,7 +1348,7 @@ def test_owned_container_recovers_when_daemon_connection_is_refused(monkeypatch)
         container.close()
 
     assert out == "ok\n"
-    assert ("restart", daemon_a.cache_dir) in calls
+    assert ("restart", str(Path(daemon_a.cache_dir))) in calls
     assert ("ensure_image", "niimath") in calls
     assert ("ensure_instance", "niimath") in calls
     assert ("run", ("http://127.0.0.1:4002", "niimath", ("niimath",), ())) in calls

--- a/pyneurodesk/tests/test_client.py
+++ b/pyneurodesk/tests/test_client.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 import neurodesk as nd
+import pyneurodesk.api as api
 from pyneurodesk import (
     CVMFSReadRequest,
     CVMFSSource,
@@ -254,6 +255,40 @@ def test_watchdog_client_endpoints() -> None:
         ("POST", "/watchdog", '{"timeout_seconds":30}'),
         ("POST", "/watchdog/feed", None),
     ]
+
+
+def test_watchdog_feed_loop_continues_after_transient_http_error(monkeypatch) -> None:
+    stop = api.threading.Event()
+    calls: list[str] = []
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeHTTPClient:
+        def __init__(self, *, base_url: str, timeout: float) -> None:
+            self.base_url = base_url
+            self.timeout = timeout
+
+        def __enter__(self) -> "FakeHTTPClient":
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def post(self, path: str) -> FakeResponse:
+            calls.append(path)
+            if len(calls) == 1:
+                raise httpx.ConnectTimeout("transient timeout")
+            stop.set()
+            return FakeResponse()
+
+    monkeypatch.setattr(api, "WATCHDOG_FEED_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(api.httpx, "Client", FakeHTTPClient)
+
+    api._feed_daemon_watchdog("http://127.0.0.1:4567", stop)
+
+    assert calls == ["/watchdog/feed", "/watchdog/feed"]
 
 
 def test_create_instance_uses_boot_timeout() -> None:

--- a/pyneurodesk/tests/test_shell.py
+++ b/pyneurodesk/tests/test_shell.py
@@ -206,10 +206,15 @@ def test_shell_load_discovers_commands_writes_wrappers_and_persists_env(
         "PATH=/usr/local/bin:/usr/bin:/bin:/opt/niimath",
         "DEPLOY_ENV_FSLDIR=/opt/fsl",
     ]
-    wrapper = (root / "bin" / "niimath").read_text()
-    assert "/usr/local/bin/neurodesk shell run-wrapper" in wrapper
-    assert '--image niimath' in wrapper
-    assert '--command niimath' in wrapper
+    wrapper = shell.wrapper_path(root / "bin", "niimath").read_text()
+    if shell.os.name == "nt":
+        assert '"/usr/local/bin/neurodesk" shell run-wrapper' in wrapper
+        assert '--image "niimath"' in wrapper
+        assert '--command "niimath"' in wrapper
+    else:
+        assert "/usr/local/bin/neurodesk shell run-wrapper" in wrapper
+        assert '--image niimath' in wrapper
+        assert '--command niimath' in wrapper
     assert calls[0] == ("cvmfs_list", "/containers/niimath_1.0.20250804_20251016")
     assert calls[-1] == ("close", None)
 
@@ -411,7 +416,8 @@ def test_shell_unload_removes_image_wrappers(monkeypatch, tmp_path: Path, capsys
             wrappers={"niimath": shell.WrapperSpec(image="niimath", command="niimath")},
         )
     )
-    shell.write_wrapper(root / "bin" / "niimath", image="niimath", command="niimath")
+    wrapper = shell.wrapper_path(root / "bin", "niimath")
+    shell.write_wrapper(wrapper, image="niimath", command="niimath")
 
     exit_code = shell.main(["shell", "unload", "niimath"])
 
@@ -420,7 +426,7 @@ def test_shell_unload_removes_image_wrappers(monkeypatch, tmp_path: Path, capsys
     new_state = shell.read_state(root, session_id="sess-1")
     assert new_state.images == {}
     assert new_state.wrappers == {}
-    assert not (root / "bin" / "niimath").exists()
+    assert not wrapper.exists()
 
 
 def test_shell_complete_returns_loaded_images_for_exec(monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -468,6 +474,7 @@ def test_run_wrapper_invokes_container_command(
     home_dir = tmp_path / "home"
     home_dir.mkdir()
     monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("USERPROFILE", str(home_dir))
 
     class FakeClient:
         def run(
@@ -570,6 +577,7 @@ def test_run_wrapper_uses_session_reference_when_present(
     home_dir = tmp_path / "home"
     home_dir.mkdir()
     monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("USERPROFILE", str(home_dir))
 
     class FakeClient:
         def ensure_image(self, ref: ContainerReference) -> object:

--- a/tools/publish_neurodesk.sh
+++ b/tools/publish_neurodesk.sh
@@ -29,7 +29,7 @@ By default this script:
   - uploads wheels with uv publish
 
 Supported default targets:
-  linux/amd64, linux/arm64, darwin/arm64
+  linux/amd64, linux/arm64, darwin/arm64, windows/amd64
 
 Options:
   --include-sdist       Also build and upload a source-only sdist.
@@ -103,7 +103,7 @@ if [[ "${BUILD_CCVM}" -eq 1 ]]; then
 fi
 
 if [[ "${#TARGETS[@]}" -eq 0 ]]; then
-  TARGETS=("linux/amd64" "linux/arm64" "darwin/arm64")
+  TARGETS=("linux/amd64" "linux/arm64" "darwin/arm64" "windows/amd64")
 fi
 
 if [[ "${BUILD_CCVM}" -eq 0 && "${#TARGETS[@]}" -ne 1 ]]; then
@@ -116,6 +116,7 @@ target_platform_tag() {
     linux/amd64) echo "manylinux_2_17_x86_64" ;;
     linux/arm64) echo "manylinux_2_17_aarch64" ;;
     darwin/arm64) echo "macosx_11_0_arm64" ;;
+    windows/amd64) echo "win_amd64" ;;
     *)
       echo "unsupported release target: $1" >&2
       exit 1


### PR DESCRIPTION
## Summary

- Add Windows amd64 wheel coverage to wheel-building CI and the neurodesk release script.
- Add basic Go/Python unit test workflows for macOS arm64, Linux arm64, and Windows amd64.
- Add an opt-in ccvm watchdog API with `POST /watchdog` and `POST /watchdog/feed`, plus Python launcher heartbeat support.
- Avoid duplicate CI runs on feature branches by limiting push triggers to `main` and relying on `pull_request` for branch validation.

## Validation

- `go test ./...`
- `cd pyneurodesk && uv run pytest -q`
- workflow YAML parse
- `git diff --check`