### PR TITLE
Improve virtio-fs throughput and SMP scaling

### DIFF
--- a/cmd/ccvm/main.go
+++ b/cmd/ccvm/main.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -221,6 +222,8 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 	mux := http.NewServeMux()
 
 	if strings.TrimSpace(os.Getenv("CCX3_PPROF")) != "" {
+		runtime.SetMutexProfileFraction(1)
+		runtime.SetBlockProfileRate(1)
 		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
 		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
 		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)

--- a/cmd/ccvm/main.go
+++ b/cmd/ccvm/main.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -219,12 +220,25 @@ func newServerShutdown(srvState *server, httpServer *http.Server) func() {
 func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *http.ServeMux {
 	mux := http.NewServeMux()
 
+	if strings.TrimSpace(os.Getenv("CCX3_PPROF")) != "" {
+		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
+	}
+
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
 
 	mux.HandleFunc("GET /capabilities", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, srvState.vms.Capabilities())
+	})
+
+	mux.HandleFunc("GET /debug/virtiofs", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+		writeJSON(w, http.StatusOK, srvState.vms.VirtioFSStats(id))
 	})
 
 	mux.HandleFunc("POST /shutdown", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/amd64vm/boot.go
+++ b/internal/amd64vm/boot.go
@@ -19,6 +19,7 @@ const (
 
 type BootConfig struct {
 	MemoryMB     uint64
+	NumCPUs      int
 	Dmesg        bool
 	ExtraCmdline []string
 }
@@ -73,6 +74,7 @@ func PrepareBoot(memory []byte, kernel []byte, initrd []byte, cfg BootConfig) (*
 	return bootamd64.PrepareBoot(memory, kernel, bootamd64.BootOptions{
 		MemoryBase: MemoryBase,
 		MemorySize: memorySize,
+		NumCPUs:    cfg.NumCPUs,
 		Initrd:     initrd,
 		Cmdline:    BootCommandLine(cfg.Dmesg, cfg.ExtraCmdline...),
 		E820:       E820Map(memorySize),

--- a/internal/hv/kvm/bindings_linux_amd64.go
+++ b/internal/hv/kvm/bindings_linux_amd64.go
@@ -3,6 +3,7 @@
 package kvm
 
 import (
+	"math/bits"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -38,6 +39,16 @@ func ioctlWithRetry(fd uintptr, request uint64, arg uintptr) (uintptr, error) {
 	for {
 		v1, err := ioctl(fd, request, arg)
 		if err == unix.EINTR {
+			continue
+		}
+		return v1, err
+	}
+}
+
+func ioctlRunVCPU(fd uintptr) (uintptr, error) {
+	for {
+		v1, err := ioctl(fd, uint64(kvmRun), 0)
+		if err == unix.EINTR || err == unix.EAGAIN {
 			continue
 		}
 		return v1, err
@@ -104,6 +115,55 @@ func getSupportedCPUID(kvmFd int) (*kvmCPUID2, error) {
 func setVCPUID(vcpuFd int, cpuid *kvmCPUID2) error {
 	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetCpuid2), uintptr(unsafe.Pointer(cpuid)))
 	return err
+}
+
+func setCPUIDTopology(cpuid *kvmCPUID2, id, cpus int) {
+	if cpuid == nil {
+		return
+	}
+	if cpus < 1 {
+		cpus = 1
+	}
+	if cpus > 255 {
+		cpus = 255
+	}
+	entries := unsafe.Slice(
+		(*kvmCPUIDEntry2)(unsafe.Pointer(uintptr(unsafe.Pointer(cpuid))+unsafe.Sizeof(*cpuid))),
+		cpuid.Nr,
+	)
+	logical := uint32(1)
+	if cpus > 1 {
+		logical = uint32(1 << bits.Len(uint(cpus-1)))
+	}
+	for i := range entries {
+		e := &entries[i]
+		switch e.Function {
+		case 1:
+			e.Ebx = (e.Ebx &^ (uint32(0xffff) << 16)) | (uint32(cpus) << 16) | (uint32(id&0xff) << 24)
+			if cpus > 1 {
+				e.Edx |= 1 << 28
+			}
+		case 4:
+			e.Eax = (e.Eax &^ (uint32(0x3f) << 26)) | (uint32(cpus-1) << 26)
+		case 0xb:
+			switch e.Index {
+			case 0:
+				e.Eax = 0
+				e.Ebx = 1
+				e.Ecx = (1 << 8) | e.Index
+				e.Edx = uint32(id)
+			case 1:
+				e.Eax = uint32(bits.Len(uint(logical - 1)))
+				e.Ebx = uint32(cpus)
+				e.Ecx = (2 << 8) | e.Index
+				e.Edx = uint32(id)
+			default:
+				e.Eax, e.Ebx, e.Ecx, e.Edx = 0, 0, e.Index, uint32(id)
+			}
+		case 0x1f:
+			e.Eax, e.Ebx, e.Ecx, e.Edx = 0, 0, e.Index, uint32(id)
+		}
+	}
 }
 
 func getRegs(vcpuFd int) (kvmRegs, error) {

--- a/internal/hv/kvm/boot_linux_amd64.go
+++ b/internal/hv/kvm/boot_linux_amd64.go
@@ -101,6 +101,7 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 		return "", fmt.Errorf("set long mode: %w", err)
 	}
 
+	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			if done(serialOut.String()) {
@@ -108,8 +109,7 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 			}
 			return serialOut.String(), err
 		}
-		exit, err := vm.Run()
-		if err != nil {
+		if err := vm.Run(&exit); err != nil {
 			return serialOut.String(), fmt.Errorf("run step %d: %w", step, err)
 		}
 		if done(serialOut.String()) {

--- a/internal/hv/kvm/boot_linux_amd64.go
+++ b/internal/hv/kvm/boot_linux_amd64.go
@@ -187,6 +187,10 @@ func handleUARTIO(uart *serial.UART8250, ioExit IOExit) error {
 }
 
 func handleBootMMIO(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, mmio MMIOExit) error {
+	return handleBootMMIOForVCPU(vm, 0, fsdevs, vsock, rng, mmio)
+}
+
+func handleBootMMIOForVCPU(vm *VM, vcpuIndex int, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, mmio MMIOExit) error {
 	for _, fsdev := range fsdevs {
 		if fsdev == nil || !fsdev.Contains(mmio.Addr, int(mmio.Len)) {
 			continue
@@ -198,7 +202,7 @@ func handleBootMMIO(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virti
 		if err != nil {
 			return err
 		}
-		vm.CompleteMMIORead(value, mmio.Len)
+		vm.CompleteVCPUMMIORead(vcpuIndex, value, mmio.Len)
 		return nil
 	}
 	if vsock != nil && vsock.Contains(mmio.Addr, int(mmio.Len)) {
@@ -209,7 +213,7 @@ func handleBootMMIO(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virti
 		if err != nil {
 			return err
 		}
-		vm.CompleteMMIORead(value, mmio.Len)
+		vm.CompleteVCPUMMIORead(vcpuIndex, value, mmio.Len)
 		return nil
 	}
 	if rng != nil && rng.Contains(mmio.Addr, int(mmio.Len)) {
@@ -220,14 +224,14 @@ func handleBootMMIO(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virti
 		if err != nil {
 			return err
 		}
-		vm.CompleteMMIORead(value, mmio.Len)
+		vm.CompleteVCPUMMIORead(vcpuIndex, value, mmio.Len)
 		return nil
 	}
 	if offset, ok := bootHPETOffset(mmio.Addr, mmio.Len); ok {
 		if mmio.Write {
 			return nil
 		}
-		vm.CompleteMMIORead(readBootHPET(offset), mmio.Len)
+		vm.CompleteVCPUMMIORead(vcpuIndex, readBootHPET(offset), mmio.Len)
 		return nil
 	}
 	return fmt.Errorf("unhandled mmio addr=%#x len=%d write=%v", mmio.Addr, mmio.Len, mmio.Write)

--- a/internal/hv/kvm/boot_linux_arm64.go
+++ b/internal/hv/kvm/boot_linux_arm64.go
@@ -161,6 +161,7 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 		}
 	}
 
+	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			if done(serialOut.String()) {
@@ -169,12 +170,8 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 			return "", err
 		}
 
-		exit, err := vm.Run()
-		if err != nil {
+		if err := vm.Run(&exit); err != nil {
 			return serialOut.String(), fmt.Errorf("run step %d: %w", step, err)
-		}
-		if exit == nil {
-			return serialOut.String(), fmt.Errorf("run step %d: nil exit", step)
 		}
 		if done(serialOut.String()) {
 			return serialOut.String(), nil

--- a/internal/hv/kvm/bootstrap_linux_amd64.go
+++ b/internal/hv/kvm/bootstrap_linux_amd64.go
@@ -137,11 +137,16 @@ func (b *Bootstrap) InitVM(vmfd int) error {
 }
 
 func (b *Bootstrap) InitVCPU(vmfd, vcpufd int) error {
+	return b.InitVCPUWithTopology(vmfd, vcpufd, 0, 1)
+}
+
+func (b *Bootstrap) InitVCPUWithTopology(vmfd, vcpufd, id, cpus int) error {
 	_ = vmfd
 	cpuid, err := getSupportedCPUID(b.fd)
 	if err != nil {
 		return err
 	}
+	setCPUIDTopology(cpuid, id, cpus)
 	return setVCPUID(vcpufd, cpuid)
 }
 

--- a/internal/hv/kvm/exec_linux_amd64.go
+++ b/internal/hv/kvm/exec_linux_amd64.go
@@ -208,7 +208,6 @@ func runManagedExecVMMulti(ctx context.Context, vm *VM, uart *serial.UART8250, f
 	defer cancel()
 	errCh := make(chan error, len(vm.vcpus))
 	var wg sync.WaitGroup
-	var deviceMu sync.Mutex
 	for index := range vm.vcpus {
 		wg.Add(1)
 		go func(index int) {
@@ -223,9 +222,7 @@ func runManagedExecVMMulti(ctx context.Context, vm *VM, uart *serial.UART8250, f
 					reportRunErr(errCh, cancel, fmt.Errorf("run vcpu %d: %w", index, err))
 					return
 				}
-				deviceMu.Lock()
 				err = handleManagedExit(vm, index, uart, fsdevs, vsock, rng, serialOut, exit)
-				deviceMu.Unlock()
 				if err != nil {
 					reportRunErr(errCh, cancel, err)
 					return

--- a/internal/hv/kvm/exec_linux_amd64.go
+++ b/internal/hv/kvm/exec_linux_amd64.go
@@ -171,16 +171,13 @@ func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, mem
 }
 
 func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript) error {
+	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		exit, err := vm.Run()
-		if err != nil {
+		if err := vm.Run(&exit); err != nil {
 			return fmt.Errorf("run step %d: %w", step, err)
-		}
-		if exit == nil {
-			return fmt.Errorf("run step %d: nil exit", step)
 		}
 		switch exit.Reason {
 		case ExitIO:

--- a/internal/hv/kvm/exec_linux_amd64.go
+++ b/internal/hv/kvm/exec_linux_amd64.go
@@ -232,6 +232,7 @@ func runManagedExecVMMulti(ctx context.Context, vm *VM, uart *serial.UART8250, f
 	}
 	defer func() {
 		cancel()
+		_ = vm.CancelRun()
 		wg.Wait()
 	}()
 

--- a/internal/hv/kvm/exec_linux_amd64.go
+++ b/internal/hv/kvm/exec_linux_amd64.go
@@ -17,7 +17,7 @@ import (
 	"j5.nz/cc/internal/vmruntime"
 )
 
-func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, req client.ExecRequest) (client.ExecResponse, string, error) {
+func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, req client.ExecRequest) (client.ExecResponse, string, error) {
 	if len(req.Command) == 0 {
 		return client.ExecResponse{}, "", fmt.Errorf("exec command is required")
 	}
@@ -46,7 +46,7 @@ func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, mem
 		_, _ = io.Copy(controlTranscript, conn)
 	}()
 
-	vm, err := NewVM()
+	vm, err := NewVMWithCPUs(cpus)
 	if err != nil {
 		return client.ExecResponse{}, "", err
 	}
@@ -72,6 +72,7 @@ func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, mem
 	extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(rng.Base, rng.IRQ))
 	plan, err := amd64vm.PrepareBoot(mem, kernel, initrd, amd64vm.BootConfig{
 		MemoryMB:     memoryMB,
+		NumCPUs:      cpus,
 		Dmesg:        dmesg,
 		ExtraCmdline: extraCmdline,
 	})
@@ -171,6 +172,9 @@ func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, mem
 }
 
 func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript) error {
+	if vm != nil && len(vm.vcpus) > 1 {
+		return runManagedExecVMMulti(ctx, vm, uart, fsdevs, vsock, rng, serialOut)
+	}
 	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
@@ -197,6 +201,80 @@ func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs
 			return fmt.Errorf("unexpected exit reason %d at pc=%#x\nserial:\n%s", exit.Reason, pc, serialOut.String())
 		}
 	}
+}
+
+func runManagedExecVMMulti(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := make(chan error, len(vm.vcpus))
+	var wg sync.WaitGroup
+	var deviceMu sync.Mutex
+	for index := range vm.vcpus {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			var exit Exit
+			for {
+				if err := runCtx.Err(); err != nil {
+					return
+				}
+				err := vm.RunVCPU(index, &exit)
+				if err != nil {
+					reportRunErr(errCh, cancel, fmt.Errorf("run vcpu %d: %w", index, err))
+					return
+				}
+				deviceMu.Lock()
+				err = handleManagedExit(vm, index, uart, fsdevs, vsock, rng, serialOut, exit)
+				deviceMu.Unlock()
+				if err != nil {
+					reportRunErr(errCh, cancel, err)
+					return
+				}
+			}
+		}(index)
+	}
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-runCtx.Done():
+		return runCtx.Err()
+	}
+}
+
+func reportRunErr(errCh chan<- error, cancel context.CancelFunc, err error) {
+	cancel()
+	select {
+	case errCh <- err:
+	default:
+	}
+}
+
+func handleManagedExit(vm *VM, vcpuIndex int, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript, exit Exit) error {
+	switch exit.Reason {
+	case ExitIO:
+		if err := handleBootIO(uart, exit.IO); err != nil {
+			return err
+		}
+	case ExitMMIO:
+		if err := handleBootMMIOForVCPU(vm, vcpuIndex, fsdevs, vsock, rng, exit.MMIO); err != nil {
+			return err
+		}
+	case ExitHLT:
+		return nil
+	case ExitShutdown:
+		return fmt.Errorf("guest shut down before exec completed\nserial:\n%s", serialOut.String())
+	case ExitSystemEvent:
+		return fmt.Errorf("unexpected system event %d before exec completed\nserial:\n%s", exit.SystemEvent, serialOut.String())
+	default:
+		pc, _ := vm.GetVCPUPC(vcpuIndex)
+		return fmt.Errorf("unexpected exit reason %d on vcpu %d at pc=%#x\nserial:\n%s", exit.Reason, vcpuIndex, pc, serialOut.String())
+	}
+	return nil
 }
 
 func sendManagedExec(control virtio.VsockConn, id string, req client.ExecRequest) error {

--- a/internal/hv/kvm/exec_linux_arm64.go
+++ b/internal/hv/kvm/exec_linux_arm64.go
@@ -179,16 +179,13 @@ func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, mem
 }
 
 func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript) error {
+	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		exit, err := vm.Run()
-		if err != nil {
+		if err := vm.Run(&exit); err != nil {
 			return fmt.Errorf("run step %d: %w", step, err)
-		}
-		if exit == nil {
-			return fmt.Errorf("run step %d: nil exit", step)
 		}
 		switch exit.Reason {
 		case ExitMMIO:

--- a/internal/hv/kvm/session_linux_amd64.go
+++ b/internal/hv/kvm/session_linux_amd64.go
@@ -34,7 +34,7 @@ type ManagedSession struct {
 	dmesg      bool
 }
 
-func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
 	backend := virtio.NewSimpleVsockBackend()
 	listener, err := backend.Listen(vmruntime.ControlPort)
 	if err != nil {
@@ -56,7 +56,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		_, _ = io.Copy(controlTranscript, conn)
 	}()
 
-	vm, err := NewVM()
+	vm, err := NewVMWithCPUs(cpus)
 	if err != nil {
 		_ = listener.Close()
 		vsock.Close()
@@ -91,6 +91,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 	extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(rng.Base, rng.IRQ))
 	plan, err := amd64vm.PrepareBoot(mem, kernel, initrd, amd64vm.BootConfig{
 		MemoryMB:     memoryMB,
+		NumCPUs:      cpus,
 		Dmesg:        dmesg,
 		ExtraCmdline: extraCmdline,
 	})

--- a/internal/hv/kvm/vm_exit_benchmark_linux_amd64_test.go
+++ b/internal/hv/kvm/vm_exit_benchmark_linux_amd64_test.go
@@ -1,0 +1,205 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const (
+	benchExitMemorySize = 16 << 20
+	benchExitCodeAddr   = 0x200000
+	benchRealCodeAddr   = 0x1000
+	benchExitStackAddr  = 0x300000
+	benchRealStackAddr  = 0x8000
+	benchExitPagingAddr = 0x100000
+	benchMMIOAddr       = 0x10000000
+	benchIOPort         = 0x3f8
+)
+
+func BenchmarkKVMExitMMIOWrite(b *testing.B) {
+	vm := newExitBenchmarkVM(b, mmioWriteLoop(benchMMIOAddr))
+	defer vm.Close()
+	benchmarkKVMExits(b, vm, ExitMMIO, func(exit *Exit) {
+		if !exit.MMIO.Write || exit.MMIO.Addr != benchMMIOAddr || exit.MMIO.Len != 4 {
+			b.Fatalf("MMIO exit = %+v, want 4-byte write to %#x", exit.MMIO, benchMMIOAddr)
+		}
+	})
+}
+
+func BenchmarkKVMExitMMIORead(b *testing.B) {
+	vm := newExitBenchmarkVM(b, mmioReadLoop(benchMMIOAddr))
+	defer vm.Close()
+	benchmarkKVMExits(b, vm, ExitMMIO, func(exit *Exit) {
+		if exit.MMIO.Write || exit.MMIO.Addr != benchMMIOAddr || exit.MMIO.Len != 4 {
+			b.Fatalf("MMIO exit = %+v, want 4-byte read from %#x", exit.MMIO, benchMMIOAddr)
+		}
+		vm.CompleteMMIORead(0, exit.MMIO.Len)
+	})
+}
+
+func BenchmarkKVMExitIOWrite(b *testing.B) {
+	vm := newRealModeExitBenchmarkVM(b, ioWriteLoop(benchIOPort))
+	defer vm.Close()
+	benchmarkKVMExits(b, vm, ExitIO, func(exit *Exit) {
+		if !exit.IO.Write || exit.IO.Port != benchIOPort || exit.IO.Size != 1 || exit.IO.Count != 1 {
+			b.Fatalf("IO exit = %+v, want 1-byte write to %#x", exit.IO, benchIOPort)
+		}
+	})
+}
+
+func BenchmarkKVMExitIORead(b *testing.B) {
+	vm := newRealModeExitBenchmarkVM(b, ioReadLoop(benchIOPort))
+	defer vm.Close()
+	benchmarkKVMExits(b, vm, ExitIO, func(exit *Exit) {
+		if exit.IO.Write || exit.IO.Port != benchIOPort || exit.IO.Size != 1 || exit.IO.Count != 1 {
+			b.Fatalf("IO exit = %+v, want 1-byte read from %#x", exit.IO, benchIOPort)
+		}
+		exit.IO.Data[0] = 0
+	})
+}
+
+func newExitBenchmarkVM(b *testing.B, code []byte) *VM {
+	b.Helper()
+	vm, err := NewVM()
+	if err != nil {
+		if strings.Contains(err.Error(), "/dev/kvm") ||
+			strings.Contains(err.Error(), "inappropriate ioctl") ||
+			strings.Contains(err.Error(), "invalid argument") ||
+			strings.Contains(err.Error(), "permission denied") {
+			b.Skip(err)
+		}
+		b.Fatal(err)
+	}
+	if _, err := vm.MapAnonymousMemory(benchExitMemorySize, 0); err != nil {
+		_ = vm.Close()
+		b.Fatalf("MapAnonymousMemory() error = %v", err)
+	}
+	if err := vm.WriteIPA(benchExitCodeAddr, code); err != nil {
+		_ = vm.Close()
+		b.Fatalf("WriteIPA(code) error = %v", err)
+	}
+	if err := vm.SetLongMode(benchExitCodeAddr, 0, benchExitStackAddr, benchExitPagingAddr); err != nil {
+		_ = vm.Close()
+		b.Fatalf("SetLongMode() error = %v", err)
+	}
+	return vm
+}
+
+func newRealModeExitBenchmarkVM(b *testing.B, code []byte) *VM {
+	b.Helper()
+	vm, err := NewVM()
+	if err != nil {
+		if strings.Contains(err.Error(), "/dev/kvm") ||
+			strings.Contains(err.Error(), "inappropriate ioctl") ||
+			strings.Contains(err.Error(), "invalid argument") ||
+			strings.Contains(err.Error(), "permission denied") {
+			b.Skip(err)
+		}
+		b.Fatal(err)
+	}
+	if _, err := vm.MapAnonymousMemory(benchExitMemorySize, 0); err != nil {
+		_ = vm.Close()
+		b.Fatalf("MapAnonymousMemory() error = %v", err)
+	}
+	if err := vm.WriteIPA(benchRealCodeAddr, code); err != nil {
+		_ = vm.Close()
+		b.Fatalf("WriteIPA(code) error = %v", err)
+	}
+	sregs, err := getSRegs(vm.vcpufd)
+	if err != nil {
+		_ = vm.Close()
+		b.Fatalf("getSRegs() error = %v", err)
+	}
+	codeSegment := kvmSegment{Base: 0, Limit: 0xffff, Type: 11, Present: 1, S: 1}
+	dataSegment := kvmSegment{Base: 0, Limit: 0xffff, Type: 3, Present: 1, S: 1}
+	sregs.Cs = codeSegment
+	sregs.Ds = dataSegment
+	sregs.Es = dataSegment
+	sregs.Fs = dataSegment
+	sregs.Gs = dataSegment
+	sregs.Ss = dataSegment
+	sregs.Cr0 &^= 1
+	sregs.Cr4 = 0
+	sregs.Efer = 0
+	if err := setSRegs(vm.vcpufd, &sregs); err != nil {
+		_ = vm.Close()
+		b.Fatalf("setSRegs() error = %v", err)
+	}
+	if err := setRegs(vm.vcpufd, &kvmRegs{
+		Rip:    benchRealCodeAddr,
+		Rsp:    benchRealStackAddr,
+		Rflags: 0x2,
+	}); err != nil {
+		_ = vm.Close()
+		b.Fatalf("setRegs() error = %v", err)
+	}
+	return vm
+}
+
+func benchmarkKVMExits(b *testing.B, vm *VM, want ExitReason, handle func(*Exit)) {
+	b.Helper()
+	b.ReportAllocs()
+	var exit Exit
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := vm.Run(&exit); err != nil {
+			b.Fatalf("Run() error = %v", err)
+		}
+		if exit.Reason != want {
+			pc, _ := vm.GetPC()
+			b.Fatalf("exit reason = %+v at pc=%#x, want %v", exit, pc, want)
+		}
+		handle(&exit)
+	}
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "exits/s")
+}
+
+func mmioWriteLoop(addr uint64) []byte {
+	code := []byte{
+		0x48, 0xbb, 0, 0, 0, 0, 0, 0, 0, 0, // movabs rbx, imm64
+		0x89, 0x03, // mov dword ptr [rbx], eax
+		0xeb, 0xfc, // jmp -4
+	}
+	binary.LittleEndian.PutUint64(code[2:10], addr)
+	return code
+}
+
+func mmioReadLoop(addr uint64) []byte {
+	code := []byte{
+		0x48, 0xbb, 0, 0, 0, 0, 0, 0, 0, 0, // movabs rbx, imm64
+		0x8b, 0x03, // mov eax, dword ptr [rbx]
+		0xeb, 0xfc, // jmp -4
+	}
+	binary.LittleEndian.PutUint64(code[2:10], addr)
+	return code
+}
+
+func ioWriteLoop(port uint16) []byte {
+	if port > 0xffff {
+		panic(fmt.Sprintf("port out of range: %#x", port))
+	}
+	code := []byte{
+		0xba, 0, 0, // mov dx, imm16
+		0xee,       // out dx, al
+		0xeb, 0xfd, // jmp -3
+	}
+	binary.LittleEndian.PutUint16(code[1:3], port)
+	return code
+}
+
+func ioReadLoop(port uint16) []byte {
+	if port > 0xffff {
+		panic(fmt.Sprintf("port out of range: %#x", port))
+	}
+	code := []byte{
+		0xba, 0, 0, // mov dx, imm16
+		0xec,       // in al, dx
+		0xeb, 0xfd, // jmp -3
+	}
+	binary.LittleEndian.PutUint16(code[1:3], port)
+	return code
+}

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -56,10 +56,9 @@ type VM struct {
 }
 
 type VCPU struct {
-	id   int
-	fd   int
-	run  []byte
-	once bool
+	id  int
+	fd  int
+	run []byte
 }
 
 type memoryMapping struct {
@@ -275,6 +274,20 @@ func (c *VCPU) Run(exit *Exit) error {
 	case ExitSystemEvent:
 		system := (*kvmSystemEvent)(unsafe.Pointer(&run.anon0[0]))
 		exit.SystemEvent = system.typ
+	}
+	return nil
+}
+
+func (v *VM) CancelRun() error {
+	if v == nil {
+		return nil
+	}
+	for _, vcpu := range v.vcpus {
+		if vcpu == nil || len(vcpu.run) == 0 {
+			continue
+		}
+		run := (*kvmRunData)(unsafe.Pointer(&vcpu.run[0]))
+		run.immediateExit = 1
 	}
 	return nil
 }

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -49,10 +49,17 @@ type VM struct {
 	kvm         *Bootstrap
 	vmfd        int
 	vcpufd      int
-	run         []byte
+	vcpus       []*VCPU
 	mem         []byte
 	lowMemLimit uint64
 	regions     []memoryMapping
+}
+
+type VCPU struct {
+	id   int
+	fd   int
+	run  []byte
+	once bool
 }
 
 type memoryMapping struct {
@@ -62,6 +69,13 @@ type memoryMapping struct {
 }
 
 func NewVM() (*VM, error) {
+	return NewVMWithCPUs(1)
+}
+
+func NewVMWithCPUs(cpus int) (*VM, error) {
+	if cpus <= 0 {
+		cpus = 1
+	}
 	k, err := Open()
 	if err != nil {
 		return nil, err
@@ -76,43 +90,56 @@ func NewVM() (*VM, error) {
 		_ = k.Close()
 		return nil, fmt.Errorf("init vm: %w", err)
 	}
-	vcpufd, err := k.CreateVCPU(vmfd, 0)
-	if err != nil {
-		_ = k.CloseVM(vmfd)
-		_ = k.Close()
-		return nil, fmt.Errorf("create vcpu: %w", err)
-	}
-	if err := k.InitVCPU(vmfd, vcpufd); err != nil {
-		_ = k.CloseVCPU(vcpufd)
-		_ = k.CloseVM(vmfd)
-		_ = k.Close()
-		return nil, fmt.Errorf("init vcpu: %w", err)
-	}
 	mmapSize, err := k.VcpuMmapSize()
 	if err != nil {
-		_ = k.CloseVCPU(vcpufd)
 		_ = k.CloseVM(vmfd)
 		_ = k.Close()
 		return nil, fmt.Errorf("get kvm_run mmap size: %w", err)
 	}
-	run, err := unix.Mmap(vcpufd, 0, mmapSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
-	if err != nil {
-		_ = k.CloseVCPU(vcpufd)
-		_ = k.CloseVM(vmfd)
-		_ = k.Close()
-		return nil, fmt.Errorf("mmap kvm_run: %w", err)
+	vm := &VM{kvm: k, vmfd: vmfd}
+	for id := 0; id < cpus; id++ {
+		vcpufd, err := k.CreateVCPU(vmfd, id)
+		if err != nil {
+			_ = vm.Close()
+			return nil, fmt.Errorf("create vcpu %d: %w", id, err)
+		}
+		if err := k.InitVCPUWithTopology(vmfd, vcpufd, id, cpus); err != nil {
+			_ = k.CloseVCPU(vcpufd)
+			_ = vm.Close()
+			return nil, fmt.Errorf("init vcpu %d: %w", id, err)
+		}
+		run, err := unix.Mmap(vcpufd, 0, mmapSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+		if err != nil {
+			_ = k.CloseVCPU(vcpufd)
+			_ = vm.Close()
+			return nil, fmt.Errorf("mmap kvm_run vcpu %d: %w", id, err)
+		}
+		vm.vcpus = append(vm.vcpus, &VCPU{id: id, fd: vcpufd, run: run})
+		if id == 0 {
+			vm.vcpufd = vcpufd
+		}
 	}
-	return &VM{kvm: k, vmfd: vmfd, vcpufd: vcpufd, run: run}, nil
+	return vm, nil
 }
 
 func (v *VM) Close() error {
 	if v == nil {
 		return nil
 	}
-	if len(v.run) != 0 {
-		_ = unix.Munmap(v.run)
-		v.run = nil
+	for _, vcpu := range v.vcpus {
+		if vcpu == nil {
+			continue
+		}
+		if len(vcpu.run) != 0 {
+			_ = unix.Munmap(vcpu.run)
+			vcpu.run = nil
+		}
+		if vcpu.fd >= 0 && v.kvm != nil {
+			_ = v.kvm.CloseVCPU(vcpu.fd)
+			vcpu.fd = -1
+		}
 	}
+	v.vcpus = nil
 	if len(v.mem) != 0 {
 		_ = unix.Munmap(v.mem)
 		v.mem = nil
@@ -125,7 +152,6 @@ func (v *VM) Close() error {
 	}
 	v.regions = nil
 	if v.kvm != nil {
-		_ = v.kvm.CloseVCPU(v.vcpufd)
 		_ = v.kvm.CloseVM(v.vmfd)
 		_ = v.kvm.Close()
 		v.kvm = nil
@@ -207,12 +233,23 @@ func mapAMD64GuestMemory(vm *VM, memoryMB uint64) ([]byte, error) {
 }
 
 func (v *VM) Run(exit *Exit) error {
+	return v.RunVCPU(0, exit)
+}
+
+func (v *VM) RunVCPU(index int, exit *Exit) error {
+	if v == nil || index < 0 || index >= len(v.vcpus) {
+		return fmt.Errorf("vcpu %d out of range", index)
+	}
+	return v.vcpus[index].Run(exit)
+}
+
+func (c *VCPU) Run(exit *Exit) error {
 	if exit == nil {
 		return fmt.Errorf("exit is nil")
 	}
-	run := (*kvmRunData)(unsafe.Pointer(&v.run[0]))
+	run := (*kvmRunData)(unsafe.Pointer(&c.run[0]))
 	run.immediateExit = 0
-	if _, err := ioctlWithRetry(uintptr(v.vcpufd), uint64(kvmRun), 0); err != nil {
+	if _, err := ioctlRunVCPU(uintptr(c.fd)); err != nil {
 		return fmt.Errorf("run vcpu: %w", err)
 	}
 	reason := ExitReason(run.exitReason)
@@ -221,7 +258,7 @@ func (v *VM) Run(exit *Exit) error {
 	case ExitIO:
 		ioData := (*kvmExitIoData)(unsafe.Pointer(&run.anon0[0]))
 		dataLen := uint64(ioData.size) * uint64(ioData.count)
-		data := v.run[ioData.dataOffset : ioData.dataOffset+dataLen]
+		data := c.run[ioData.dataOffset : ioData.dataOffset+dataLen]
 		exit.IO = IOExit{
 			Port:  ioData.port,
 			Data:  data,
@@ -243,7 +280,14 @@ func (v *VM) Run(exit *Exit) error {
 }
 
 func (v *VM) GetPC() (uint64, error) {
-	regs, err := getRegs(v.vcpufd)
+	return v.GetVCPUPC(0)
+}
+
+func (v *VM) GetVCPUPC(index int) (uint64, error) {
+	if v == nil || index < 0 || index >= len(v.vcpus) {
+		return 0, fmt.Errorf("vcpu %d out of range", index)
+	}
+	regs, err := getRegs(v.vcpus[index].fd)
 	if err != nil {
 		return 0, err
 	}
@@ -251,7 +295,18 @@ func (v *VM) GetPC() (uint64, error) {
 }
 
 func (v *VM) CompleteMMIORead(value uint64, size uint32) {
-	run := (*kvmRunData)(unsafe.Pointer(&v.run[0]))
+	v.CompleteVCPUMMIORead(0, value, size)
+}
+
+func (v *VM) CompleteVCPUMMIORead(index int, value uint64, size uint32) {
+	if v == nil || index < 0 || index >= len(v.vcpus) {
+		return
+	}
+	v.vcpus[index].CompleteMMIORead(value, size)
+}
+
+func (c *VCPU) CompleteMMIORead(value uint64, size uint32) {
+	run := (*kvmRunData)(unsafe.Pointer(&c.run[0]))
 	mmio := (*kvmExitMMIOData)(unsafe.Pointer(&run.anon0[0]))
 	for i := range mmio.data {
 		mmio.data[i] = 0
@@ -352,10 +407,14 @@ func (v *VM) findMemoryRegion(addr uint64) ([]byte, uint64, bool) {
 }
 
 func (v *VM) SetLongMode(entry, zeroPage, stack, pagingBase uint64) error {
+	if v == nil || len(v.vcpus) == 0 {
+		return fmt.Errorf("missing bootstrap vcpu")
+	}
 	if err := v.setupPageTables(pagingBase, 4); err != nil {
 		return err
 	}
-	sregs, err := getSRegs(v.vcpufd)
+	bsp := v.vcpus[0]
+	sregs, err := getSRegs(bsp.fd)
 	if err != nil {
 		return err
 	}
@@ -384,10 +443,10 @@ func (v *VM) SetLongMode(entry, zeroPage, stack, pagingBase uint64) error {
 	sregs.Fs = data
 	sregs.Gs = data
 	sregs.Ss = data
-	if err := setSRegs(v.vcpufd, &sregs); err != nil {
+	if err := setSRegs(bsp.fd, &sregs); err != nil {
 		return err
 	}
-	return setRegs(v.vcpufd, &kvmRegs{
+	return setRegs(bsp.fd, &kvmRegs{
 		Rip:    entry,
 		Rsi:    zeroPage,
 		Rsp:    stack,

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -206,40 +206,40 @@ func mapAMD64GuestMemory(vm *VM, memoryMB uint64) ([]byte, error) {
 	return mem, nil
 }
 
-func (v *VM) Run() (*Exit, error) {
+func (v *VM) Run(exit *Exit) error {
+	if exit == nil {
+		return fmt.Errorf("exit is nil")
+	}
 	run := (*kvmRunData)(unsafe.Pointer(&v.run[0]))
 	run.immediateExit = 0
 	if _, err := ioctlWithRetry(uintptr(v.vcpufd), uint64(kvmRun), 0); err != nil {
-		return nil, fmt.Errorf("run vcpu: %w", err)
+		return fmt.Errorf("run vcpu: %w", err)
 	}
 	reason := ExitReason(run.exitReason)
+	*exit = Exit{Reason: reason}
 	switch reason {
 	case ExitIO:
 		ioData := (*kvmExitIoData)(unsafe.Pointer(&run.anon0[0]))
 		dataLen := uint64(ioData.size) * uint64(ioData.count)
 		data := v.run[ioData.dataOffset : ioData.dataOffset+dataLen]
-		return &Exit{
-			Reason: reason,
-			IO: IOExit{
-				Port:  ioData.port,
-				Data:  data,
-				Size:  ioData.size,
-				Count: ioData.count,
-				Write: ioData.direction != 0,
-			},
-		}, nil
+		exit.IO = IOExit{
+			Port:  ioData.port,
+			Data:  data,
+			Size:  ioData.size,
+			Count: ioData.count,
+			Write: ioData.direction != 0,
+		}
 	case ExitMMIO:
 		mmio := (*kvmExitMMIOData)(unsafe.Pointer(&run.anon0[0]))
-		return &Exit{Reason: reason, MMIO: MMIOExit{Addr: mmio.physAddr, Data: mmio.data, Len: mmio.len, Write: mmio.isWrite != 0}}, nil
+		exit.MMIO = MMIOExit{Addr: mmio.physAddr, Data: mmio.data, Len: mmio.len, Write: mmio.isWrite != 0}
 	case ExitInternal:
 		ie := (*internalError)(unsafe.Pointer(&run.anon0[0]))
-		return nil, fmt.Errorf("internal error: %d", ie.Suberror)
+		return fmt.Errorf("internal error: %d", ie.Suberror)
 	case ExitSystemEvent:
 		system := (*kvmSystemEvent)(unsafe.Pointer(&run.anon0[0]))
-		return &Exit{Reason: reason, SystemEvent: system.typ}, nil
-	default:
-		return &Exit{Reason: reason}, nil
+		exit.SystemEvent = system.typ
 	}
+	return nil
 }
 
 func (v *VM) GetPC() (uint64, error) {
@@ -279,10 +279,23 @@ func (v *VM) ReadIPA(addr uint64, size int) ([]byte, error) {
 		return []byte{}, nil
 	}
 	out := make([]byte, size)
-	if err := v.copyFromGuest(addr, out); err != nil {
-		return nil, fmt.Errorf("read guest memory %#x size %d: unmapped", addr, size)
+	if err := v.ReadIPAInto(addr, out); err != nil {
+		return nil, err
 	}
 	return out, nil
+}
+
+func (v *VM) ReadIPAInto(addr uint64, dst []byte) error {
+	if v == nil {
+		return fmt.Errorf("vm is nil")
+	}
+	if len(dst) == 0 {
+		return nil
+	}
+	if err := v.copyFromGuest(addr, dst); err != nil {
+		return fmt.Errorf("read guest memory %#x size %d: unmapped", addr, len(dst))
+	}
+	return nil
 }
 
 func (v *VM) WriteIPA(addr uint64, data []byte) error {

--- a/internal/hv/kvm/vm_linux_arm64.go
+++ b/internal/hv/kvm/vm_linux_arm64.go
@@ -187,40 +187,39 @@ func (v *VM) GetPC() (uint64, error) {
 	return value, nil
 }
 
-func (v *VM) Run() (*Exit, error) {
+func (v *VM) Run(exit *Exit) error {
+	if exit == nil {
+		return fmt.Errorf("exit is nil")
+	}
 	run := (*kvmRunData)(unsafe.Pointer(&v.run[0]))
 	run.immediateExit = 0
 	if _, err := ioctlWithRetry(uintptr(v.vcpufd), uint64(kvmRun), 0); err != nil {
-		return nil, fmt.Errorf("run vcpu: %w", err)
+		return fmt.Errorf("run vcpu: %w", err)
 	}
 	reason := ExitReason(run.exitReason)
+	*exit = Exit{Reason: reason}
 	switch reason {
 	case ExitMMIO:
 		mmio := (*kvmExitMMIOData)(unsafe.Pointer(&run.anon0[0]))
-		return &Exit{
-			Reason: reason,
-			MMIO: MMIOExit{
-				Addr:  mmio.physAddr,
-				Data:  mmio.data,
-				Len:   mmio.len,
-				Write: mmio.isWrite != 0,
-			},
-		}, nil
+		exit.MMIO = MMIOExit{
+			Addr:  mmio.physAddr,
+			Data:  mmio.data,
+			Len:   mmio.len,
+			Write: mmio.isWrite != 0,
+		}
 	case ExitSystemEvent:
 		system := (*kvmSystemEvent)(unsafe.Pointer(&run.anon0[0]))
-		return &Exit{Reason: reason, SystemEvent: system.typ}, nil
+		exit.SystemEvent = system.typ
 	case ExitShutdown:
-		return &Exit{Reason: reason}, nil
 	case ExitException:
 		// KVM arm64 MMIO should normally be surfaced as KVM_EXIT_MMIO.
-		return &Exit{Reason: reason}, nil
 	default:
 		if reason == 17 {
 			ie := (*internalError)(unsafe.Pointer(&run.anon0[0]))
-			return nil, fmt.Errorf("internal error: %d", ie.Suberror)
+			return fmt.Errorf("internal error: %d", ie.Suberror)
 		}
-		return &Exit{Reason: reason}, nil
 	}
+	return nil
 }
 
 func (v *VM) CancelRun() error {
@@ -271,13 +270,31 @@ func (v *VM) ReadIPA(addr uint64, size int) ([]byte, error) {
 	if size < 0 {
 		return nil, fmt.Errorf("invalid read size %d", size)
 	}
+	if size == 0 {
+		return []byte{}, nil
+	}
+	out := make([]byte, size)
+	if err := v.ReadIPAInto(addr, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (v *VM) ReadIPAInto(addr uint64, dst []byte) error {
+	if v == nil {
+		return fmt.Errorf("vm is nil")
+	}
+	if len(dst) == 0 {
+		return nil
+	}
 	start := v.memRegion.GuestPhysAddr
 	end := start + v.memRegion.MemorySize
-	if addr < start || addr+uint64(size) > end {
-		return nil, fmt.Errorf("read guest memory %#x size %d: unmapped", addr, size)
+	if addr < start || addr+uint64(len(dst)) > end {
+		return fmt.Errorf("read guest memory %#x size %d: unmapped", addr, len(dst))
 	}
 	off := addr - start
-	return append([]byte(nil), v.mem[off:off+uint64(size)]...), nil
+	copy(dst, v.mem[off:off+uint64(len(dst))])
+	return nil
 }
 
 func (v *VM) WriteIPA(addr uint64, data []byte) error {

--- a/internal/linux/boot/amd64/plan.go
+++ b/internal/linux/boot/amd64/plan.go
@@ -18,6 +18,7 @@ type E820Entry struct {
 type BootOptions struct {
 	MemoryBase  uint64
 	MemorySize  uint64
+	NumCPUs     int
 	Cmdline     string
 	LoadAddr    uint64
 	Initrd      []byte
@@ -46,6 +47,9 @@ func PrepareBoot(memory []byte, kernelFile []byte, opts BootOptions) (*BootPlan,
 	}
 	if opts.MemorySize == 0 {
 		opts.MemorySize = uint64(len(memory))
+	}
+	if opts.NumCPUs <= 0 {
+		opts.NumCPUs = 1
 	}
 	if opts.ZeroPageGPA == 0 {
 		opts.ZeroPageGPA = 0x00090000
@@ -111,6 +115,11 @@ func PrepareBoot(memory []byte, kernelFile []byte, opts BootOptions) (*BootPlan,
 	if err := img.buildZeroPage(memory, memStart, loadAddr, opts.Cmdline, opts.CmdlineGPA, initrdAddr, uint32(len(opts.Initrd)), opts.ZeroPageGPA, e820); err != nil {
 		return nil, err
 	}
+	if opts.NumCPUs > 1 {
+		if err := writeMPTable(memory, memStart, opts.NumCPUs); err != nil {
+			return nil, err
+		}
+	}
 
 	stack := opts.StackTopGPA
 	if stack == 0 {
@@ -131,6 +140,102 @@ func PrepareBoot(memory []byte, kernelFile []byte, opts BootOptions) (*BootPlan,
 		StackTopGPA: stack,
 		PagingBase:  opts.PagingBase,
 	}, nil
+}
+
+func writeMPTable(memory []byte, memStart uint64, numCPUs int) error {
+	const (
+		fpGPA       = 0x000f0000
+		tableGPA    = 0x000f0100
+		lapicAddr   = 0xfee00000
+		ioapicAddr  = 0xfec00000
+		entryCPU    = 0
+		entryBus    = 1
+		entryIOAPIC = 2
+		entryIOInt  = 3
+		entryLInt   = 4
+	)
+	if numCPUs < 1 {
+		numCPUs = 1
+	}
+	if numCPUs > 255 {
+		numCPUs = 255
+	}
+	entryCount := numCPUs + 1 + 1 + 16 + 2
+	tableLen := 44 + numCPUs*20 + 8 + 8 + 16*8 + 2*8
+	table := make([]byte, tableLen)
+	copy(table[0:4], "PCMP")
+	binary.LittleEndian.PutUint16(table[4:6], uint16(tableLen))
+	table[6] = 4
+	copy(table[8:16], []byte("CC      "))
+	copy(table[16:28], []byte("CC SMP      "))
+	binary.LittleEndian.PutUint16(table[34:36], uint16(entryCount))
+	binary.LittleEndian.PutUint32(table[36:40], lapicAddr)
+	off := 44
+	for cpu := 0; cpu < numCPUs; cpu++ {
+		table[off] = entryCPU
+		table[off+1] = byte(cpu)
+		table[off+2] = 0x14
+		table[off+3] = 1
+		if cpu == 0 {
+			table[off+3] |= 2
+		}
+		binary.LittleEndian.PutUint32(table[off+4:off+8], 0x600)
+		binary.LittleEndian.PutUint32(table[off+8:off+12], 0x201)
+		off += 20
+	}
+	table[off] = entryBus
+	table[off+1] = 0
+	copy(table[off+2:off+8], []byte("ISA   "))
+	off += 8
+	table[off] = entryIOAPIC
+	table[off+1] = byte(numCPUs)
+	table[off+2] = 0x11
+	table[off+3] = 1
+	binary.LittleEndian.PutUint32(table[off+4:off+8], ioapicAddr)
+	off += 8
+	for irq := 0; irq < 16; irq++ {
+		table[off] = entryIOInt
+		table[off+1] = 0
+		binary.LittleEndian.PutUint16(table[off+2:off+4], 0)
+		table[off+4] = 0
+		table[off+5] = byte(irq)
+		table[off+6] = byte(numCPUs)
+		table[off+7] = byte(irq)
+		off += 8
+	}
+	for lint := 0; lint < 2; lint++ {
+		table[off] = entryLInt
+		table[off+1] = byte(lint)
+		binary.LittleEndian.PutUint16(table[off+2:off+4], 0)
+		table[off+4] = 0
+		table[off+5] = 0
+		table[off+6] = 0xff
+		table[off+7] = byte(lint)
+		off += 8
+	}
+	table[7] = checksum(table)
+	if err := writeAt(memory, memStart, tableGPA, table); err != nil {
+		return fmt.Errorf("write MP config table: %w", err)
+	}
+
+	fp := make([]byte, 16)
+	copy(fp[0:4], "_MP_")
+	binary.LittleEndian.PutUint32(fp[4:8], tableGPA)
+	fp[8] = 1
+	fp[9] = 4
+	fp[10] = checksum(fp)
+	if err := writeAt(memory, memStart, fpGPA, fp); err != nil {
+		return fmt.Errorf("write MP floating pointer: %w", err)
+	}
+	return nil
+}
+
+func checksum(buf []byte) byte {
+	var sum byte
+	for _, b := range buf {
+		sum += b
+	}
+	return -sum
 }
 
 func (k *KernelImage) buildZeroPage(memory []byte, memStart, loadAddr uint64, cmdline string, cmdlineGPA, initrdGPA uint64, initrdSize uint32, zeroPageGPA uint64, e820 []E820Entry) error {

--- a/internal/virtio/console.go
+++ b/internal/virtio/console.go
@@ -57,6 +57,10 @@ type GuestMemory interface {
 	WriteIPA(addr uint64, data []byte) error
 }
 
+type guestMemoryReaderInto interface {
+	ReadIPAInto(addr uint64, dst []byte) error
+}
+
 type IRQController interface {
 	SetIRQ(irq uint32, level bool) error
 }

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -58,6 +58,7 @@ const (
 	fuseWrite      = 16
 	fuseStatfs     = 17
 	fuseRelease    = 18
+	fuseFsync      = 20
 	fuseGetXattr   = 22
 	fuseListXattr  = 23
 	fuseFlush      = 25
@@ -65,6 +66,7 @@ const (
 	fuseOpenDir    = 27
 	fuseReadDir    = 28
 	fuseReleaseDir = 29
+	fuseFsyncDir   = 30
 	fuseAccess     = 34
 	fuseCreate     = 35
 	fuseDestroy    = 38
@@ -141,6 +143,14 @@ type fsXattrBackend interface {
 
 type fsFlushBackend interface {
 	Flush(nodeID uint64, fh uint64, lockOwner uint64) int32
+}
+
+type fsFsyncBackend interface {
+	Fsync(nodeID uint64, fh uint64, flags uint32) int32
+}
+
+type fsFsyncDirBackend interface {
+	FsyncDir(nodeID uint64, fh uint64, flags uint32) int32
 }
 
 type fsLseekBackend interface {
@@ -685,6 +695,20 @@ func (f *FS) dispatchFUSELocked(req []byte) ([]byte, error) {
 		f.logPathf("release", nodeID, fmt.Sprintf(" fh=%d", binary.LittleEndian.Uint64(req[40:48])))
 		f.backend.Release(nodeID, binary.LittleEndian.Uint64(req[40:48]))
 		return reply(0, nil), nil
+	case fuseFsync:
+		if len(req) < fuseInHeaderSize+16 {
+			return nil, fmt.Errorf("virtio-fs FSYNC too short")
+		}
+		fh := binary.LittleEndian.Uint64(req[40:48])
+		flags := binary.LittleEndian.Uint32(req[48:52])
+		f.logPathf("fsync", nodeID, fmt.Sprintf(" fh=%d flags=%#x", fh, flags))
+		if be, ok := f.backend.(fsFsyncBackend); ok {
+			return reply(be.Fsync(nodeID, fh, flags), nil), nil
+		}
+		if f.Strict {
+			return nil, fmt.Errorf("virtio-fs missing fsync backend for FSYNC node=%d fh=%d", nodeID, fh)
+		}
+		return reply(0, nil), nil
 	case fuseOpenDir:
 		if len(req) < fuseInHeaderSize+8 {
 			return nil, fmt.Errorf("virtio-fs OPENDIR too short")
@@ -717,6 +741,20 @@ func (f *FS) dispatchFUSELocked(req []byte) ([]byte, error) {
 		}
 		f.logPathf("releasedir", nodeID, fmt.Sprintf(" fh=%d", binary.LittleEndian.Uint64(req[40:48])))
 		f.backend.ReleaseDir(nodeID, binary.LittleEndian.Uint64(req[40:48]))
+		return reply(0, nil), nil
+	case fuseFsyncDir:
+		if len(req) < fuseInHeaderSize+16 {
+			return nil, fmt.Errorf("virtio-fs FSYNCDIR too short")
+		}
+		fh := binary.LittleEndian.Uint64(req[40:48])
+		flags := binary.LittleEndian.Uint32(req[48:52])
+		f.logPathf("fsyncdir", nodeID, fmt.Sprintf(" fh=%d flags=%#x", fh, flags))
+		if be, ok := f.backend.(fsFsyncDirBackend); ok {
+			return reply(be.FsyncDir(nodeID, fh, flags), nil), nil
+		}
+		if f.Strict {
+			return nil, fmt.Errorf("virtio-fs missing fsyncdir backend for FSYNCDIR node=%d fh=%d", nodeID, fh)
+		}
 		return reply(0, nil), nil
 	case fuseRmDir:
 		name := readCStringName(req[fuseInHeaderSize:])
@@ -938,6 +976,8 @@ func fuseOpcodeName(opcode uint32) string {
 		return "STATFS"
 	case fuseRelease:
 		return "RELEASE"
+	case fuseFsync:
+		return "FSYNC"
 	case fuseGetXattr:
 		return "GETXATTR"
 	case fuseListXattr:
@@ -952,6 +992,8 @@ func fuseOpcodeName(opcode uint32) string {
 		return "READDIR"
 	case fuseReleaseDir:
 		return "RELEASEDIR"
+	case fuseFsyncDir:
+		return "FSYNCDIR"
 	case fuseAccess:
 		return "ACCESS"
 	case fuseCreate:
@@ -1438,8 +1480,28 @@ func (p *passthroughFS) Flush(_ uint64, fh uint64, _ uint64) int32 {
 	if handle == nil || handle.file == nil {
 		return -linuxEBADF
 	}
+	return 0
+}
+
+func (p *passthroughFS) Fsync(_ uint64, fh uint64, _ uint32) int32 {
+	p.mu.Lock()
+	handle := p.handles[fh]
+	p.mu.Unlock()
+	if handle == nil || handle.file == nil {
+		return -linuxEBADF
+	}
 	if err := handle.file.Sync(); err != nil {
 		return errnoFromError(err)
+	}
+	return 0
+}
+
+func (p *passthroughFS) FsyncDir(_ uint64, fh uint64, _ uint32) int32 {
+	p.mu.Lock()
+	_, ok := p.dirHandles[fh]
+	p.mu.Unlock()
+	if !ok {
+		return -linuxEBADF
 	}
 	return 0
 }
@@ -1944,6 +2006,14 @@ func (p *imageFS) Release(_ uint64, fh uint64) {
 }
 
 func (p *imageFS) Flush(_ uint64, _ uint64, _ uint64) int32 {
+	return 0
+}
+
+func (p *imageFS) Fsync(_ uint64, _ uint64, _ uint32) int32 {
+	return 0
+}
+
+func (p *imageFS) FsyncDir(_ uint64, _ uint64, _ uint32) int32 {
 	return 0
 }
 

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -24,8 +24,10 @@ const (
 	mmioDeviceIDFS = 26
 
 	fsQueueHiprio       = 0
-	fsQueueRequest      = 1
+	fsControlQueueCount = 1
+	fsQueueRequest      = fsQueueHiprio + fsControlQueueCount
 	fsRequestQueueCount = 4
+	fsQueueCount        = fsControlQueueCount + fsRequestQueueCount
 
 	fsCfgTagSize        = 36
 	fsCfgNumQueueOff    = fsCfgTagSize
@@ -44,10 +46,6 @@ const (
 	fuseDirentBaseSize  = 24
 	fuseWriteOutSize    = 8
 )
-
-func fsTotalQueueCount() int {
-	return fsQueueRequest + fsRequestQueueCount
-}
 
 const (
 	fuseLookup     = 1
@@ -1773,7 +1771,7 @@ func (f *FS) configBytesLocked() []byte {
 }
 
 func (f *FS) resetQueueStateLocked() {
-	queueCount := fsTotalQueueCount()
+	queueCount := fsQueueCount
 	if cap(f.queues) < queueCount {
 		f.queues = make([]queue, queueCount)
 	} else {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -105,6 +105,7 @@ const (
 const (
 	fuseOpenKeepCache = 1 << 1
 	fuseOpenCacheDir  = 1 << 3
+	fuseOpenNoFlush   = 1 << 5
 )
 
 const (
@@ -232,6 +233,39 @@ type FS struct {
 	fuseRequests     uint64
 	interruptRaises  uint64
 	irqTransitions   uint64
+	fuseOpStats      [fuseStatsSlots]fuseOpStat
+}
+
+const fuseStatsSlots = 64
+
+type FSStats struct {
+	Tag             string        `json:"tag"`
+	MMIOReads       uint64        `json:"mmio_reads"`
+	MMIOWrites      uint64        `json:"mmio_writes"`
+	QueueNotifies   [2]uint64     `json:"queue_notifies"`
+	FUSERequests    uint64        `json:"fuse_requests"`
+	InterruptRaises uint64        `json:"interrupt_raises"`
+	IRQTransitions  uint64        `json:"irq_transitions"`
+	IRQHigh         bool          `json:"irq_high"`
+	InterruptStatus uint32        `json:"interrupt_status"`
+	QueueReady      [2]bool       `json:"queue_ready"`
+	QueueLastAvail  [2]uint16     `json:"queue_last_avail"`
+	FUSEOps         []FUSEOpStats `json:"fuse_ops"`
+}
+
+type FUSEOpStats struct {
+	Opcode       uint32 `json:"opcode"`
+	Name         string `json:"name"`
+	Count        uint64 `json:"count"`
+	TotalNanos   int64  `json:"total_nanos"`
+	MaxNanos     int64  `json:"max_nanos"`
+	AverageNanos int64  `json:"average_nanos"`
+}
+
+type fuseOpStat struct {
+	count      uint64
+	totalNanos int64
+	maxNanos   int64
 }
 
 type fsDesc struct {
@@ -419,8 +453,8 @@ func (f *FS) processQueueLocked(qidx int) error {
 		return nil
 	}
 
-	header, err := f.mem.ReadIPA(q.availAddr, 4)
-	if err != nil {
+	var header [4]byte
+	if err := f.readIPAInto(q.availAddr, header[:]); err != nil {
 		return err
 	}
 	availFlags := binary.LittleEndian.Uint16(header[0:2])
@@ -428,11 +462,11 @@ func (f *FS) processQueueLocked(qidx int) error {
 	interruptNeeded := false
 	for q.lastAvailIdx != availIdx {
 		slot := q.lastAvailIdx % q.size
-		entry, err := f.mem.ReadIPA(q.availAddr+4+uint64(slot)*2, 2)
-		if err != nil {
+		var entry [2]byte
+		if err := f.readIPAInto(q.availAddr+4+uint64(slot)*2, entry[:]); err != nil {
 			return err
 		}
-		head := binary.LittleEndian.Uint16(entry)
+		head := binary.LittleEndian.Uint16(entry[:])
 		f.logf("queue-notify q=%d head=%d", qidx, head)
 		usedLen, reply, err := f.handleRequestLocked(q, head)
 		if err != nil {
@@ -457,11 +491,15 @@ func (f *FS) processQueueLocked(qidx int) error {
 }
 
 func (f *FS) handleRequestLocked(q *queue, head uint16) (uint32, bool, error) {
-	descs, err := f.readDescriptorChainLocked(q, head)
+	var descScratch [8]fsDesc
+	descs, err := f.readDescriptorChainLocked(q, head, descScratch[:0])
 	if err != nil {
 		return 0, false, err
 	}
-	var reqDescs, respDescs []fsDesc
+	var reqScratch [4]fsDesc
+	var respScratch [4]fsDesc
+	reqDescs := reqScratch[:0]
+	respDescs := respScratch[:0]
 	for _, d := range descs {
 		if d.write {
 			respDescs = append(respDescs, d)
@@ -479,13 +517,19 @@ func (f *FS) handleRequestLocked(q *queue, head uint16) (uint32, bool, error) {
 	for _, d := range reqDescs {
 		reqLen += int(d.length)
 	}
-	req := make([]byte, 0, reqLen)
+	var reqStack [4096]byte
+	var req []byte
+	if reqLen <= len(reqStack) {
+		req = reqStack[:reqLen]
+	} else {
+		req = make([]byte, reqLen)
+	}
+	reqOff := 0
 	for _, d := range reqDescs {
-		chunk, err := f.mem.ReadIPA(d.addr, int(d.length))
-		if err != nil {
+		if err := f.readIPAInto(d.addr, req[reqOff:reqOff+int(d.length)]); err != nil {
 			return 0, false, err
 		}
-		req = append(req, chunk...)
+		reqOff += int(d.length)
 	}
 	reply, err := f.dispatchFUSELocked(req)
 	if err != nil {
@@ -652,6 +696,7 @@ func (f *FS) dispatchFUSELocked(req []byte) ([]byte, error) {
 		}
 		extra := make([]byte, fuseOpenOutSize)
 		binary.LittleEndian.PutUint64(extra[0:8], fh)
+		binary.LittleEndian.PutUint32(extra[8:12], fuseOpenNoFlush)
 		return reply(0, extra), nil
 	case fuseRead:
 		if len(req) < fuseInHeaderSize+24 {
@@ -933,6 +978,7 @@ func (f *FS) dispatchFUSELocked(req []byte) ([]byte, error) {
 			binary.LittleEndian.PutUint64(extra[24:32], 1)
 			encodeFuseAttr(extra[40:], attr)
 			binary.LittleEndian.PutUint64(extra[fuseEntryOutSize:fuseEntryOutSize+8], fh)
+			binary.LittleEndian.PutUint32(extra[fuseEntryOutSize+8:fuseEntryOutSize+12], fuseOpenNoFlush)
 			return reply(0, extra), nil
 		}
 		return reply(-linuxENOSYS, nil), nil
@@ -1020,6 +1066,15 @@ func fuseOpcodeMetricName(opcode uint32) string {
 }
 
 func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
+	duration := time.Since(start)
+	if opcode < uint32(len(f.fuseOpStats)) {
+		opStats := &f.fuseOpStats[opcode]
+		opStats.count++
+		opStats.totalNanos += duration.Nanoseconds()
+		if duration.Nanoseconds() > opStats.maxNanos {
+			opStats.maxNanos = duration.Nanoseconds()
+		}
+	}
 	if f.RecordTiming == nil {
 		return
 	}
@@ -1027,7 +1082,7 @@ func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
 	if tag == "" {
 		tag = "unknown"
 	}
-	f.RecordTiming("virtio.fs."+tag+".fuse."+fuseOpcodeMetricName(opcode), time.Since(start))
+	f.RecordTiming("virtio.fs."+tag+".fuse."+fuseOpcodeMetricName(opcode), duration)
 }
 
 func (f *FS) logf(format string, args ...any) {
@@ -1048,15 +1103,26 @@ func (f *FS) logPathf(op string, nodeID uint64, suffix string) {
 	_, _ = fmt.Fprintf(f.Log, "%s node=%d%s\n", op, nodeID, suffix)
 }
 
-func (f *FS) readDescriptorChainLocked(q *queue, head uint16) ([]fsDesc, error) {
-	var out []fsDesc
+func (f *FS) readIPAInto(addr uint64, dst []byte) error {
+	if reader, ok := f.mem.(guestMemoryReaderInto); ok {
+		return reader.ReadIPAInto(addr, dst)
+	}
+	buf, err := f.mem.ReadIPA(addr, len(dst))
+	if err != nil {
+		return err
+	}
+	copy(dst, buf)
+	return nil
+}
+
+func (f *FS) readDescriptorChainLocked(q *queue, head uint16, out []fsDesc) ([]fsDesc, error) {
 	index := head
 	for i := uint16(0); i < q.size; i++ {
 		if index >= q.size {
 			return nil, fmt.Errorf("virtio-fs descriptor index %d out of range", index)
 		}
-		buf, err := f.mem.ReadIPA(q.descAddr+uint64(index)*16, 16)
-		if err != nil {
+		var buf [16]byte
+		if err := f.readIPAInto(q.descAddr+uint64(index)*16, buf[:]); err != nil {
 			return nil, err
 		}
 		desc := fsDesc{
@@ -1077,16 +1143,16 @@ func (f *FS) readDescriptorChainLocked(q *queue, head uint16) ([]fsDesc, error) 
 
 func (f *FS) writeUsedLocked(q *queue, head uint16, usedLen uint32) error {
 	slot := q.usedIdx % q.size
-	elem := make([]byte, 8)
+	var elem [8]byte
 	binary.LittleEndian.PutUint32(elem[0:4], uint32(head))
 	binary.LittleEndian.PutUint32(elem[4:8], usedLen)
-	if err := f.mem.WriteIPA(q.usedAddr+4+uint64(slot)*8, elem); err != nil {
+	if err := f.mem.WriteIPA(q.usedAddr+4+uint64(slot)*8, elem[:]); err != nil {
 		return err
 	}
 	q.usedIdx++
-	idx := make([]byte, 2)
-	binary.LittleEndian.PutUint16(idx, q.usedIdx)
-	return f.mem.WriteIPA(q.usedAddr+2, idx)
+	var idx [2]byte
+	binary.LittleEndian.PutUint16(idx[:], q.usedIdx)
+	return f.mem.WriteIPA(q.usedAddr+2, idx[:])
 }
 
 func (f *FS) updateIRQLocked() error {
@@ -1128,6 +1194,60 @@ func (f *FS) Summary() string {
 		f.queues[0].lastAvailIdx,
 		f.queues[1].lastAvailIdx,
 	)
+}
+
+func (f *FS) Stats() FSStats {
+	if f == nil {
+		return FSStats{}
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	tag := strings.TrimRight(string(f.tag[:]), "\x00")
+	ops := make([]FUSEOpStats, 0, len(f.fuseOpStats))
+	for opcode, stat := range f.fuseOpStats {
+		if stat.count == 0 {
+			continue
+		}
+		avg := int64(0)
+		if stat.count != 0 {
+			avg = stat.totalNanos / int64(stat.count)
+		}
+		opcodeValue := uint32(opcode)
+		ops = append(ops, FUSEOpStats{
+			Opcode:       opcodeValue,
+			Name:         fuseOpcodeName(opcodeValue),
+			Count:        stat.count,
+			TotalNanos:   stat.totalNanos,
+			MaxNanos:     stat.maxNanos,
+			AverageNanos: avg,
+		})
+	}
+	sort.Slice(ops, func(i, j int) bool {
+		if ops[i].Count == ops[j].Count {
+			return ops[i].Opcode < ops[j].Opcode
+		}
+		return ops[i].Count > ops[j].Count
+	})
+	return FSStats{
+		Tag:             tag,
+		MMIOReads:       f.mmioReads,
+		MMIOWrites:      f.mmioWrites,
+		QueueNotifies:   f.queueNotifies,
+		FUSERequests:    f.fuseRequests,
+		InterruptRaises: f.interruptRaises,
+		IRQTransitions:  f.irqTransitions,
+		IRQHigh:         f.irqHigh,
+		InterruptStatus: f.interruptStatus,
+		QueueReady: [2]bool{
+			f.queues[0].ready,
+			f.queues[1].ready,
+		},
+		QueueLastAvail: [2]uint16{
+			f.queues[0].lastAvailIdx,
+			f.queues[1].lastAvailIdx,
+		},
+		FUSEOps: ops,
+	}
 }
 
 func (f *FS) selectedQueueLocked() *queue {
@@ -1214,6 +1334,20 @@ func readCStringName(buf []byte) string {
 	return string(buf)
 }
 
+func cleanChildName(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	if !strings.Contains(name, "/") && name != "." && name != ".." {
+		return name, true
+	}
+	clean := path.Clean("/" + name)
+	if clean == "/" {
+		return "", false
+	}
+	return strings.TrimPrefix(clean, "/"), true
+}
+
 func bytesIndexByte(buf []byte, want byte) int {
 	for i, b := range buf {
 		if b == want {
@@ -1227,7 +1361,7 @@ type passthroughFS struct {
 	root string
 	meta map[string]fsmeta.Entry
 
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	nextNodeID uint64
 	nextHandle uint64
 	nodes      map[uint64]string
@@ -1354,12 +1488,11 @@ func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, in
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	clean := path.Clean("/" + name)
-	if clean == "/" {
+	rel, ok := cleanChildName(name)
+	if !ok {
 		attr, errno := p.GetAttr(parent)
 		return parent, attr, errno
 	}
-	rel := strings.TrimPrefix(clean, "/")
 	host := filepath.Join(hostParent, filepath.FromSlash(rel))
 	info, err := os.Lstat(host)
 	if err != nil {
@@ -1379,11 +1512,10 @@ func (p *passthroughFS) Mkdir(parent uint64, name string, mode uint32) (uint64, 
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	clean := path.Clean("/" + name)
-	if clean == "/" {
+	rel, ok := cleanChildName(name)
+	if !ok {
 		return 0, FuseAttr{}, -linuxEINVAL
 	}
-	rel := strings.TrimPrefix(clean, "/")
 	host := filepath.Join(hostParent, filepath.FromSlash(rel))
 	if err := os.Mkdir(host, fs.FileMode(mode&linuxPermMask)); err != nil {
 		return 0, FuseAttr{}, errnoFromError(err)
@@ -1414,11 +1546,11 @@ func (p *passthroughFS) Create(parent uint64, name string, flags uint32, mode ui
 	if errno != 0 {
 		return 0, 0, FuseAttr{}, errno
 	}
-	clean := path.Clean("/" + name)
-	if clean == "/" {
+	rel, ok := cleanChildName(name)
+	if !ok {
 		return 0, 0, FuseAttr{}, -linuxEINVAL
 	}
-	host := filepath.Join(hostParent, filepath.FromSlash(strings.TrimPrefix(clean, "/")))
+	host := filepath.Join(hostParent, filepath.FromSlash(rel))
 	file, err := os.OpenFile(host, translateLinuxOpenFlags(flags)|os.O_CREATE, fs.FileMode(mode&linuxPermMask))
 	if err != nil {
 		return 0, 0, FuseAttr{}, errnoFromError(err)
@@ -1474,9 +1606,9 @@ func (p *passthroughFS) Release(_ uint64, fh uint64) {
 }
 
 func (p *passthroughFS) Flush(_ uint64, fh uint64, _ uint64) int32 {
-	p.mu.Lock()
+	p.mu.RLock()
 	handle := p.handles[fh]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if handle == nil || handle.file == nil {
 		return -linuxEBADF
 	}
@@ -1484,9 +1616,9 @@ func (p *passthroughFS) Flush(_ uint64, fh uint64, _ uint64) int32 {
 }
 
 func (p *passthroughFS) Fsync(_ uint64, fh uint64, _ uint32) int32 {
-	p.mu.Lock()
+	p.mu.RLock()
 	handle := p.handles[fh]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if handle == nil || handle.file == nil {
 		return -linuxEBADF
 	}
@@ -1497,9 +1629,9 @@ func (p *passthroughFS) Fsync(_ uint64, fh uint64, _ uint32) int32 {
 }
 
 func (p *passthroughFS) FsyncDir(_ uint64, fh uint64, _ uint32) int32 {
-	p.mu.Lock()
+	p.mu.RLock()
 	_, ok := p.dirHandles[fh]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if !ok {
 		return -linuxEBADF
 	}
@@ -1508,9 +1640,9 @@ func (p *passthroughFS) FsyncDir(_ uint64, fh uint64, _ uint32) int32 {
 
 func (p *passthroughFS) Read(nodeID uint64, fh uint64, off uint64, size uint32) ([]byte, int32) {
 	p.logf("read node=%d path=%q fh=%d off=%d size=%d", nodeID, p.DebugPath(nodeID), fh, off, size)
-	p.mu.Lock()
+	p.mu.RLock()
 	handle, ok := p.handles[fh]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if !ok || handle == nil || handle.nodeID != nodeID || handle.file == nil {
 		return nil, -linuxEBADF
 	}
@@ -1523,9 +1655,9 @@ func (p *passthroughFS) Read(nodeID uint64, fh uint64, off uint64, size uint32) 
 }
 
 func (p *passthroughFS) Lseek(nodeID uint64, fh uint64, offset uint64, whence uint32) (uint64, int32) {
-	p.mu.Lock()
+	p.mu.RLock()
 	handle, ok := p.handles[fh]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if !ok || handle == nil || handle.nodeID != nodeID {
 		return 0, -linuxEBADF
 	}
@@ -1589,9 +1721,9 @@ func (p *passthroughFS) OpenDir(nodeID uint64, _ uint32) (uint64, int32) {
 }
 
 func (p *passthroughFS) Write(nodeID uint64, fh uint64, off uint64, data []byte, _ uint32) (uint32, int32) {
-	p.mu.Lock()
+	p.mu.RLock()
 	handle := p.handles[fh]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if handle == nil || handle.nodeID != nodeID || handle.file == nil {
 		return 0, -linuxEBADF
 	}

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"j5.nz/cc/internal/fdt"
@@ -222,7 +223,6 @@ type FS struct {
 
 	mu               sync.Mutex
 	workerOnce       sync.Once
-	statsMu          sync.Mutex
 	mem              GuestMemory
 	irq              IRQController
 	backend          FSBackend
@@ -239,7 +239,7 @@ type FS struct {
 	mmioReads        uint64
 	mmioWrites       uint64
 	queueNotifies    []uint64
-	fuseRequests     uint64
+	fuseRequests     atomic.Uint64
 	interruptRaises  uint64
 	irqTransitions   uint64
 	workCh           chan fsWork
@@ -310,9 +310,9 @@ type FUSEOpStats struct {
 }
 
 type fuseOpStat struct {
-	count      uint64
-	totalNanos int64
-	maxNanos   int64
+	count      atomic.Uint64
+	totalNanos atomic.Int64
+	maxNanos   atomic.Int64
 }
 
 type fsDesc struct {
@@ -1339,15 +1339,17 @@ func fuseOpcodeMetricName(opcode uint32) string {
 
 func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
 	duration := time.Since(start)
-	f.statsMu.Lock()
-	defer f.statsMu.Unlock()
-	f.fuseRequests++
+	f.fuseRequests.Add(1)
 	if opcode < uint32(len(f.fuseOpStats)) {
 		opStats := &f.fuseOpStats[opcode]
-		opStats.count++
-		opStats.totalNanos += duration.Nanoseconds()
-		if duration.Nanoseconds() > opStats.maxNanos {
-			opStats.maxNanos = duration.Nanoseconds()
+		nanos := duration.Nanoseconds()
+		opStats.count.Add(1)
+		opStats.totalNanos.Add(nanos)
+		for {
+			oldMax := opStats.maxNanos.Load()
+			if nanos <= oldMax || opStats.maxNanos.CompareAndSwap(oldMax, nanos) {
+				break
+			}
 		}
 	}
 	if f.RecordTiming == nil {
@@ -1504,8 +1506,6 @@ func (f *FS) Summary() string {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.statsMu.Lock()
-	defer f.statsMu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	queueNotifies := append([]uint64(nil), f.queueNotifies...)
 	queueReady := f.queueReadySnapshotLocked()
@@ -1517,7 +1517,7 @@ func (f *FS) Summary() string {
 		f.mmioWrites,
 		f.status,
 		queueNotifies,
-		f.fuseRequests,
+		f.fuseRequests.Load(),
 		f.interruptRaises,
 		f.irqTransitions,
 		f.irqHigh,
@@ -1533,25 +1533,25 @@ func (f *FS) Stats() FSStats {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.statsMu.Lock()
-	defer f.statsMu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	ops := make([]FUSEOpStats, 0, len(f.fuseOpStats))
 	for opcode, stat := range f.fuseOpStats {
-		if stat.count == 0 {
+		count := stat.count.Load()
+		if count == 0 {
 			continue
 		}
+		totalNanos := stat.totalNanos.Load()
 		avg := int64(0)
-		if stat.count != 0 {
-			avg = stat.totalNanos / int64(stat.count)
+		if count != 0 {
+			avg = totalNanos / int64(count)
 		}
 		opcodeValue := uint32(opcode)
 		ops = append(ops, FUSEOpStats{
 			Opcode:       opcodeValue,
 			Name:         fuseOpcodeName(opcodeValue),
-			Count:        stat.count,
-			TotalNanos:   stat.totalNanos,
-			MaxNanos:     stat.maxNanos,
+			Count:        count,
+			TotalNanos:   totalNanos,
+			MaxNanos:     stat.maxNanos.Load(),
 			AverageNanos: avg,
 		})
 	}
@@ -1566,7 +1566,7 @@ func (f *FS) Stats() FSStats {
 		MMIOReads:       f.mmioReads,
 		MMIOWrites:      f.mmioWrites,
 		QueueNotifies:   append([]uint64(nil), f.queueNotifies...),
-		FUSERequests:    f.fuseRequests,
+		FUSERequests:    f.fuseRequests.Load(),
 		InterruptRaises: f.interruptRaises,
 		IRQTransitions:  f.irqTransitions,
 		IRQHigh:         f.irqHigh,

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -2089,7 +2089,7 @@ func (p *passthroughFS) GetAttr(nodeID uint64) (FuseAttr, int32) {
 
 func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, int32) {
 	p.logNode("lookup-parent", parent)
-	hostParent, errno := p.hostPath(parent)
+	hostParent, guestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
@@ -2103,7 +2103,7 @@ func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, in
 	if err != nil {
 		return 0, FuseAttr{}, errnoFromError(err)
 	}
-	guestPath := p.guestPathForHost(host)
+	guestPath := joinGuestChild(guestParent, rel)
 	if p.root != "" {
 		p.logf("lookup name=%q guest=%q host=%q", name, guestPath, host)
 	}
@@ -2113,7 +2113,7 @@ func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, in
 
 func (p *passthroughFS) Mkdir(parent uint64, name string, mode uint32) (uint64, FuseAttr, int32) {
 	p.logNode("mkdir-parent", parent)
-	hostParent, errno := p.hostPath(parent)
+	hostParent, guestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
@@ -2129,7 +2129,7 @@ func (p *passthroughFS) Mkdir(parent uint64, name string, mode uint32) (uint64, 
 	if err != nil {
 		return 0, FuseAttr{}, errnoFromError(err)
 	}
-	guestPath := p.guestPathForHost(host)
+	guestPath := joinGuestChild(guestParent, rel)
 	if p.meta != nil {
 		p.mu.Lock()
 		if _, ok := p.meta[guestPath]; !ok {
@@ -2147,7 +2147,7 @@ func (p *passthroughFS) Mkdir(parent uint64, name string, mode uint32) (uint64, 
 
 func (p *passthroughFS) Create(parent uint64, name string, flags uint32, mode uint32) (uint64, uint64, FuseAttr, int32) {
 	p.logNode("create-parent", parent)
-	hostParent, errno := p.hostPath(parent)
+	hostParent, guestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return 0, 0, FuseAttr{}, errno
 	}
@@ -2165,7 +2165,7 @@ func (p *passthroughFS) Create(parent uint64, name string, flags uint32, mode ui
 		_ = file.Close()
 		return 0, 0, FuseAttr{}, errnoFromError(err)
 	}
-	guestPath := p.guestPathForHost(host)
+	guestPath := joinGuestChild(guestParent, rel)
 	nodeID := p.ensureNode(guestPath)
 	p.mu.Lock()
 	handle := p.nextHandle
@@ -2244,7 +2244,7 @@ func (p *passthroughFS) FsyncDir(_ uint64, fh uint64, _ uint32) int32 {
 }
 
 func (p *passthroughFS) Read(nodeID uint64, fh uint64, off uint64, size uint32) ([]byte, int32) {
-	p.logf("read node=%d path=%q fh=%d off=%d size=%d", nodeID, p.DebugPath(nodeID), fh, off, size)
+	p.logf("read node=%d fh=%d off=%d size=%d", nodeID, fh, off, size)
 	p.mu.RLock()
 	handle, ok := p.handles[fh]
 	p.mu.RUnlock()
@@ -2296,7 +2296,7 @@ func (p *passthroughFS) Lseek(nodeID uint64, fh uint64, offset uint64, whence ui
 
 func (p *passthroughFS) OpenDir(nodeID uint64, _ uint32) (uint64, int32) {
 	p.logNode("opendir", nodeID)
-	host, errno := p.hostPath(nodeID)
+	host, guest, errno := p.hostAndGuestPath(nodeID)
 	if errno != 0 {
 		return 0, errno
 	}
@@ -2309,7 +2309,7 @@ func (p *passthroughFS) OpenDir(nodeID uint64, _ uint32) (uint64, int32) {
 		{name: "..", typ: dirTypeDir, ino: nodeID},
 	}
 	for _, entry := range entries {
-		childPath := p.guestPathForHost(filepath.Join(host, entry.Name()))
+		childPath := joinGuestChild(guest, entry.Name())
 		childID := p.ensureNode(childPath)
 		dirEntries = append(dirEntries, dirEntry{
 			name: entry.Name(),
@@ -2386,7 +2386,7 @@ func (p *passthroughFS) Readlink(nodeID uint64) (string, int32) {
 
 func (p *passthroughFS) RmDir(parent uint64, name string) int32 {
 	p.logNode("rmdir-parent", parent)
-	hostParent, errno := p.hostPath(parent)
+	hostParent, guestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return errno
 	}
@@ -2399,7 +2399,7 @@ func (p *passthroughFS) RmDir(parent uint64, name string) int32 {
 	if err := os.Remove(host); err != nil {
 		return errnoFromError(err)
 	}
-	guestPath := p.guestPathForHost(host)
+	guestPath := joinGuestChild(guestParent, rel)
 	p.mu.Lock()
 	delete(p.meta, guestPath)
 	delete(p.pathToNode, guestPath)
@@ -2414,7 +2414,7 @@ func (p *passthroughFS) RmDir(parent uint64, name string) int32 {
 }
 
 func (p *passthroughFS) Unlink(parent uint64, name string) int32 {
-	hostParent, errno := p.hostPath(parent)
+	hostParent, guestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return errno
 	}
@@ -2426,25 +2426,27 @@ func (p *passthroughFS) Unlink(parent uint64, name string) int32 {
 	if err := os.Remove(host); err != nil {
 		return errnoFromError(err)
 	}
-	p.removeNodeForGuestPath(p.guestPathForHost(host))
+	p.removeNodeForGuestPath(joinGuestChild(guestParent, strings.TrimPrefix(clean, "/")))
 	return 0
 }
 
 func (p *passthroughFS) Rename(parent uint64, name string, newParent uint64, newName string, _ uint32) int32 {
-	oldParent, errno := p.hostPath(parent)
+	oldParent, oldGuestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return errno
 	}
-	newParentPath, errno := p.hostPath(newParent)
+	newParentPath, newGuestParent, errno := p.hostAndGuestPath(newParent)
 	if errno != 0 {
 		return errno
 	}
-	oldHost := filepath.Join(oldParent, filepath.FromSlash(strings.TrimPrefix(path.Clean("/"+name), "/")))
-	newHost := filepath.Join(newParentPath, filepath.FromSlash(strings.TrimPrefix(path.Clean("/"+newName), "/")))
+	oldRel := strings.TrimPrefix(path.Clean("/"+name), "/")
+	newRel := strings.TrimPrefix(path.Clean("/"+newName), "/")
+	oldHost := filepath.Join(oldParent, filepath.FromSlash(oldRel))
+	newHost := filepath.Join(newParentPath, filepath.FromSlash(newRel))
 	if err := os.Rename(oldHost, newHost); err != nil {
 		return errnoFromError(err)
 	}
-	p.renameNodeGuestPath(p.guestPathForHost(oldHost), p.guestPathForHost(newHost))
+	p.renameNodeGuestPath(joinGuestChild(oldGuestParent, oldRel), joinGuestChild(newGuestParent, newRel))
 	return 0
 }
 
@@ -2509,19 +2511,24 @@ func (p *passthroughFS) StatFS(_ uint64) (uint64, uint64, uint64, uint64, uint64
 }
 
 func (p *passthroughFS) hostPath(nodeID uint64) (string, int32) {
+	host, _, errno := p.hostAndGuestPath(nodeID)
+	return host, errno
+}
+
+func (p *passthroughFS) hostAndGuestPath(nodeID uint64) (string, string, int32) {
 	p.mu.Lock()
 	guest, ok := p.nodes[nodeID]
 	p.mu.Unlock()
 	if !ok {
-		return "", -linuxENOENT
+		return "", "", -linuxENOENT
 	}
 	if p.root == "" {
-		return "", -linuxENOENT
+		return "", "", -linuxENOENT
 	}
 	if guest == "/" {
-		return p.root, 0
+		return p.root, guest, 0
 	}
-	return filepath.Join(p.root, filepath.FromSlash(strings.TrimPrefix(guest, "/"))), 0
+	return filepath.Join(p.root, filepath.FromSlash(strings.TrimPrefix(guest, "/"))), guest, 0
 }
 
 func (p *passthroughFS) guestPathForHost(host string) string {
@@ -2535,6 +2542,13 @@ func (p *passthroughFS) guestPathForHost(host string) string {
 	return "/" + filepath.ToSlash(rel)
 }
 
+func joinGuestChild(parentGuest, rel string) string {
+	if rel == "" {
+		return path.Clean(parentGuest)
+	}
+	return path.Join(parentGuest, filepath.ToSlash(rel))
+}
+
 func (p *passthroughFS) DebugPath(nodeID uint64) string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -2542,7 +2556,7 @@ func (p *passthroughFS) DebugPath(nodeID uint64) string {
 }
 
 func (p *passthroughFS) GetXattr(nodeID uint64, name string) ([]byte, int32) {
-	p.logf("getxattr-backend node=%d path=%q name=%q", nodeID, p.DebugPath(nodeID), name)
+	p.logf("getxattr-backend node=%d name=%q", nodeID, name)
 	return nil, -linuxENODATA
 }
 
@@ -2552,7 +2566,7 @@ func (p *passthroughFS) ListXattr(nodeID uint64) ([]byte, int32) {
 }
 
 func (p *passthroughFS) logNode(op string, nodeID uint64) {
-	p.logf("%s node=%d path=%q", op, nodeID, p.DebugPath(nodeID))
+	p.logf("%s node=%d", op, nodeID)
 }
 
 func (p *passthroughFS) logf(format string, args ...any) {
@@ -2625,14 +2639,20 @@ func (p *passthroughFS) fileAttr(nodeID uint64, info os.FileInfo) FuseAttr {
 	if attr.BlkSize == 0 {
 		attr.BlkSize = 4096
 	}
-	if meta, ok := p.meta[p.DebugPath(nodeID)]; ok {
-		attr.UID = meta.UID
-		attr.GID = meta.GID
-		if meta.RDev != 0 {
-			attr.RDev = meta.RDev
-		}
-		if meta.Mode != 0 {
-			attr.Mode = fsmeta.NormalizeLinuxMode(meta.Mode, info.Mode())
+	if p.meta != nil {
+		p.mu.RLock()
+		guestPath := p.nodes[nodeID]
+		meta, ok := p.meta[guestPath]
+		p.mu.RUnlock()
+		if ok {
+			attr.UID = meta.UID
+			attr.GID = meta.GID
+			if meta.RDev != 0 {
+				attr.RDev = meta.RDev
+			}
+			if meta.Mode != 0 {
+				attr.Mode = fsmeta.NormalizeLinuxMode(meta.Mode, info.Mode())
+			}
 		}
 	}
 	if info.IsDir() {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -105,6 +105,8 @@ const (
 
 const (
 	fuseCapPosixLocks = 1 << 1
+	fuseCapBigWrites  = 1 << 5
+	fuseCapMaxPages   = 1 << 22
 )
 
 const (
@@ -1000,6 +1002,16 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		if maxWrite == 0 {
 			maxWrite = 128 << 10
 		}
+		if maxWrite > 4096 {
+			flags |= fuseCapBigWrites | fuseCapMaxPages
+		}
+		maxPages := (maxWrite + 4095) / 4096
+		if maxPages == 0 {
+			maxPages = 1
+		}
+		if maxPages > 0xffff {
+			maxPages = 0xffff
+		}
 		extra := make([]byte, fuseInitOutSize)
 		replyMajor := uint32(7)
 		replyMinor := uint32(31)
@@ -1017,6 +1029,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		binary.LittleEndian.PutUint16(extra[18:20], 32)
 		binary.LittleEndian.PutUint32(extra[20:24], maxWrite)
 		binary.LittleEndian.PutUint32(extra[24:28], 1)
+		binary.LittleEndian.PutUint16(extra[28:30], uint16(maxPages))
 		f.logf("init-reply major=%d minor=%d max_write=%d", replyMajor, replyMinor, maxWrite)
 		return reply(0, extra), nil
 	case fuseGetAttr:

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -95,13 +95,14 @@ const (
 )
 
 const (
-	linuxORDONLY = 0
-	linuxOWRONLY = 1
-	linuxORDWR   = 2
-	linuxOCREAT  = 0x40
-	linuxOEXCL   = 0x80
-	linuxOTRUNC  = 0x200
-	linuxOAPPEND = 0x400
+	linuxOACCMODE = 3
+	linuxORDONLY  = 0
+	linuxOWRONLY  = 1
+	linuxORDWR    = 2
+	linuxOCREAT   = 0x40
+	linuxOEXCL    = 0x80
+	linuxOTRUNC   = 0x200
+	linuxOAPPEND  = 0x400
 )
 
 const (
@@ -113,6 +114,12 @@ const (
 	fuseOpenKeepCache = 1 << 1
 	fuseOpenCacheDir  = 1 << 3
 	fuseOpenNoFlush   = 1 << 5
+)
+
+const (
+	fsCacheStrict     = "strict"
+	fsCacheNormal     = "normal"
+	fsCacheAggressive = "aggressive"
 )
 
 const (
@@ -220,6 +227,9 @@ type FS struct {
 	Strict       bool
 	Async        bool
 	RecordTiming func(name string, duration time.Duration)
+	cacheMode    string
+	entryTTL     time.Duration
+	attrTTL      time.Duration
 
 	mu               sync.Mutex
 	workerOnce       sync.Once
@@ -330,12 +340,16 @@ type fsDesc struct {
 }
 
 func NewFS(base, size uint64, irq uint32, tag string, backend FSBackend) *FS {
+	cacheMode, entryTTL, attrTTL := resolveFSCachePolicy()
 	fs := &FS{
 		Base:        base,
 		Size:        size,
 		IRQ:         irq,
 		backend:     backend,
 		Async:       strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_ASYNC")) != "",
+		cacheMode:   cacheMode,
+		entryTTL:    entryTTL,
+		attrTTL:     attrTTL,
 		workCh:      make(chan fsWork, 1024),
 		completions: make(map[fsCompletionKey]fsCompletion),
 	}
@@ -346,6 +360,17 @@ func NewFS(base, size uint64, irq uint32, tag string, backend FSBackend) *FS {
 	copy(fs.tag[:], []byte(tag))
 	fs.resetLocked()
 	return fs
+}
+
+func resolveFSCachePolicy() (string, time.Duration, time.Duration) {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_CACHE"))) {
+	case fsCacheStrict:
+		return fsCacheStrict, 0, 0
+	case fsCacheAggressive:
+		return fsCacheAggressive, 60 * time.Second, 60 * time.Second
+	default:
+		return fsCacheNormal, time.Second, time.Second
+	}
 }
 
 func (f *FS) Attach(mem GuestMemory, irq IRQController) {
@@ -976,7 +1001,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 			return reply(errno, nil), nil
 		}
 		extra := make([]byte, fuseAttrOutSize)
-		binary.LittleEndian.PutUint64(extra[0:8], 1)
+		encodeFuseAttrTTL(extra[0:16], f.attrTTL)
 		encodeFuseAttr(extra[16:], attr)
 		return reply(0, extra), nil
 	case fuseSetAttr:
@@ -997,7 +1022,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 				return reply(errno, nil), nil
 			}
 			extra := make([]byte, fuseAttrOutSize)
-			binary.LittleEndian.PutUint64(extra[0:8], 1)
+			encodeFuseAttrTTL(extra[0:16], f.attrTTL)
 			encodeFuseAttr(extra[16:], attr)
 			return reply(0, extra), nil
 		}
@@ -1011,9 +1036,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		}
 		f.logPathf("lookup-child", childID, "")
 		extra := make([]byte, fuseEntryOutSize)
-		binary.LittleEndian.PutUint64(extra[0:8], childID)
-		binary.LittleEndian.PutUint64(extra[16:24], 1)
-		binary.LittleEndian.PutUint64(extra[24:32], 1)
+		f.encodeFuseEntryOut(extra, childID)
 		encodeFuseAttr(extra[40:], attr)
 		return reply(0, extra), nil
 	case fuseMkdir:
@@ -1029,9 +1052,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 				return reply(errno, nil), nil
 			}
 			extra := make([]byte, fuseEntryOutSize)
-			binary.LittleEndian.PutUint64(extra[0:8], childID)
-			binary.LittleEndian.PutUint64(extra[16:24], 1)
-			binary.LittleEndian.PutUint64(extra[24:32], 1)
+			f.encodeFuseEntryOut(extra, childID)
 			encodeFuseAttr(extra[40:], attr)
 			return reply(0, extra), nil
 		}
@@ -1054,7 +1075,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		}
 		extra := make([]byte, fuseOpenOutSize)
 		binary.LittleEndian.PutUint64(extra[0:8], fh)
-		binary.LittleEndian.PutUint32(extra[8:12], fuseOpenNoFlush)
+		binary.LittleEndian.PutUint32(extra[8:12], f.openResponseFlags(flags, false))
 		return reply(0, extra), nil
 	case fuseRead:
 		if len(req) < fuseInHeaderSize+24 {
@@ -1124,6 +1145,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		}
 		extra := make([]byte, fuseOpenOutSize)
 		binary.LittleEndian.PutUint64(extra[0:8], fh)
+		binary.LittleEndian.PutUint32(extra[8:12], f.openResponseFlags(flags, true))
 		return reply(0, extra), nil
 	case fuseReadDir:
 		if len(req) < fuseInHeaderSize+24 {
@@ -1308,7 +1330,7 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 			return reply(errno, nil), nil
 		}
 		extra := make([]byte, fuseStatxOutSize)
-		binary.LittleEndian.PutUint64(extra[0:8], 1)
+		encodeFuseAttrTTL(extra[0:16], f.attrTTL)
 		encodeFuseStatx(extra[32:], attr)
 		return reply(0, extra), nil
 	case fuseSyncFS:
@@ -1331,12 +1353,10 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 				return reply(errno, nil), nil
 			}
 			extra := make([]byte, fuseEntryOutSize+fuseOpenOutSize)
-			binary.LittleEndian.PutUint64(extra[0:8], childID)
-			binary.LittleEndian.PutUint64(extra[16:24], 1)
-			binary.LittleEndian.PutUint64(extra[24:32], 1)
+			f.encodeFuseEntryOut(extra[:fuseEntryOutSize], childID)
 			encodeFuseAttr(extra[40:], attr)
 			binary.LittleEndian.PutUint64(extra[fuseEntryOutSize:fuseEntryOutSize+8], fh)
-			binary.LittleEndian.PutUint32(extra[fuseEntryOutSize+8:fuseEntryOutSize+12], fuseOpenNoFlush)
+			binary.LittleEndian.PutUint32(extra[fuseEntryOutSize+8:fuseEntryOutSize+12], f.openResponseFlags(flags, false))
 			return reply(0, extra), nil
 		}
 		return reply(-linuxENOSYS, nil), nil
@@ -1455,6 +1475,41 @@ func fuseReply(unique uint64, errno int32, extra []byte) []byte {
 	binary.LittleEndian.PutUint64(out[8:16], unique)
 	copy(out[16:], extra)
 	return out
+}
+
+func (f *FS) encodeFuseEntryOut(dst []byte, nodeID uint64) {
+	binary.LittleEndian.PutUint64(dst[0:8], nodeID)
+	binary.LittleEndian.PutUint64(dst[8:16], 1)
+	encodeFuseTTL(dst[16:24], dst[32:36], f.entryTTL)
+	encodeFuseTTL(dst[24:32], dst[36:40], f.attrTTL)
+}
+
+func encodeFuseAttrTTL(dst []byte, ttl time.Duration) {
+	encodeFuseTTL(dst[0:8], dst[8:12], ttl)
+}
+
+func encodeFuseTTL(secDst []byte, nsecDst []byte, ttl time.Duration) {
+	if ttl < 0 {
+		ttl = 0
+	}
+	sec := ttl / time.Second
+	nsec := ttl % time.Second
+	binary.LittleEndian.PutUint64(secDst, uint64(sec))
+	binary.LittleEndian.PutUint32(nsecDst, uint32(nsec))
+}
+
+func (f *FS) openResponseFlags(openFlags uint32, dir bool) uint32 {
+	flags := uint32(fuseOpenNoFlush)
+	if f.cacheMode == fsCacheStrict {
+		return flags
+	}
+	if dir {
+		return flags | fuseOpenCacheDir
+	}
+	if openFlags&linuxOACCMODE == linuxORDONLY {
+		flags |= fuseOpenKeepCache
+	}
+	return flags
 }
 
 func takeFSReqBuffer(size int) ([]byte, bool) {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -279,6 +279,12 @@ type fsCompletion struct {
 	err   error
 }
 
+type fsInlineCompletion struct {
+	work  fsWork
+	reply []byte
+	err   error
+}
+
 var fsReqPool = sync.Pool{
 	New: func() any {
 		return make([]byte, fsPooledReqSize)
@@ -730,6 +736,10 @@ func (f *FS) enqueueWorks(works []fsWork) {
 }
 
 func (f *FS) processWorksInline(works []fsWork) error {
+	if len(works) == 0 {
+		return nil
+	}
+	completions := make([]fsInlineCompletion, 0, len(works))
 	for _, work := range works {
 		reply, err := f.dispatchFUSE(work.req)
 		putFSReqBuffer(work.req, work.pooledReq)
@@ -738,11 +748,9 @@ func (f *FS) processWorksInline(works []fsWork) error {
 		if err != nil {
 			return err
 		}
-		if err := f.completeWork(work, reply, nil); err != nil {
-			return err
-		}
+		completions = append(completions, fsInlineCompletion{work: work, reply: reply})
 	}
-	return nil
+	return f.completeWorksInline(completions)
 }
 
 func (f *FS) startWorkers() {
@@ -781,6 +789,63 @@ func (f *FS) completeWork(work fsWork, reply []byte, workErr error) error {
 	return f.drainCompletionsLocked(work.qidx)
 }
 
+func (f *FS) completeWorksInline(completions []fsInlineCompletion) error {
+	if len(completions) == 0 {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for index := 0; index < len(completions); {
+		qidx := completions[index].work.qidx
+		if qidx < 0 || qidx >= len(f.queues) {
+			index++
+			continue
+		}
+		q := &f.queues[qidx]
+		oldUsedIdx := q.usedIdx
+		wroteCompletion := false
+		interruptSuppressed := true
+		for index < len(completions) && completions[index].work.qidx == qidx {
+			completion := completions[index]
+			index++
+			if completion.work.generation != f.configGeneration {
+				continue
+			}
+			if completion.err != nil {
+				return completion.err
+			}
+			if completion.reply == nil {
+				continue
+			}
+			if err := f.writeCompletionUsedLocked(q, completion.work, completion.reply); err != nil {
+				return err
+			}
+			wroteCompletion = true
+			if !completion.work.suppressInterrupt {
+				interruptSuppressed = false
+			}
+		}
+		if !wroteCompletion || !f.isCompletingQueue(qidx) {
+			continue
+		}
+		shouldInterrupt := false
+		if f.driverFeatures&featureRingEventIdx != 0 {
+			shouldInterrupt = f.shouldInterruptLocked(q, oldUsedIdx, q.usedIdx, 0)
+		} else {
+			shouldInterrupt = !interruptSuppressed
+		}
+		if shouldInterrupt {
+			f.interruptStatus |= fsInterruptVring
+			f.interruptRaises++
+			f.logf("interrupt-raise status=%#x", f.interruptStatus)
+			if err := f.updateIRQLocked(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (f *FS) drainCompletionsLocked(qidx int) error {
 	q := &f.queues[qidx]
 	for {
@@ -805,6 +870,22 @@ func (f *FS) drainCompletionsLocked(qidx int) error {
 }
 
 func (f *FS) writeCompletionLocked(q *queue, work fsWork, reply []byte) error {
+	if err := f.writeCompletionUsedLocked(q, work, reply); err != nil {
+		return err
+	}
+	if (f.driverFeatures&featureRingEventIdx != 0 || !work.suppressInterrupt) && f.isCompletingQueue(work.qidx) {
+		if f.driverFeatures&featureRingEventIdx != 0 && !f.shouldInterruptLocked(q, q.usedIdx-1, q.usedIdx, 0) {
+			return nil
+		}
+		f.interruptStatus |= fsInterruptVring
+		f.interruptRaises++
+		f.logf("interrupt-raise status=%#x", f.interruptStatus)
+		return f.updateIRQLocked()
+	}
+	return nil
+}
+
+func (f *FS) writeCompletionUsedLocked(q *queue, work fsWork, reply []byte) error {
 	offset := 0
 	for i := 0; i < work.respCount; i++ {
 		d := work.responseDesc(i)
@@ -827,15 +908,6 @@ func (f *FS) writeCompletionLocked(q *queue, work fsWork, reply []byte) error {
 		return err
 	}
 	f.logf("used-ring q=%d head=%d len=%d", work.qidx, work.head, len(reply))
-	if (f.driverFeatures&featureRingEventIdx != 0 || !work.suppressInterrupt) && f.isCompletingQueue(work.qidx) {
-		if f.driverFeatures&featureRingEventIdx != 0 && !f.shouldInterruptLocked(q, q.usedIdx-1, q.usedIdx, 0) {
-			return nil
-		}
-		f.interruptStatus |= fsInterruptVring
-		f.interruptRaises++
-		f.logf("interrupt-raise status=%#x", f.interruptStatus)
-		return f.updateIRQLocked()
-	}
 	return nil
 }
 

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -211,9 +211,12 @@ type FS struct {
 	IRQ          uint32
 	Log          io.Writer
 	Strict       bool
+	Async        bool
 	RecordTiming func(name string, duration time.Duration)
 
 	mu               sync.Mutex
+	workerOnce       sync.Once
+	statsMu          sync.Mutex
 	mem              GuestMemory
 	irq              IRQController
 	backend          FSBackend
@@ -233,10 +236,48 @@ type FS struct {
 	fuseRequests     uint64
 	interruptRaises  uint64
 	irqTransitions   uint64
+	workCh           chan fsWork
+	nextWorkSeq      [2]uint64
+	nextCompleteSeq  [2]uint64
+	completions      map[fsCompletionKey]fsCompletion
 	fuseOpStats      [fuseStatsSlots]fuseOpStat
 }
 
 const fuseStatsSlots = 64
+const fsWorkerCount = 1
+const fsInlineRespDescs = 32
+const fsPooledReqSize = 4096
+
+type fsWork struct {
+	qidx              int
+	head              uint16
+	seq               uint64
+	generation        uint32
+	unique            uint64
+	req               []byte
+	pooledReq         bool
+	suppressInterrupt bool
+	respCount         int
+	respDescs         [fsInlineRespDescs]fsDesc
+	respExtra         []fsDesc
+}
+
+type fsCompletionKey struct {
+	qidx int
+	seq  uint64
+}
+
+type fsCompletion struct {
+	work  fsWork
+	reply []byte
+	err   error
+}
+
+var fsReqPool = sync.Pool{
+	New: func() any {
+		return make([]byte, fsPooledReqSize)
+	},
+}
 
 type FSStats struct {
 	Tag             string        `json:"tag"`
@@ -278,10 +319,13 @@ type fsDesc struct {
 
 func NewFS(base, size uint64, irq uint32, tag string, backend FSBackend) *FS {
 	fs := &FS{
-		Base:    base,
-		Size:    size,
-		IRQ:     irq,
-		backend: backend,
+		Base:        base,
+		Size:        size,
+		IRQ:         irq,
+		backend:     backend,
+		Async:       strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_ASYNC")) != "",
+		workCh:      make(chan fsWork, 1024),
+		completions: make(map[fsCompletionKey]fsCompletion),
 	}
 	if fs.backend == nil {
 		fs.backend = NewPassthroughFS("", nil)
@@ -370,7 +414,6 @@ func (f *FS) Read(addr uint64, size int) (uint64, error) {
 
 func (f *FS) Write(addr uint64, size int, value uint64) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.mmioWrites++
 
 	offset := addr - f.Base
@@ -430,7 +473,9 @@ func (f *FS) Write(addr uint64, size int, value uint64) error {
 	case regInterruptAck:
 		f.logf("interrupt-ack value=%#x", value)
 		f.interruptStatus &^= uint32(value)
-		return f.updateIRQLocked()
+		err := f.updateIRQLocked()
+		f.mu.Unlock()
+		return err
 	case regStatus:
 		f.status = uint32(value)
 		if f.status == 0 {
@@ -439,11 +484,22 @@ func (f *FS) Write(addr uint64, size int, value uint64) error {
 	case regQueueNotify:
 		if int(value) < len(f.queues) {
 			f.queueNotifies[value]++
-			if err := f.processQueueLocked(int(value)); err != nil {
-				return err
+			if f.Async {
+				works, err := f.processQueueAsyncLocked(int(value))
+				if err != nil {
+					f.mu.Unlock()
+					return err
+				}
+				f.mu.Unlock()
+				f.enqueueWorks(works)
+				return nil
 			}
+			err := f.processQueueLocked(int(value))
+			f.mu.Unlock()
+			return err
 		}
 	}
+	f.mu.Unlock()
 	return nil
 }
 
@@ -488,6 +544,37 @@ func (f *FS) processQueueLocked(qidx int) error {
 		return f.updateIRQLocked()
 	}
 	return nil
+}
+
+func (f *FS) processQueueAsyncLocked(qidx int) ([]fsWork, error) {
+	q := &f.queues[qidx]
+	if !q.ready || q.size == 0 || f.mem == nil {
+		return nil, nil
+	}
+
+	var header [4]byte
+	if err := f.readIPAInto(q.availAddr, header[:]); err != nil {
+		return nil, err
+	}
+	suppressInterrupt := binary.LittleEndian.Uint16(header[0:2])&1 != 0
+	availIdx := binary.LittleEndian.Uint16(header[2:4])
+	var works []fsWork
+	for q.lastAvailIdx != availIdx {
+		slot := q.lastAvailIdx % q.size
+		var entry [2]byte
+		if err := f.readIPAInto(q.availAddr+4+uint64(slot)*2, entry[:]); err != nil {
+			return nil, err
+		}
+		head := binary.LittleEndian.Uint16(entry[:])
+		f.logf("queue-notify q=%d head=%d", qidx, head)
+		work, err := f.prepareRequestLocked(qidx, q, head, suppressInterrupt)
+		if err != nil {
+			return nil, err
+		}
+		works = append(works, work)
+		q.lastAvailIdx++
+	}
+	return works, nil
 }
 
 func (f *FS) handleRequestLocked(q *queue, head uint16) (uint32, bool, error) {
@@ -558,7 +645,172 @@ func (f *FS) handleRequestLocked(q *queue, head uint16) (uint32, bool, error) {
 	return uint32(len(reply)), true, nil
 }
 
+func (f *FS) prepareRequestLocked(qidx int, q *queue, head uint16, suppressInterrupt bool) (fsWork, error) {
+	seq := f.nextWorkSeq[qidx]
+	f.nextWorkSeq[qidx]++
+	work := fsWork{qidx: qidx, head: head, seq: seq, generation: f.configGeneration, suppressInterrupt: suppressInterrupt}
+	var descScratch [8]fsDesc
+	descs, err := f.readDescriptorChainLocked(q, head, descScratch[:0])
+	if err != nil {
+		return work, err
+	}
+	var reqScratch [4]fsDesc
+	var respScratch [4]fsDesc
+	reqDescs := reqScratch[:0]
+	respDescs := respScratch[:0]
+	for _, d := range descs {
+		if d.write {
+			respDescs = append(respDescs, d)
+			continue
+		}
+		if len(respDescs) != 0 {
+			return work, fmt.Errorf("virtio-fs descriptor order invalid")
+		}
+		reqDescs = append(reqDescs, d)
+	}
+	if len(reqDescs) == 0 {
+		return work, fmt.Errorf("virtio-fs missing request descriptors")
+	}
+	reqLen := 0
+	for _, d := range reqDescs {
+		reqLen += int(d.length)
+	}
+	req, pooledReq := takeFSReqBuffer(reqLen)
+	reqOff := 0
+	for _, d := range reqDescs {
+		if err := f.readIPAInto(d.addr, req[reqOff:reqOff+int(d.length)]); err != nil {
+			putFSReqBuffer(req, pooledReq)
+			return work, err
+		}
+		reqOff += int(d.length)
+	}
+	if len(req) >= 16 {
+		work.unique = binary.LittleEndian.Uint64(req[8:16])
+	}
+	work.req = req
+	work.pooledReq = pooledReq
+	work.respCount = len(respDescs)
+	if len(respDescs) <= len(work.respDescs) {
+		copy(work.respDescs[:], respDescs)
+	} else {
+		work.respExtra = append([]fsDesc(nil), respDescs...)
+	}
+	return work, nil
+}
+
+func (f *FS) enqueueWorks(works []fsWork) {
+	if len(works) == 0 {
+		return
+	}
+	f.workerOnce.Do(f.startWorkers)
+	for _, work := range works {
+		f.workCh <- work
+	}
+}
+
+func (f *FS) startWorkers() {
+	for i := 0; i < fsWorkerCount; i++ {
+		go f.runWorker()
+	}
+}
+
+func (f *FS) runWorker() {
+	for work := range f.workCh {
+		reply, err := f.dispatchFUSE(work.req)
+		putFSReqBuffer(work.req, work.pooledReq)
+		work.req = nil
+		work.pooledReq = false
+		if err != nil {
+			f.logf("async-fuse-error q=%d head=%d: %v", work.qidx, work.head, err)
+			reply = fuseReply(work.unique, -linuxEIO, nil)
+			err = nil
+		}
+		if err := f.completeWork(work, reply, err); err != nil {
+			f.logf("async-complete-error q=%d head=%d: %v", work.qidx, work.head, err)
+		}
+	}
+}
+
+func (f *FS) completeWork(work fsWork, reply []byte, workErr error) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if work.generation != f.configGeneration || work.qidx < 0 || work.qidx >= len(f.queues) {
+		return nil
+	}
+	if f.completions == nil {
+		f.completions = make(map[fsCompletionKey]fsCompletion)
+	}
+	f.completions[fsCompletionKey{qidx: work.qidx, seq: work.seq}] = fsCompletion{work: work, reply: reply, err: workErr}
+	return f.drainCompletionsLocked(work.qidx)
+}
+
+func (f *FS) drainCompletionsLocked(qidx int) error {
+	q := &f.queues[qidx]
+	for {
+		seq := f.nextCompleteSeq[qidx]
+		key := fsCompletionKey{qidx: qidx, seq: seq}
+		completion, ok := f.completions[key]
+		if !ok {
+			return nil
+		}
+		delete(f.completions, key)
+		f.nextCompleteSeq[qidx]++
+		if completion.err != nil {
+			return completion.err
+		}
+		if completion.reply == nil {
+			continue
+		}
+		if err := f.writeCompletionLocked(q, completion.work, completion.reply); err != nil {
+			return err
+		}
+	}
+}
+
+func (f *FS) writeCompletionLocked(q *queue, work fsWork, reply []byte) error {
+	offset := 0
+	for i := 0; i < work.respCount; i++ {
+		d := work.responseDesc(i)
+		if offset >= len(reply) {
+			break
+		}
+		chunk := len(reply) - offset
+		if chunk > int(d.length) {
+			chunk = int(d.length)
+		}
+		if err := f.mem.WriteIPA(d.addr, reply[offset:offset+chunk]); err != nil {
+			return err
+		}
+		offset += chunk
+	}
+	if offset < len(reply) {
+		return fmt.Errorf("virtio-fs response truncated: need %d have %d", len(reply), offset)
+	}
+	if err := f.writeUsedLocked(q, work.head, uint32(len(reply))); err != nil {
+		return err
+	}
+	f.logf("used-ring q=%d head=%d len=%d", work.qidx, work.head, len(reply))
+	if !work.suppressInterrupt && (work.qidx == fsQueueRequest || work.qidx == fsQueueHiprio) {
+		f.interruptStatus |= fsInterruptVring
+		f.interruptRaises++
+		f.logf("interrupt-raise status=%#x", f.interruptStatus)
+		return f.updateIRQLocked()
+	}
+	return nil
+}
+
+func (w *fsWork) responseDesc(index int) fsDesc {
+	if w.respExtra != nil {
+		return w.respExtra[index]
+	}
+	return w.respDescs[index]
+}
+
 func (f *FS) dispatchFUSELocked(req []byte) ([]byte, error) {
+	return f.dispatchFUSE(req)
+}
+
+func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 	if len(req) < fuseInHeaderSize {
 		return nil, fmt.Errorf("virtio-fs short request: %d", len(req))
 	}
@@ -567,16 +819,10 @@ func (f *FS) dispatchFUSELocked(req []byte) ([]byte, error) {
 	nodeID := binary.LittleEndian.Uint64(req[16:24])
 	opStart := time.Now()
 	defer f.recordFUSEDispatchTiming(opcode, opStart)
-	f.fuseRequests++
 	f.logf("opcode=%d unique=%d node=%d", opcode, unique, nodeID)
 
 	reply := func(errno int32, extra []byte) []byte {
-		out := make([]byte, fuseOutHeaderSize+len(extra))
-		binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
-		binary.LittleEndian.PutUint32(out[4:8], uint32(errno))
-		binary.LittleEndian.PutUint64(out[8:16], unique)
-		copy(out[16:], extra)
-		return out
+		return fuseReply(unique, errno, extra)
 	}
 
 	switch opcode {
@@ -1067,6 +1313,9 @@ func fuseOpcodeMetricName(opcode uint32) string {
 
 func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
 	duration := time.Since(start)
+	f.statsMu.Lock()
+	defer f.statsMu.Unlock()
+	f.fuseRequests++
 	if opcode < uint32(len(f.fuseOpStats)) {
 		opStats := &f.fuseOpStats[opcode]
 		opStats.count++
@@ -1083,6 +1332,31 @@ func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
 		tag = "unknown"
 	}
 	f.RecordTiming("virtio.fs."+tag+".fuse."+fuseOpcodeMetricName(opcode), duration)
+}
+
+func fuseReply(unique uint64, errno int32, extra []byte) []byte {
+	out := make([]byte, fuseOutHeaderSize+len(extra))
+	binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+	binary.LittleEndian.PutUint32(out[4:8], uint32(errno))
+	binary.LittleEndian.PutUint64(out[8:16], unique)
+	copy(out[16:], extra)
+	return out
+}
+
+func takeFSReqBuffer(size int) ([]byte, bool) {
+	if size > fsPooledReqSize {
+		return make([]byte, size), false
+	}
+	buf := fsReqPool.Get().([]byte)
+	return buf[:size], true
+}
+
+func putFSReqBuffer(buf []byte, pooled bool) {
+	if !pooled {
+		return
+	}
+	buf = buf[:fsPooledReqSize]
+	fsReqPool.Put(buf)
 }
 
 func (f *FS) logf(format string, args ...any) {
@@ -1175,6 +1449,8 @@ func (f *FS) Summary() string {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.statsMu.Lock()
+	defer f.statsMu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	return fmt.Sprintf(
 		"virtio-fs tag=%q mmio_reads=%d mmio_writes=%d status=%#x q0_notify=%d q1_notify=%d fuse_requests=%d interrupt_raises=%d irq_transitions=%d irq_high=%t interrupt_status=%#x q0_ready=%t q1_ready=%t q0_last=%d q1_last=%d",
@@ -1202,6 +1478,8 @@ func (f *FS) Stats() FSStats {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.statsMu.Lock()
+	defer f.statsMu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	ops := make([]FUSEOpStats, 0, len(f.fuseOpStats))
 	for opcode, stat := range f.fuseOpStats {
@@ -1275,6 +1553,9 @@ func (f *FS) resetLocked() {
 	f.irqHigh = false
 	f.configGeneration++
 	f.queues = [2]queue{}
+	f.nextWorkSeq = [2]uint64{}
+	f.nextCompleteSeq = [2]uint64{}
+	f.completions = make(map[fsCompletionKey]fsCompletion)
 }
 
 func (f *FS) configBytesLocked() []byte {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -104,9 +104,10 @@ const (
 )
 
 const (
-	fuseCapPosixLocks = 1 << 1
-	fuseCapBigWrites  = 1 << 5
-	fuseCapMaxPages   = 1 << 22
+	fuseCapPosixLocks     = 1 << 1
+	fuseCapBigWrites      = 1 << 5
+	fuseCapWritebackCache = 1 << 16
+	fuseCapMaxPages       = 1 << 22
 )
 
 const (
@@ -199,6 +200,10 @@ type fsRenameBackend interface {
 	Rename(parent uint64, name string, newParent uint64, newName string, flags uint32) int32
 }
 
+type fsWritebackCacheBackend interface {
+	SetWritebackCache(enabled bool)
+}
+
 type FuseAttr struct {
 	Ino       uint64
 	Size      uint64
@@ -219,16 +224,17 @@ type FuseAttr struct {
 }
 
 type FS struct {
-	Base         uint64
-	Size         uint64
-	IRQ          uint32
-	Log          io.Writer
-	Strict       bool
-	Async        bool
-	RecordTiming func(name string, duration time.Duration)
-	cacheMode    string
-	entryTTL     time.Duration
-	attrTTL      time.Duration
+	Base           uint64
+	Size           uint64
+	IRQ            uint32
+	Log            io.Writer
+	Strict         bool
+	Async          bool
+	RecordTiming   func(name string, duration time.Duration)
+	cacheMode      string
+	writebackCache bool
+	entryTTL       time.Duration
+	attrTTL        time.Duration
 
 	mu               sync.Mutex
 	workerOnce       sync.Once
@@ -363,20 +369,24 @@ type fsDesc struct {
 func NewFS(base, size uint64, irq uint32, tag string, backend FSBackend) *FS {
 	cacheMode, entryTTL, attrTTL := resolveFSCachePolicy()
 	fs := &FS{
-		Base:        base,
-		Size:        size,
-		IRQ:         irq,
-		backend:     backend,
-		Async:       strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_ASYNC")) != "",
-		cacheMode:   cacheMode,
-		entryTTL:    entryTTL,
-		attrTTL:     attrTTL,
-		workCh:      make(chan fsWork, 1024),
-		completions: make(map[fsCompletionKey]fsCompletion),
+		Base:           base,
+		Size:           size,
+		IRQ:            irq,
+		backend:        backend,
+		Async:          strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_ASYNC")) != "",
+		cacheMode:      cacheMode,
+		writebackCache: strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_WRITEBACK")) != "",
+		entryTTL:       entryTTL,
+		attrTTL:        attrTTL,
+		workCh:         make(chan fsWork, 1024),
+		completions:    make(map[fsCompletionKey]fsCompletion),
 	}
 	fs.resetQueueStateLocked()
 	if fs.backend == nil {
 		fs.backend = NewPassthroughFS("", nil)
+	}
+	if be, ok := fs.backend.(fsWritebackCacheBackend); ok {
+		be.SetWritebackCache(fs.writebackCache)
 	}
 	copy(fs.tag[:], []byte(tag))
 	fs.resetLocked()
@@ -1005,6 +1015,9 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		if maxWrite > 4096 {
 			flags |= fuseCapBigWrites | fuseCapMaxPages
 		}
+		if f.writebackCache {
+			flags |= fuseCapWritebackCache
+		}
 		maxPages := (maxWrite + 4095) / 4096
 		if maxPages == 0 {
 			maxPages = 1
@@ -1025,8 +1038,14 @@ func (f *FS) dispatchFUSE(req []byte) ([]byte, error) {
 		binary.LittleEndian.PutUint32(extra[4:8], replyMinor)
 		binary.LittleEndian.PutUint32(extra[8:12], 128<<10)
 		binary.LittleEndian.PutUint32(extra[12:16], flags)
-		binary.LittleEndian.PutUint16(extra[16:18], 16)
-		binary.LittleEndian.PutUint16(extra[18:20], 32)
+		maxBackground := uint16(16)
+		congestionThreshold := uint16(32)
+		if f.writebackCache {
+			maxBackground = 256
+			congestionThreshold = 192
+		}
+		binary.LittleEndian.PutUint16(extra[16:18], maxBackground)
+		binary.LittleEndian.PutUint16(extra[18:20], congestionThreshold)
 		binary.LittleEndian.PutUint32(extra[20:24], maxWrite)
 		binary.LittleEndian.PutUint32(extra[24:28], 1)
 		binary.LittleEndian.PutUint16(extra[28:30], uint16(maxPages))
@@ -1975,8 +1994,9 @@ func bytesIndexByte(buf []byte, want byte) int {
 }
 
 type passthroughFS struct {
-	root string
-	meta map[string]fsmeta.Entry
+	root           string
+	meta           map[string]fsmeta.Entry
+	writebackCache bool
 
 	mu         sync.RWMutex
 	nextNodeID uint64
@@ -2086,6 +2106,12 @@ func (p *passthroughFS) Init() (uint32, uint32) {
 	return 128 << 10, fuseCapPosixLocks
 }
 
+func (p *passthroughFS) SetWritebackCache(enabled bool) {
+	p.mu.Lock()
+	p.writebackCache = enabled
+	p.mu.Unlock()
+}
+
 func (p *passthroughFS) GetAttr(nodeID uint64) (FuseAttr, int32) {
 	p.logNode("getattr", nodeID)
 	host, errno := p.hostPath(nodeID)
@@ -2168,7 +2194,7 @@ func (p *passthroughFS) Create(parent uint64, name string, flags uint32, mode ui
 		return 0, 0, FuseAttr{}, -linuxEINVAL
 	}
 	host := filepath.Join(hostParent, filepath.FromSlash(rel))
-	file, err := os.OpenFile(host, translateLinuxOpenFlags(flags)|os.O_CREATE, fs.FileMode(mode&linuxPermMask))
+	file, err := os.OpenFile(host, p.translateOpenFlags(flags)|os.O_CREATE, fs.FileMode(mode&linuxPermMask))
 	if err != nil {
 		return 0, 0, FuseAttr{}, errnoFromError(err)
 	}
@@ -2200,7 +2226,7 @@ func (p *passthroughFS) Open(nodeID uint64, flags uint32) (uint64, int32) {
 	if info.IsDir() {
 		return 0, -linuxEISDIR
 	}
-	file, err := os.OpenFile(host, translateLinuxOpenFlags(flags), 0)
+	file, err := os.OpenFile(host, p.translateOpenFlags(flags), 0)
 	if err != nil {
 		return 0, errnoFromError(err)
 	}
@@ -2525,6 +2551,13 @@ func (p *passthroughFS) StatFS(_ uint64) (uint64, uint64, uint64, uint64, uint64
 func (p *passthroughFS) hostPath(nodeID uint64) (string, int32) {
 	host, _, errno := p.hostAndGuestPath(nodeID)
 	return host, errno
+}
+
+func (p *passthroughFS) translateOpenFlags(flags uint32) int {
+	p.mu.RLock()
+	writebackCache := p.writebackCache
+	p.mu.RUnlock()
+	return translateLinuxOpenFlags(flags, writebackCache)
 }
 
 func (p *passthroughFS) hostAndGuestPath(nodeID uint64) (string, string, int32) {
@@ -3285,11 +3318,15 @@ func errorAs(err error, target any) bool {
 	return false
 }
 
-func translateLinuxOpenFlags(flags uint32) int {
+func translateLinuxOpenFlags(flags uint32, writebackCache bool) int {
 	openFlags := 0
 	switch flags & 0x3 {
 	case linuxOWRONLY:
-		openFlags |= os.O_WRONLY
+		if writebackCache {
+			openFlags |= os.O_RDWR
+		} else {
+			openFlags |= os.O_WRONLY
+		}
 	case linuxORDWR:
 		openFlags |= os.O_RDWR
 	default:

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -22,25 +22,31 @@ import (
 const (
 	mmioDeviceIDFS = 26
 
-	fsQueueHiprio  = 0
-	fsQueueRequest = 1
+	fsQueueHiprio       = 0
+	fsQueueRequest      = 1
+	fsRequestQueueCount = 4
 
-	fsCfgTagSize       = 36
-	fsCfgNumQueueOff   = fsCfgTagSize
-	fsCfgTotalSize     = fsCfgTagSize + 4
-	fsInterruptVring   = 0x1
-	fuseInHeaderSize   = 40
-	fuseOutHeaderSize  = 16
-	fuseAttrSize       = 88
-	fuseEntryOutSize   = 40 + fuseAttrSize
-	fuseAttrOutSize    = 16 + fuseAttrSize
-	fuseOpenOutSize    = 16
-	fuseInitOutSize    = 40
-	fuseStatfsOutSize  = 80
-	fuseStatxOutSize   = 288
-	fuseDirentBaseSize = 24
-	fuseWriteOutSize   = 8
+	fsCfgTagSize        = 36
+	fsCfgNumQueueOff    = fsCfgTagSize
+	fsCfgTotalSize      = fsCfgTagSize + 4
+	fsInterruptVring    = 0x1
+	featureRingEventIdx = uint64(1) << 29
+	fuseInHeaderSize    = 40
+	fuseOutHeaderSize   = 16
+	fuseAttrSize        = 88
+	fuseEntryOutSize    = 40 + fuseAttrSize
+	fuseAttrOutSize     = 16 + fuseAttrSize
+	fuseOpenOutSize     = 16
+	fuseInitOutSize     = 40
+	fuseStatfsOutSize   = 80
+	fuseStatxOutSize    = 288
+	fuseDirentBaseSize  = 24
+	fuseWriteOutSize    = 8
 )
+
+func fsTotalQueueCount() int {
+	return fsQueueRequest + fsRequestQueueCount
+}
 
 const (
 	fuseLookup     = 1
@@ -229,16 +235,16 @@ type FS struct {
 	interruptStatus  uint32
 	irqHigh          bool
 	configGeneration uint32
-	queues           [2]queue
+	queues           []queue
 	mmioReads        uint64
 	mmioWrites       uint64
-	queueNotifies    [2]uint64
+	queueNotifies    []uint64
 	fuseRequests     uint64
 	interruptRaises  uint64
 	irqTransitions   uint64
 	workCh           chan fsWork
-	nextWorkSeq      [2]uint64
-	nextCompleteSeq  [2]uint64
+	nextWorkSeq      []uint64
+	nextCompleteSeq  []uint64
 	completions      map[fsCompletionKey]fsCompletion
 	fuseOpStats      [fuseStatsSlots]fuseOpStat
 }
@@ -283,14 +289,14 @@ type FSStats struct {
 	Tag             string        `json:"tag"`
 	MMIOReads       uint64        `json:"mmio_reads"`
 	MMIOWrites      uint64        `json:"mmio_writes"`
-	QueueNotifies   [2]uint64     `json:"queue_notifies"`
+	QueueNotifies   []uint64      `json:"queue_notifies"`
 	FUSERequests    uint64        `json:"fuse_requests"`
 	InterruptRaises uint64        `json:"interrupt_raises"`
 	IRQTransitions  uint64        `json:"irq_transitions"`
 	IRQHigh         bool          `json:"irq_high"`
 	InterruptStatus uint32        `json:"interrupt_status"`
-	QueueReady      [2]bool       `json:"queue_ready"`
-	QueueLastAvail  [2]uint16     `json:"queue_last_avail"`
+	QueueReady      []bool        `json:"queue_ready"`
+	QueueLastAvail  []uint16      `json:"queue_last_avail"`
 	FUSEOps         []FUSEOpStats `json:"fuse_ops"`
 }
 
@@ -327,6 +333,7 @@ func NewFS(base, size uint64, irq uint32, tag string, backend FSBackend) *FS {
 		workCh:      make(chan fsWork, 1024),
 		completions: make(map[fsCompletionKey]fsCompletion),
 	}
+	fs.resetQueueStateLocked()
 	if fs.backend == nil {
 		fs.backend = NewPassthroughFS("", nil)
 	}
@@ -375,7 +382,7 @@ func (f *FS) Read(addr uint64, size int) (uint64, error) {
 		return truncateValue(mmioVendorID, size), nil
 	case regDeviceFeatures:
 		if f.deviceFeatureSel == 0 {
-			return truncateValue(0, size), nil
+			return truncateValue(featureRingEventIdx, size), nil
 		}
 		if f.deviceFeatureSel == 1 {
 			return truncateValue(1, size), nil
@@ -444,6 +451,11 @@ func (f *FS) Write(addr uint64, size int, value uint64) error {
 			if value == 0 {
 				q.lastAvailIdx = 0
 				q.usedIdx = 0
+			} else if f.driverFeatures&featureRingEventIdx != 0 {
+				if err := f.writeAvailEventLocked(q); err != nil {
+					f.mu.Unlock()
+					return err
+				}
 			}
 		}
 	case regQueueDescLow:
@@ -483,7 +495,7 @@ func (f *FS) Write(addr uint64, size int, value uint64) error {
 		}
 	case regQueueNotify:
 		if int(value) < len(f.queues) {
-			f.queueNotifies[value]++
+			f.queueNotifies[int(value)]++
 			if f.Async {
 				works, err := f.processQueueAsyncLocked(int(value))
 				if err != nil {
@@ -515,6 +527,7 @@ func (f *FS) processQueueLocked(qidx int) error {
 	}
 	availFlags := binary.LittleEndian.Uint16(header[0:2])
 	availIdx := binary.LittleEndian.Uint16(header[2:4])
+	oldUsedIdx := q.usedIdx
 	interruptNeeded := false
 	for q.lastAvailIdx != availIdx {
 		slot := q.lastAvailIdx % q.size
@@ -537,7 +550,12 @@ func (f *FS) processQueueLocked(qidx int) error {
 		}
 		q.lastAvailIdx++
 	}
-	if interruptNeeded && (qidx == fsQueueRequest || qidx == fsQueueHiprio) && (availFlags&1) == 0 {
+	if f.driverFeatures&featureRingEventIdx != 0 {
+		if err := f.writeAvailEventLocked(q); err != nil {
+			return err
+		}
+	}
+	if interruptNeeded && f.isCompletingQueue(qidx) && f.shouldInterruptLocked(q, oldUsedIdx, q.usedIdx, availFlags) {
 		f.interruptStatus |= fsInterruptVring
 		f.interruptRaises++
 		f.logf("interrupt-raise status=%#x", f.interruptStatus)
@@ -573,6 +591,11 @@ func (f *FS) processQueueAsyncLocked(qidx int) ([]fsWork, error) {
 		}
 		works = append(works, work)
 		q.lastAvailIdx++
+	}
+	if f.driverFeatures&featureRingEventIdx != 0 {
+		if err := f.writeAvailEventLocked(q); err != nil {
+			return nil, err
+		}
 	}
 	return works, nil
 }
@@ -790,7 +813,10 @@ func (f *FS) writeCompletionLocked(q *queue, work fsWork, reply []byte) error {
 		return err
 	}
 	f.logf("used-ring q=%d head=%d len=%d", work.qidx, work.head, len(reply))
-	if !work.suppressInterrupt && (work.qidx == fsQueueRequest || work.qidx == fsQueueHiprio) {
+	if (f.driverFeatures&featureRingEventIdx != 0 || !work.suppressInterrupt) && f.isCompletingQueue(work.qidx) {
+		if f.driverFeatures&featureRingEventIdx != 0 && !f.shouldInterruptLocked(q, q.usedIdx-1, q.usedIdx, 0) {
+			return nil
+		}
 		f.interruptStatus |= fsInterruptVring
 		f.interruptRaises++
 		f.logf("interrupt-raise status=%#x", f.interruptStatus)
@@ -1429,6 +1455,35 @@ func (f *FS) writeUsedLocked(q *queue, head uint16, usedLen uint32) error {
 	return f.mem.WriteIPA(q.usedAddr+2, idx[:])
 }
 
+func (f *FS) shouldInterruptLocked(q *queue, oldUsedIdx, newUsedIdx, availFlags uint16) bool {
+	if oldUsedIdx == newUsedIdx {
+		return false
+	}
+	if f.driverFeatures&featureRingEventIdx == 0 {
+		return availFlags&1 == 0
+	}
+	var buf [2]byte
+	if err := f.readIPAInto(q.availAddr+4+uint64(q.size)*2, buf[:]); err != nil {
+		f.logf("used-event-read-error: %v", err)
+		return true
+	}
+	usedEvent := binary.LittleEndian.Uint16(buf[:])
+	return vringNeedEvent(usedEvent, newUsedIdx, oldUsedIdx)
+}
+
+func (f *FS) writeAvailEventLocked(q *queue) error {
+	if q.size == 0 || q.usedAddr == 0 {
+		return nil
+	}
+	var buf [2]byte
+	binary.LittleEndian.PutUint16(buf[:], q.lastAvailIdx)
+	return f.mem.WriteIPA(q.usedAddr+4+uint64(q.size)*8, buf[:])
+}
+
+func vringNeedEvent(eventIdx, newIdx, oldIdx uint16) bool {
+	return uint16(newIdx-eventIdx-1) < uint16(newIdx-oldIdx)
+}
+
 func (f *FS) updateIRQLocked() error {
 	if f.irq == nil {
 		return nil
@@ -1452,23 +1507,23 @@ func (f *FS) Summary() string {
 	f.statsMu.Lock()
 	defer f.statsMu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
+	queueNotifies := append([]uint64(nil), f.queueNotifies...)
+	queueReady := f.queueReadySnapshotLocked()
+	queueLastAvail := f.queueLastAvailSnapshotLocked()
 	return fmt.Sprintf(
-		"virtio-fs tag=%q mmio_reads=%d mmio_writes=%d status=%#x q0_notify=%d q1_notify=%d fuse_requests=%d interrupt_raises=%d irq_transitions=%d irq_high=%t interrupt_status=%#x q0_ready=%t q1_ready=%t q0_last=%d q1_last=%d",
+		"virtio-fs tag=%q mmio_reads=%d mmio_writes=%d status=%#x queue_notifies=%v fuse_requests=%d interrupt_raises=%d irq_transitions=%d irq_high=%t interrupt_status=%#x queue_ready=%v queue_last=%v",
 		tag,
 		f.mmioReads,
 		f.mmioWrites,
 		f.status,
-		f.queueNotifies[0],
-		f.queueNotifies[1],
+		queueNotifies,
 		f.fuseRequests,
 		f.interruptRaises,
 		f.irqTransitions,
 		f.irqHigh,
 		f.interruptStatus,
-		f.queues[0].ready,
-		f.queues[1].ready,
-		f.queues[0].lastAvailIdx,
-		f.queues[1].lastAvailIdx,
+		queueReady,
+		queueLastAvail,
 	)
 }
 
@@ -1510,22 +1565,36 @@ func (f *FS) Stats() FSStats {
 		Tag:             tag,
 		MMIOReads:       f.mmioReads,
 		MMIOWrites:      f.mmioWrites,
-		QueueNotifies:   f.queueNotifies,
+		QueueNotifies:   append([]uint64(nil), f.queueNotifies...),
 		FUSERequests:    f.fuseRequests,
 		InterruptRaises: f.interruptRaises,
 		IRQTransitions:  f.irqTransitions,
 		IRQHigh:         f.irqHigh,
 		InterruptStatus: f.interruptStatus,
-		QueueReady: [2]bool{
-			f.queues[0].ready,
-			f.queues[1].ready,
-		},
-		QueueLastAvail: [2]uint16{
-			f.queues[0].lastAvailIdx,
-			f.queues[1].lastAvailIdx,
-		},
-		FUSEOps: ops,
+		QueueReady:      f.queueReadySnapshotLocked(),
+		QueueLastAvail:  f.queueLastAvailSnapshotLocked(),
+		FUSEOps:         ops,
 	}
+}
+
+func (f *FS) queueReadySnapshotLocked() []bool {
+	ready := make([]bool, len(f.queues))
+	for i := range f.queues {
+		ready[i] = f.queues[i].ready
+	}
+	return ready
+}
+
+func (f *FS) queueLastAvailSnapshotLocked() []uint16 {
+	last := make([]uint16, len(f.queues))
+	for i := range f.queues {
+		last[i] = f.queues[i].lastAvailIdx
+	}
+	return last
+}
+
+func (f *FS) isCompletingQueue(qidx int) bool {
+	return qidx >= 0 && qidx < len(f.queues)
 }
 
 func (f *FS) selectedQueueLocked() *queue {
@@ -1552,17 +1621,42 @@ func (f *FS) resetLocked() {
 	f.interruptStatus = 0
 	f.irqHigh = false
 	f.configGeneration++
-	f.queues = [2]queue{}
-	f.nextWorkSeq = [2]uint64{}
-	f.nextCompleteSeq = [2]uint64{}
-	f.completions = make(map[fsCompletionKey]fsCompletion)
+	f.resetQueueStateLocked()
 }
 
 func (f *FS) configBytesLocked() []byte {
 	cfg := make([]byte, fsCfgTotalSize)
 	copy(cfg[:fsCfgTagSize], f.tag[:])
-	binary.LittleEndian.PutUint32(cfg[fsCfgNumQueueOff:fsCfgNumQueueOff+4], 1)
+	binary.LittleEndian.PutUint32(cfg[fsCfgNumQueueOff:fsCfgNumQueueOff+4], fsRequestQueueCount)
 	return cfg
+}
+
+func (f *FS) resetQueueStateLocked() {
+	queueCount := fsTotalQueueCount()
+	if cap(f.queues) < queueCount {
+		f.queues = make([]queue, queueCount)
+	} else {
+		f.queues = f.queues[:queueCount]
+		clear(f.queues)
+	}
+	if len(f.queueNotifies) != queueCount {
+		old := f.queueNotifies
+		f.queueNotifies = make([]uint64, queueCount)
+		copy(f.queueNotifies, old)
+	}
+	if cap(f.nextWorkSeq) < queueCount {
+		f.nextWorkSeq = make([]uint64, queueCount)
+	} else {
+		f.nextWorkSeq = f.nextWorkSeq[:queueCount]
+		clear(f.nextWorkSeq)
+	}
+	if cap(f.nextCompleteSeq) < queueCount {
+		f.nextCompleteSeq = make([]uint64, queueCount)
+	} else {
+		f.nextCompleteSeq = f.nextCompleteSeq[:queueCount]
+		clear(f.nextCompleteSeq)
+	}
+	f.completions = make(map[fsCompletionKey]fsCompletion)
 }
 
 func encodeFuseAttr(dst []byte, attr FuseAttr) {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -255,12 +255,21 @@ type FS struct {
 	nextCompleteSeq  []uint64
 	completions      map[fsCompletionKey]fsCompletion
 	fuseOpStats      [fuseStatsSlots]fuseOpStat
+	stageStats       [fsStageCount]timingStat
 }
 
 const fuseStatsSlots = 64
+const fsStageCount = 4
 const fsWorkerCount = 1
 const fsInlineRespDescs = 32
 const fsPooledReqSize = 4096
+
+const (
+	fsStageQueueHarvest = iota
+	fsStageInlineDispatch
+	fsStageInlineComplete
+	fsStageAsyncComplete
+)
 
 type fsWork struct {
 	qidx              int
@@ -312,6 +321,7 @@ type FSStats struct {
 	QueueReady      []bool        `json:"queue_ready"`
 	QueueLastAvail  []uint16      `json:"queue_last_avail"`
 	FUSEOps         []FUSEOpStats `json:"fuse_ops"`
+	Stages          []TimingStats `json:"stages"`
 }
 
 type FUSEOpStats struct {
@@ -324,6 +334,18 @@ type FUSEOpStats struct {
 }
 
 type fuseOpStat struct {
+	timingStat
+}
+
+type TimingStats struct {
+	Name         string `json:"name"`
+	Count        uint64 `json:"count"`
+	TotalNanos   int64  `json:"total_nanos"`
+	MaxNanos     int64  `json:"max_nanos"`
+	AverageNanos int64  `json:"average_nanos"`
+}
+
+type timingStat struct {
 	count      atomic.Uint64
 	totalNanos atomic.Int64
 	maxNanos   atomic.Int64
@@ -525,7 +547,9 @@ func (f *FS) Write(addr uint64, size int, value uint64) error {
 	case regQueueNotify:
 		if int(value) < len(f.queues) {
 			f.queueNotifies[int(value)]++
+			harvestStart := time.Now()
 			works, err := f.processQueueAsyncLocked(int(value))
+			f.recordStageDuration(fsStageQueueHarvest, time.Since(harvestStart))
 			if err != nil {
 				f.mu.Unlock()
 				return err
@@ -763,6 +787,7 @@ func (f *FS) processWorksInline(works []fsWork) error {
 		return nil
 	}
 	completions := make([]fsInlineCompletion, 0, len(works))
+	dispatchStart := time.Now()
 	for _, work := range works {
 		reply, err := f.dispatchFUSE(work.req)
 		putFSReqBuffer(work.req, work.pooledReq)
@@ -773,6 +798,7 @@ func (f *FS) processWorksInline(works []fsWork) error {
 		}
 		completions = append(completions, fsInlineCompletion{work: work, reply: reply})
 	}
+	f.recordStageDuration(fsStageInlineDispatch, time.Since(dispatchStart))
 	return f.completeWorksInline(completions)
 }
 
@@ -800,6 +826,7 @@ func (f *FS) runWorker() {
 }
 
 func (f *FS) completeWork(work fsWork, reply []byte, workErr error) error {
+	defer f.recordStageTiming(fsStageAsyncComplete, time.Now())
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if work.generation != f.configGeneration || work.qidx < 0 || work.qidx >= len(f.queues) {
@@ -816,6 +843,7 @@ func (f *FS) completeWorksInline(completions []fsInlineCompletion) error {
 	if len(completions) == 0 {
 		return nil
 	}
+	defer f.recordStageTiming(fsStageInlineComplete, time.Now())
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for index := 0; index < len(completions); {
@@ -1445,16 +1473,7 @@ func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
 	duration := time.Since(start)
 	f.fuseRequests.Add(1)
 	if opcode < uint32(len(f.fuseOpStats)) {
-		opStats := &f.fuseOpStats[opcode]
-		nanos := duration.Nanoseconds()
-		opStats.count.Add(1)
-		opStats.totalNanos.Add(nanos)
-		for {
-			oldMax := opStats.maxNanos.Load()
-			if nanos <= oldMax || opStats.maxNanos.CompareAndSwap(oldMax, nanos) {
-				break
-			}
-		}
+		recordTimingStat(&f.fuseOpStats[opcode].timingStat, duration)
 	}
 	if f.RecordTiming == nil {
 		return
@@ -1464,6 +1483,52 @@ func (f *FS) recordFUSEDispatchTiming(opcode uint32, start time.Time) {
 		tag = "unknown"
 	}
 	f.RecordTiming("virtio.fs."+tag+".fuse."+fuseOpcodeMetricName(opcode), duration)
+}
+
+func (f *FS) recordStageTiming(stage int, start time.Time) {
+	f.recordStageDuration(stage, time.Since(start))
+}
+
+func (f *FS) recordStageDuration(stage int, duration time.Duration) {
+	if stage < 0 || stage >= len(f.stageStats) {
+		return
+	}
+	recordTimingStat(&f.stageStats[stage], duration)
+	if f.RecordTiming == nil {
+		return
+	}
+	tag := strings.TrimRight(string(f.tag[:]), "\x00")
+	if tag == "" {
+		tag = "unknown"
+	}
+	f.RecordTiming("virtio.fs."+tag+".stage."+fsStageName(stage), duration)
+}
+
+func recordTimingStat(stat *timingStat, duration time.Duration) {
+	nanos := duration.Nanoseconds()
+	stat.count.Add(1)
+	stat.totalNanos.Add(nanos)
+	for {
+		oldMax := stat.maxNanos.Load()
+		if nanos <= oldMax || stat.maxNanos.CompareAndSwap(oldMax, nanos) {
+			break
+		}
+	}
+}
+
+func fsStageName(stage int) string {
+	switch stage {
+	case fsStageQueueHarvest:
+		return "queue_harvest"
+	case fsStageInlineDispatch:
+		return "inline_dispatch"
+	case fsStageInlineComplete:
+		return "inline_complete"
+	case fsStageAsyncComplete:
+		return "async_complete"
+	default:
+		return "unknown"
+	}
 }
 
 func fuseReply(unique uint64, errno int32, extra []byte) []byte {
@@ -1675,11 +1740,11 @@ func (f *FS) Stats() FSStats {
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	ops := make([]FUSEOpStats, 0, len(f.fuseOpStats))
 	for opcode, stat := range f.fuseOpStats {
-		count := stat.count.Load()
+		count := stat.timingStat.count.Load()
 		if count == 0 {
 			continue
 		}
-		totalNanos := stat.totalNanos.Load()
+		totalNanos := stat.timingStat.totalNanos.Load()
 		avg := int64(0)
 		if count != 0 {
 			avg = totalNanos / int64(count)
@@ -1690,7 +1755,7 @@ func (f *FS) Stats() FSStats {
 			Name:         fuseOpcodeName(opcodeValue),
 			Count:        count,
 			TotalNanos:   totalNanos,
-			MaxNanos:     stat.maxNanos.Load(),
+			MaxNanos:     stat.timingStat.maxNanos.Load(),
 			AverageNanos: avg,
 		})
 	}
@@ -1700,6 +1765,12 @@ func (f *FS) Stats() FSStats {
 		}
 		return ops[i].Count > ops[j].Count
 	})
+	stages := make([]TimingStats, 0, len(f.stageStats))
+	for stage, stat := range f.stageStats {
+		if stats, ok := timingStatsSnapshot(fsStageName(stage), &stat); ok {
+			stages = append(stages, stats)
+		}
+	}
 	return FSStats{
 		Tag:             tag,
 		MMIOReads:       f.mmioReads,
@@ -1713,7 +1784,27 @@ func (f *FS) Stats() FSStats {
 		QueueReady:      f.queueReadySnapshotLocked(),
 		QueueLastAvail:  f.queueLastAvailSnapshotLocked(),
 		FUSEOps:         ops,
+		Stages:          stages,
 	}
+}
+
+func timingStatsSnapshot(name string, stat *timingStat) (TimingStats, bool) {
+	count := stat.count.Load()
+	if count == 0 {
+		return TimingStats{}, false
+	}
+	totalNanos := stat.totalNanos.Load()
+	avg := int64(0)
+	if count != 0 {
+		avg = totalNanos / int64(count)
+	}
+	return TimingStats{
+		Name:         name,
+		Count:        count,
+		TotalNanos:   totalNanos,
+		MaxNanos:     stat.maxNanos.Load(),
+		AverageNanos: avg,
+	}, true
 }
 
 func (f *FS) queueReadySnapshotLocked() []bool {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -496,19 +496,17 @@ func (f *FS) Write(addr uint64, size int, value uint64) error {
 	case regQueueNotify:
 		if int(value) < len(f.queues) {
 			f.queueNotifies[int(value)]++
-			if f.Async {
-				works, err := f.processQueueAsyncLocked(int(value))
-				if err != nil {
-					f.mu.Unlock()
-					return err
-				}
+			works, err := f.processQueueAsyncLocked(int(value))
+			if err != nil {
 				f.mu.Unlock()
+				return err
+			}
+			f.mu.Unlock()
+			if f.Async {
 				f.enqueueWorks(works)
 				return nil
 			}
-			err := f.processQueueLocked(int(value))
-			f.mu.Unlock()
-			return err
+			return f.processWorksInline(works)
 		}
 	}
 	f.mu.Unlock()
@@ -729,6 +727,22 @@ func (f *FS) enqueueWorks(works []fsWork) {
 	for _, work := range works {
 		f.workCh <- work
 	}
+}
+
+func (f *FS) processWorksInline(works []fsWork) error {
+	for _, work := range works {
+		reply, err := f.dispatchFUSE(work.req)
+		putFSReqBuffer(work.req, work.pooledReq)
+		work.req = nil
+		work.pooledReq = false
+		if err != nil {
+			return err
+		}
+		if err := f.completeWork(work, reply, nil); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (f *FS) startWorkers() {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -105,7 +105,6 @@ const (
 
 const (
 	fuseCapPosixLocks = 1 << 1
-	fuseCapPosixACL   = 1 << 20
 )
 
 const (
@@ -2071,7 +2070,7 @@ func NewImageFS(root imagefs.Directory, statfsPath string) FSBackend {
 }
 
 func (p *passthroughFS) Init() (uint32, uint32) {
-	return 128 << 10, fuseCapPosixACL | fuseCapPosixLocks
+	return 128 << 10, fuseCapPosixLocks
 }
 
 func (p *passthroughFS) GetAttr(nodeID uint64) (FuseAttr, int32) {
@@ -2516,9 +2515,9 @@ func (p *passthroughFS) hostPath(nodeID uint64) (string, int32) {
 }
 
 func (p *passthroughFS) hostAndGuestPath(nodeID uint64) (string, string, int32) {
-	p.mu.Lock()
+	p.mu.RLock()
 	guest, ok := p.nodes[nodeID]
-	p.mu.Unlock()
+	p.mu.RUnlock()
 	if !ok {
 		return "", "", -linuxENOENT
 	}
@@ -2550,8 +2549,8 @@ func joinGuestChild(parentGuest, rel string) string {
 }
 
 func (p *passthroughFS) DebugPath(nodeID uint64) string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.nodes[nodeID]
 }
 
@@ -2681,7 +2680,7 @@ func (p *imageFS) pathForNode(id uint64) string {
 }
 
 func (p *imageFS) Init() (uint32, uint32) {
-	return 128 << 10, fuseCapPosixACL | fuseCapPosixLocks
+	return 128 << 10, fuseCapPosixLocks
 }
 
 func (p *imageFS) GetAttr(nodeID uint64) (FuseAttr, int32) {

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -474,6 +474,24 @@ func TestStrictFUSEIoctlReturnsENOTTY(t *testing.T) {
 	}
 }
 
+func TestFUSEInitAdvertisesImplementedCapabilities(t *testing.T) {
+	t.Parallel()
+
+	backends := []struct {
+		name    string
+		backend FSBackend
+	}{
+		{name: "passthrough", backend: NewPassthroughFS(t.TempDir(), nil)},
+		{name: "image", backend: NewImageFS(imagefs.NewHostFS(t.TempDir(), nil), "")},
+	}
+	for _, tc := range backends {
+		_, flags := tc.backend.Init()
+		if flags != fuseCapPosixLocks {
+			t.Fatalf("%s Init flags = %#x, want %#x", tc.name, flags, fuseCapPosixLocks)
+		}
+	}
+}
+
 func TestFUSECachePolicyEncodesTTLAndOpenFlags(t *testing.T) {
 	t.Setenv("CCX3_VIRTIOFS_CACHE", "aggressive")
 

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -176,7 +176,7 @@ func TestFSConfigReportsMultipleRequestQueues(t *testing.T) {
 	if got := binary.LittleEndian.Uint32(cfg[fsCfgNumQueueOff : fsCfgNumQueueOff+4]); got != fsRequestQueueCount {
 		t.Fatalf("num_request_queues = %d, want %d", got, fsRequestQueueCount)
 	}
-	for qidx := 0; qidx < fsTotalQueueCount(); qidx++ {
+	for qidx := 0; qidx < fsQueueCount; qidx++ {
 		if err := fsdev.Write(0x1000+regQueueSel, 4, uint64(qidx)); err != nil {
 			t.Fatalf("Write(queue-sel %d) error = %v", qidx, err)
 		}
@@ -188,7 +188,7 @@ func TestFSConfigReportsMultipleRequestQueues(t *testing.T) {
 			t.Fatalf("queue %d num max = %d, want 128", qidx, got)
 		}
 	}
-	if err := fsdev.Write(0x1000+regQueueSel, 4, uint64(fsTotalQueueCount())); err != nil {
+	if err := fsdev.Write(0x1000+regQueueSel, 4, uint64(fsQueueCount)); err != nil {
 		t.Fatalf("Write(queue-sel out of range) error = %v", err)
 	}
 	got, err := fsdev.Read(0x1000+regQueueNumMax, 4)
@@ -522,6 +522,7 @@ func TestFUSECachePolicyEncodesTTLAndOpenFlags(t *testing.T) {
 	if openFlags&fuseOpenNoFlush == 0 {
 		t.Fatalf("OPEN flags = %#x, want NO_FLUSH", openFlags)
 	}
+	fsdev.backend.Release(nodeID, binary.LittleEndian.Uint64(openReply[fuseOutHeaderSize:fuseOutHeaderSize+8]))
 }
 
 func TestFUSEStrictCachePolicyDisablesTTLAndKeepCache(t *testing.T) {
@@ -569,6 +570,7 @@ func TestFUSEStrictCachePolicyDisablesTTLAndKeepCache(t *testing.T) {
 	if openFlags&fuseOpenNoFlush == 0 {
 		t.Fatalf("OPEN flags = %#x, want NO_FLUSH", openFlags)
 	}
+	fsdev.backend.Release(nodeID, binary.LittleEndian.Uint64(openReply[fuseOutHeaderSize:fuseOutHeaderSize+8]))
 }
 
 func containsFuseDirent(data []byte, name string) bool {

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -527,6 +527,85 @@ func TestFUSEInitEnablesLargeWrites(t *testing.T) {
 	}
 }
 
+func TestFUSEInitExplicitWritebackCache(t *testing.T) {
+	t.Setenv("CCX3_VIRTIOFS_WRITEBACK", "1")
+
+	fsdev := NewFS(0, 0, 0, "root", NewPassthroughFS(t.TempDir(), nil))
+
+	const unique = uint64(45)
+	req := make([]byte, fuseInHeaderSize+16)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseInit)
+	binary.LittleEndian.PutUint64(req[8:16], unique)
+	binary.LittleEndian.PutUint32(req[40:44], 7)
+	binary.LittleEndian.PutUint32(req[44:48], 31)
+
+	reply, err := fsdev.dispatchFUSELocked(req)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(INIT) error = %v", err)
+	}
+	extra := reply[fuseOutHeaderSize:]
+	flags := binary.LittleEndian.Uint32(extra[12:16])
+	if flags&fuseCapWritebackCache == 0 {
+		t.Fatalf("INIT flags = %#x, missing WRITEBACK_CACHE", flags)
+	}
+	if got := binary.LittleEndian.Uint16(extra[16:18]); got != 256 {
+		t.Fatalf("INIT max_background = %d, want 256", got)
+	}
+	if got := binary.LittleEndian.Uint16(extra[18:20]); got != 192 {
+		t.Fatalf("INIT congestion_threshold = %d, want 192", got)
+	}
+}
+
+func TestFUSEGetXattrMissing(t *testing.T) {
+	t.Parallel()
+
+	fsdev := NewFS(0, 0, 0, "root", NewPassthroughFS(t.TempDir(), nil))
+
+	const unique = uint64(46)
+	req := make([]byte, fuseInHeaderSize+8+len("security.capability")+1)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseGetXattr)
+	binary.LittleEndian.PutUint64(req[8:16], unique)
+	binary.LittleEndian.PutUint64(req[16:24], 1)
+	copy(req[fuseInHeaderSize+8:], "security.capability")
+
+	reply, err := fsdev.dispatchFUSELocked(req)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(GETXATTR) error = %v", err)
+	}
+	if got := int32(binary.LittleEndian.Uint32(reply[4:8])); got != -linuxENODATA {
+		t.Fatalf("GETXATTR errno = %d, want %d", got, -linuxENODATA)
+	}
+}
+
+func TestPassthroughWritebackWriteOnlyHandleAllowsRead(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "data.bin"), []byte("abcdef"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	be := NewPassthroughFS(root, nil).(*passthroughFS)
+	be.SetWritebackCache(true)
+	nodeID, _, errno := be.Lookup(1, "data.bin")
+	if errno != 0 {
+		t.Fatalf("Lookup() errno = %d", errno)
+	}
+	fh, errno := be.Open(nodeID, linuxOWRONLY)
+	if errno != 0 {
+		t.Fatalf("Open(O_WRONLY) errno = %d", errno)
+	}
+	defer be.Release(nodeID, fh)
+	got, errno := be.Read(nodeID, fh, 1, 3)
+	if errno != 0 {
+		t.Fatalf("Read() errno = %d", errno)
+	}
+	if string(got) != "bcd" {
+		t.Fatalf("Read() = %q, want bcd", got)
+	}
+}
+
 func TestFUSECachePolicyEncodesTTLAndOpenFlags(t *testing.T) {
 	t.Setenv("CCX3_VIRTIOFS_CACHE", "aggressive")
 

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -492,6 +492,41 @@ func TestFUSEInitAdvertisesImplementedCapabilities(t *testing.T) {
 	}
 }
 
+func TestFUSEInitEnablesLargeWrites(t *testing.T) {
+	t.Parallel()
+
+	fsdev := NewFS(0, 0, 0, "root", NewPassthroughFS(t.TempDir(), nil))
+
+	const unique = uint64(44)
+	req := make([]byte, fuseInHeaderSize+16)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseInit)
+	binary.LittleEndian.PutUint64(req[8:16], unique)
+	binary.LittleEndian.PutUint32(req[40:44], 7)
+	binary.LittleEndian.PutUint32(req[44:48], 31)
+
+	reply, err := fsdev.dispatchFUSELocked(req)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(INIT) error = %v", err)
+	}
+	if got := int32(binary.LittleEndian.Uint32(reply[4:8])); got != 0 {
+		t.Fatalf("INIT errno = %d, want 0", got)
+	}
+	extra := reply[fuseOutHeaderSize:]
+	flags := binary.LittleEndian.Uint32(extra[12:16])
+	for _, flag := range []uint32{fuseCapBigWrites, fuseCapMaxPages} {
+		if flags&flag == 0 {
+			t.Fatalf("INIT flags = %#x, missing %#x", flags, flag)
+		}
+	}
+	if got := binary.LittleEndian.Uint32(extra[20:24]); got != 128<<10 {
+		t.Fatalf("INIT max_write = %d, want %d", got, 128<<10)
+	}
+	if got := binary.LittleEndian.Uint16(extra[28:30]); got != 32 {
+		t.Fatalf("INIT max_pages = %d, want 32", got)
+	}
+}
+
 func TestFUSECachePolicyEncodesTTLAndOpenFlags(t *testing.T) {
 	t.Setenv("CCX3_VIRTIOFS_CACHE", "aggressive")
 

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -30,6 +30,9 @@ func TestPassthroughFSCreateWriteRenameUnlink(t *testing.T) {
 	if errno := be.Flush(nodeID, fh, 0); errno != 0 {
 		t.Fatalf("Flush() errno = %d", errno)
 	}
+	if errno := be.Fsync(nodeID, fh, 0); errno != 0 {
+		t.Fatalf("Fsync() errno = %d", errno)
+	}
 	be.Release(nodeID, fh)
 
 	data, err := os.ReadFile(filepath.Join(root, "hello.txt"))
@@ -51,6 +54,41 @@ func TestPassthroughFSCreateWriteRenameUnlink(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "renamed.txt")); !os.IsNotExist(err) {
 		t.Fatalf("Stat(after unlink) error = %v, want not exist", err)
+	}
+}
+
+func TestStrictFUSEFsyncUsesBackendHandle(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	backend := NewPassthroughFS(root, nil)
+	be := backend.(*passthroughFS)
+	nodeID, fh, _, errno := be.Create(1, "data.txt", linuxOWRONLY|linuxOCREAT|linuxOTRUNC, 0o644)
+	if errno != 0 {
+		t.Fatalf("Create() errno = %d", errno)
+	}
+	defer be.Release(nodeID, fh)
+
+	fsdev := NewFS(0, 0, 0, "root", backend)
+	fsdev.Strict = true
+
+	const unique = uint64(44)
+	req := make([]byte, fuseInHeaderSize+16)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseFsync)
+	binary.LittleEndian.PutUint64(req[8:16], unique)
+	binary.LittleEndian.PutUint64(req[16:24], nodeID)
+	binary.LittleEndian.PutUint64(req[40:48], fh)
+
+	reply, err := fsdev.dispatchFUSELocked(req)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(FSYNC) error = %v", err)
+	}
+	if got := int32(binary.LittleEndian.Uint32(reply[4:8])); got != 0 {
+		t.Fatalf("FSYNC errno = %d, want 0", got)
+	}
+	if got := binary.LittleEndian.Uint64(reply[8:16]); got != unique {
+		t.Fatalf("FSYNC unique = %d, want %d", got, unique)
 	}
 }
 

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -169,6 +169,185 @@ func TestFSAsyncQueueCompletesLongResponseChain(t *testing.T) {
 	}
 }
 
+func TestFSConfigReportsMultipleRequestQueues(t *testing.T) {
+	fsdev := NewFS(0x1000, 0x1000, 44, "root", NewPassthroughFS(t.TempDir(), nil))
+
+	cfg := fsdev.configBytesLocked()
+	if got := binary.LittleEndian.Uint32(cfg[fsCfgNumQueueOff : fsCfgNumQueueOff+4]); got != fsRequestQueueCount {
+		t.Fatalf("num_request_queues = %d, want %d", got, fsRequestQueueCount)
+	}
+	for qidx := 0; qidx < fsTotalQueueCount(); qidx++ {
+		if err := fsdev.Write(0x1000+regQueueSel, 4, uint64(qidx)); err != nil {
+			t.Fatalf("Write(queue-sel %d) error = %v", qidx, err)
+		}
+		got, err := fsdev.Read(0x1000+regQueueNumMax, 4)
+		if err != nil {
+			t.Fatalf("Read(queue-num-max %d) error = %v", qidx, err)
+		}
+		if got != 128 {
+			t.Fatalf("queue %d num max = %d, want 128", qidx, got)
+		}
+	}
+	if err := fsdev.Write(0x1000+regQueueSel, 4, uint64(fsTotalQueueCount())); err != nil {
+		t.Fatalf("Write(queue-sel out of range) error = %v", err)
+	}
+	got, err := fsdev.Read(0x1000+regQueueNumMax, 4)
+	if err != nil {
+		t.Fatalf("Read(queue-num-max out of range) error = %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("out of range queue num max = %d, want 0", got)
+	}
+}
+
+func TestFSSyncSecondaryRequestQueueCompletes(t *testing.T) {
+	mem := &testGuestMemory{data: make([]byte, 0x8000)}
+	irq := &testIRQController{}
+
+	fsdev := NewFS(0x1000, 0x1000, 44, "root", NewPassthroughFS(t.TempDir(), nil))
+	fsdev.Strict = true
+	fsdev.Attach(mem, irq)
+
+	const (
+		qidx      = fsQueueRequest + 1
+		descAddr  = 0x2000
+		availAddr = 0x3000
+		usedAddr  = 0x3100
+		reqAddr   = 0x3200
+		respAddr  = 0x3300
+		queueSize = 8
+	)
+	req := make([]byte, fuseInHeaderSize+16)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseInit)
+	binary.LittleEndian.PutUint64(req[8:16], 202)
+	binary.LittleEndian.PutUint32(req[40:44], 7)
+	binary.LittleEndian.PutUint32(req[44:48], 31)
+	copy(mem.data[reqAddr:], req)
+
+	binary.LittleEndian.PutUint64(mem.data[descAddr:descAddr+8], reqAddr)
+	binary.LittleEndian.PutUint32(mem.data[descAddr+8:descAddr+12], uint32(len(req)))
+	binary.LittleEndian.PutUint16(mem.data[descAddr+12:descAddr+14], descFNext)
+	binary.LittleEndian.PutUint16(mem.data[descAddr+14:descAddr+16], 1)
+	binary.LittleEndian.PutUint64(mem.data[descAddr+16:descAddr+24], respAddr)
+	binary.LittleEndian.PutUint32(mem.data[descAddr+24:descAddr+28], fuseOutHeaderSize+fuseInitOutSize)
+	binary.LittleEndian.PutUint16(mem.data[descAddr+28:descAddr+30], descFWrite)
+
+	binary.LittleEndian.PutUint16(mem.data[availAddr+2:availAddr+4], 1)
+	binary.LittleEndian.PutUint16(mem.data[availAddr+4:availAddr+6], 0)
+
+	for _, write := range []struct {
+		reg   uint64
+		value uint64
+	}{
+		{regQueueSel, qidx},
+		{regQueueNum, queueSize},
+		{regQueueDescLow, descAddr},
+		{regQueueAvailLow, availAddr},
+		{regQueueUsedLow, usedAddr},
+		{regQueueReady, 1},
+		{regQueueNotify, qidx},
+	} {
+		if err := fsdev.Write(0x1000+write.reg, 4, write.value); err != nil {
+			t.Fatalf("Write(reg=%#x) error = %v", write.reg, err)
+		}
+	}
+
+	if usedIdx := binary.LittleEndian.Uint16(mem.data[usedAddr+2 : usedAddr+4]); usedIdx != 1 {
+		t.Fatalf("used idx = %d, want 1", usedIdx)
+	}
+	if irq.calls == 0 || !irq.level || irq.irq != 44 {
+		t.Fatalf("irq state = irq=%d level=%v calls=%d, want irq=44 asserted", irq.irq, irq.level, irq.calls)
+	}
+	if got := binary.LittleEndian.Uint64(mem.data[respAddr+8 : respAddr+16]); got != 202 {
+		t.Fatalf("reply unique = %d, want 202", got)
+	}
+}
+
+func TestFSSyncQueueHonorsUsedEventIdx(t *testing.T) {
+	mem := &testGuestMemory{data: make([]byte, 0x8000)}
+	irq := &testIRQController{}
+
+	fsdev := NewFS(0x1000, 0x1000, 44, "root", NewPassthroughFS(t.TempDir(), nil))
+	fsdev.Strict = true
+	fsdev.driverFeatures = featureRingEventIdx
+	fsdev.Attach(mem, irq)
+
+	const (
+		descAddr  = 0x2000
+		availAddr = 0x3000
+		usedAddr  = 0x3100
+		reqAddr   = 0x3200
+		respAddr  = 0x3300
+		queueSize = 8
+	)
+	req := make([]byte, fuseInHeaderSize+16)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseInit)
+	binary.LittleEndian.PutUint64(req[8:16], 101)
+	binary.LittleEndian.PutUint32(req[40:44], 7)
+	binary.LittleEndian.PutUint32(req[44:48], 31)
+	copy(mem.data[reqAddr:], req)
+
+	binary.LittleEndian.PutUint64(mem.data[descAddr:descAddr+8], reqAddr)
+	binary.LittleEndian.PutUint32(mem.data[descAddr+8:descAddr+12], uint32(len(req)))
+	binary.LittleEndian.PutUint16(mem.data[descAddr+12:descAddr+14], descFNext)
+	binary.LittleEndian.PutUint16(mem.data[descAddr+14:descAddr+16], 1)
+	binary.LittleEndian.PutUint64(mem.data[descAddr+16:descAddr+24], respAddr)
+	binary.LittleEndian.PutUint32(mem.data[descAddr+24:descAddr+28], fuseOutHeaderSize+fuseInitOutSize)
+	binary.LittleEndian.PutUint16(mem.data[descAddr+28:descAddr+30], descFWrite)
+
+	binary.LittleEndian.PutUint16(mem.data[availAddr+2:availAddr+4], 1)
+	binary.LittleEndian.PutUint16(mem.data[availAddr+4:availAddr+6], 0)
+	binary.LittleEndian.PutUint16(mem.data[availAddr+4+queueSize*2:availAddr+6+queueSize*2], 1)
+
+	for _, write := range []struct {
+		reg   uint64
+		value uint64
+	}{
+		{regQueueSel, fsQueueRequest},
+		{regQueueNum, queueSize},
+		{regQueueDescLow, descAddr},
+		{regQueueAvailLow, availAddr},
+		{regQueueUsedLow, usedAddr},
+		{regQueueReady, 1},
+		{regQueueNotify, fsQueueRequest},
+	} {
+		if err := fsdev.Write(0x1000+write.reg, 4, write.value); err != nil {
+			t.Fatalf("Write(reg=%#x) error = %v", write.reg, err)
+		}
+	}
+
+	if usedIdx := binary.LittleEndian.Uint16(mem.data[usedAddr+2 : usedAddr+4]); usedIdx != 1 {
+		t.Fatalf("used idx = %d, want 1", usedIdx)
+	}
+	if irq.calls != 0 {
+		t.Fatalf("irq calls = %d, want 0", irq.calls)
+	}
+}
+
+func TestVringNeedEvent(t *testing.T) {
+	tests := []struct {
+		name  string
+		event uint16
+		new   uint16
+		old   uint16
+		want  bool
+	}{
+		{name: "next completion requested", event: 0, new: 1, old: 0, want: true},
+		{name: "future completion suppresses", event: 1, new: 1, old: 0, want: false},
+		{name: "wrap requested", event: 0xffff, new: 0, old: 0xffff, want: true},
+		{name: "wrap future suppresses", event: 0, new: 0, old: 0xffff, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vringNeedEvent(tt.event, tt.new, tt.old); got != tt.want {
+				t.Fatalf("vringNeedEvent(%d, %d, %d) = %v, want %v", tt.event, tt.new, tt.old, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPassthroughFSSetAttrTruncate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -92,6 +92,83 @@ func TestStrictFUSEFsyncUsesBackendHandle(t *testing.T) {
 	}
 }
 
+func TestFSAsyncQueueCompletesLongResponseChain(t *testing.T) {
+	mem := &testGuestMemory{data: make([]byte, 0x8000)}
+	irq := &testIRQController{}
+
+	fsdev := NewFS(0x1000, 0x1000, 44, "root", NewPassthroughFS(t.TempDir(), nil))
+	fsdev.Strict = true
+	fsdev.Async = true
+	fsdev.Attach(mem, irq)
+
+	const (
+		descAddr  = 0x2000
+		availAddr = 0x3000
+		usedAddr  = 0x3100
+		reqAddr   = 0x3200
+		respAddr  = 0x4000
+	)
+	req := make([]byte, fuseInHeaderSize+16)
+	binary.LittleEndian.PutUint32(req[0:4], uint32(len(req)))
+	binary.LittleEndian.PutUint32(req[4:8], fuseInit)
+	binary.LittleEndian.PutUint64(req[8:16], 99)
+	binary.LittleEndian.PutUint32(req[40:44], 7)
+	binary.LittleEndian.PutUint32(req[44:48], 31)
+	copy(mem.data[reqAddr:], req)
+
+	binary.LittleEndian.PutUint64(mem.data[descAddr:descAddr+8], reqAddr)
+	binary.LittleEndian.PutUint32(mem.data[descAddr+8:descAddr+12], uint32(len(req)))
+	binary.LittleEndian.PutUint16(mem.data[descAddr+12:descAddr+14], descFNext)
+	binary.LittleEndian.PutUint16(mem.data[descAddr+14:descAddr+16], 1)
+	for i := 0; i < fuseOutHeaderSize+fuseInitOutSize; i++ {
+		descOff := descAddr + 16 + i*16
+		flags := uint16(descFWrite)
+		if i != fuseOutHeaderSize+fuseInitOutSize-1 {
+			flags |= descFNext
+		}
+		binary.LittleEndian.PutUint64(mem.data[descOff:descOff+8], respAddr+uint64(i))
+		binary.LittleEndian.PutUint32(mem.data[descOff+8:descOff+12], 1)
+		binary.LittleEndian.PutUint16(mem.data[descOff+12:descOff+14], flags)
+		binary.LittleEndian.PutUint16(mem.data[descOff+14:descOff+16], uint16(i+2))
+	}
+	binary.LittleEndian.PutUint16(mem.data[availAddr+2:availAddr+4], 1)
+	binary.LittleEndian.PutUint16(mem.data[availAddr+4:availAddr+6], 0)
+
+	for _, write := range []struct {
+		reg   uint64
+		value uint64
+	}{
+		{regQueueSel, fsQueueRequest},
+		{regQueueNum, 128},
+		{regQueueDescLow, descAddr},
+		{regQueueAvailLow, availAddr},
+		{regQueueUsedLow, usedAddr},
+		{regQueueReady, 1},
+		{regQueueNotify, fsQueueRequest},
+	} {
+		if err := fsdev.Write(0x1000+write.reg, 4, write.value); err != nil {
+			t.Fatalf("Write(reg=%#x) error = %v", write.reg, err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for binary.LittleEndian.Uint16(mem.data[usedAddr+2:usedAddr+4]) != 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if usedIdx := binary.LittleEndian.Uint16(mem.data[usedAddr+2 : usedAddr+4]); usedIdx != 1 {
+		t.Fatalf("used idx = %d, want 1", usedIdx)
+	}
+	if usedLen := binary.LittleEndian.Uint32(mem.data[usedAddr+8 : usedAddr+12]); usedLen != fuseOutHeaderSize+fuseInitOutSize {
+		t.Fatalf("used len = %d, want %d", usedLen, fuseOutHeaderSize+fuseInitOutSize)
+	}
+	if irq.calls == 0 || !irq.level || irq.irq != 44 {
+		t.Fatalf("irq state = irq=%d level=%v calls=%d, want irq=44 asserted", irq.irq, irq.level, irq.calls)
+	}
+	if got := binary.LittleEndian.Uint64(mem.data[respAddr+8 : respAddr+16]); got != 99 {
+		t.Fatalf("reply unique = %d, want 99", got)
+	}
+}
+
 func TestPassthroughFSSetAttrTruncate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/virtio/fs_test.go
+++ b/internal/virtio/fs_test.go
@@ -474,6 +474,103 @@ func TestStrictFUSEIoctlReturnsENOTTY(t *testing.T) {
 	}
 }
 
+func TestFUSECachePolicyEncodesTTLAndOpenFlags(t *testing.T) {
+	t.Setenv("CCX3_VIRTIOFS_CACHE", "aggressive")
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "data.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsdev := NewFS(0, 0, 0, "root", NewPassthroughFS(root, nil))
+
+	lookupReq := make([]byte, fuseInHeaderSize+len("data.txt")+1)
+	binary.LittleEndian.PutUint32(lookupReq[0:4], uint32(len(lookupReq)))
+	binary.LittleEndian.PutUint32(lookupReq[4:8], fuseLookup)
+	binary.LittleEndian.PutUint64(lookupReq[8:16], 1)
+	binary.LittleEndian.PutUint64(lookupReq[16:24], 1)
+	copy(lookupReq[fuseInHeaderSize:], "data.txt")
+	lookupReply, err := fsdev.dispatchFUSELocked(lookupReq)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(LOOKUP) error = %v", err)
+	}
+	if got := int32(binary.LittleEndian.Uint32(lookupReply[4:8])); got != 0 {
+		t.Fatalf("LOOKUP errno = %d, want 0", got)
+	}
+	extra := lookupReply[fuseOutHeaderSize:]
+	if got := binary.LittleEndian.Uint64(extra[16:24]); got != 60 {
+		t.Fatalf("LOOKUP entry TTL seconds = %d, want 60", got)
+	}
+	if got := binary.LittleEndian.Uint64(extra[24:32]); got != 60 {
+		t.Fatalf("LOOKUP attr TTL seconds = %d, want 60", got)
+	}
+	nodeID := binary.LittleEndian.Uint64(extra[0:8])
+
+	openReq := make([]byte, fuseInHeaderSize+8)
+	binary.LittleEndian.PutUint32(openReq[0:4], uint32(len(openReq)))
+	binary.LittleEndian.PutUint32(openReq[4:8], fuseOpen)
+	binary.LittleEndian.PutUint64(openReq[8:16], 2)
+	binary.LittleEndian.PutUint64(openReq[16:24], nodeID)
+	binary.LittleEndian.PutUint32(openReq[40:44], linuxORDONLY)
+	openReply, err := fsdev.dispatchFUSELocked(openReq)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(OPEN) error = %v", err)
+	}
+	openFlags := binary.LittleEndian.Uint32(openReply[fuseOutHeaderSize+8 : fuseOutHeaderSize+12])
+	if openFlags&fuseOpenKeepCache == 0 {
+		t.Fatalf("OPEN flags = %#x, want KEEP_CACHE", openFlags)
+	}
+	if openFlags&fuseOpenNoFlush == 0 {
+		t.Fatalf("OPEN flags = %#x, want NO_FLUSH", openFlags)
+	}
+}
+
+func TestFUSEStrictCachePolicyDisablesTTLAndKeepCache(t *testing.T) {
+	t.Setenv("CCX3_VIRTIOFS_CACHE", "strict")
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "data.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsdev := NewFS(0, 0, 0, "root", NewPassthroughFS(root, nil))
+
+	lookupReq := make([]byte, fuseInHeaderSize+len("data.txt")+1)
+	binary.LittleEndian.PutUint32(lookupReq[0:4], uint32(len(lookupReq)))
+	binary.LittleEndian.PutUint32(lookupReq[4:8], fuseLookup)
+	binary.LittleEndian.PutUint64(lookupReq[8:16], 1)
+	binary.LittleEndian.PutUint64(lookupReq[16:24], 1)
+	copy(lookupReq[fuseInHeaderSize:], "data.txt")
+	lookupReply, err := fsdev.dispatchFUSELocked(lookupReq)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(LOOKUP) error = %v", err)
+	}
+	extra := lookupReply[fuseOutHeaderSize:]
+	if got := binary.LittleEndian.Uint64(extra[16:24]); got != 0 {
+		t.Fatalf("LOOKUP entry TTL seconds = %d, want 0", got)
+	}
+	if got := binary.LittleEndian.Uint64(extra[24:32]); got != 0 {
+		t.Fatalf("LOOKUP attr TTL seconds = %d, want 0", got)
+	}
+	nodeID := binary.LittleEndian.Uint64(extra[0:8])
+
+	openReq := make([]byte, fuseInHeaderSize+8)
+	binary.LittleEndian.PutUint32(openReq[0:4], uint32(len(openReq)))
+	binary.LittleEndian.PutUint32(openReq[4:8], fuseOpen)
+	binary.LittleEndian.PutUint64(openReq[8:16], 2)
+	binary.LittleEndian.PutUint64(openReq[16:24], nodeID)
+	binary.LittleEndian.PutUint32(openReq[40:44], linuxORDONLY)
+	openReply, err := fsdev.dispatchFUSELocked(openReq)
+	if err != nil {
+		t.Fatalf("dispatchFUSELocked(OPEN) error = %v", err)
+	}
+	openFlags := binary.LittleEndian.Uint32(openReply[fuseOutHeaderSize+8 : fuseOutHeaderSize+12])
+	if openFlags&fuseOpenKeepCache != 0 {
+		t.Fatalf("OPEN flags = %#x, want no KEEP_CACHE", openFlags)
+	}
+	if openFlags&fuseOpenNoFlush == 0 {
+		t.Fatalf("OPEN flags = %#x, want NO_FLUSH", openFlags)
+	}
+}
+
 func containsFuseDirent(data []byte, name string) bool {
 	for off := 0; off+fuseDirentBaseSize <= len(data); {
 		nameLen := int(binary.LittleEndian.Uint32(data[off+16 : off+20]))

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -420,13 +420,13 @@ func (m *mountedFS) Create(parent uint64, name string, flags uint32, mode uint32
 	if !ok {
 		return 0, 0, FuseAttr{}, -linuxEROFS
 	}
-	_, fh, attr, errno := createBackend.Create(backendParent, name, flags, mode)
+	backendNodeID, fh, attr, errno := createBackend.Create(backendParent, name, flags, mode)
 	if errno != 0 {
 		return 0, 0, FuseAttr{}, errno
 	}
 	id := m.ensureNode(childPath)
 	attr.Ino = id
-	return id, m.storeHandle(backend, m.mustResolveNodeID(childPath), fh, false), attr, 0
+	return id, m.storeHandle(backend, backendNodeID, fh, false), attr, 0
 }
 
 func (m *mountedFS) Write(nodeID uint64, fh uint64, off uint64, data []byte, flags uint32) (uint32, int32) {
@@ -850,14 +850,6 @@ func (m *mountedFS) takeHandle(id uint64, dir bool) *mountedHandle {
 	}
 	delete(m.handles, id)
 	return handle
-}
-
-func (m *mountedFS) mustResolveNodeID(guestPath string) uint64 {
-	backend, nodeID, _, errno := m.resolveBackendNode(guestPath)
-	if errno != 0 || backend == nil {
-		return 0
-	}
-	return nodeID
 }
 
 func parentPath(guestPath string) string {

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -25,8 +25,9 @@ type ShareMount struct {
 }
 
 type mountedFS struct {
-	root   FSBackend
-	mounts []shareMount
+	root           FSBackend
+	mounts         []shareMount
+	writebackCache bool
 
 	mu         sync.RWMutex
 	nextNodeID uint64
@@ -104,6 +105,12 @@ func (m *mountedFS) AddShare(share ShareMount) error {
 	if share.Backend == nil {
 		return nil
 	}
+	m.mu.RLock()
+	writebackCache := m.writebackCache
+	m.mu.RUnlock()
+	if be, ok := share.Backend.(fsWritebackCacheBackend); ok {
+		be.SetWritebackCache(writebackCache)
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -130,6 +137,26 @@ func (m *mountedFS) AddShare(share ShareMount) error {
 		return len(m.mounts[i].path) < len(m.mounts[j].path)
 	})
 	return nil
+}
+
+func (m *mountedFS) SetWritebackCache(enabled bool) {
+	m.mu.Lock()
+	m.writebackCache = enabled
+	root := m.root
+	backends := make([]FSBackend, 0, len(m.mounts))
+	for _, mount := range m.mounts {
+		backends = append(backends, mount.backend)
+	}
+	m.mu.Unlock()
+
+	if be, ok := root.(fsWritebackCacheBackend); ok {
+		be.SetWritebackCache(enabled)
+	}
+	for _, backend := range backends {
+		if be, ok := backend.(fsWritebackCacheBackend); ok {
+			be.SetWritebackCache(enabled)
+		}
+	}
 }
 
 func cleanMountPath(value string) string {

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -405,7 +405,11 @@ func (m *mountedFS) Create(parent uint64, name string, flags uint32, mode uint32
 	if parentNode == nil {
 		return 0, 0, FuseAttr{}, -linuxENOENT
 	}
-	childPath := path.Join(parentNode.path, path.Base(path.Clean("/"+name)))
+	childName, ok := cleanChildName(name)
+	if !ok {
+		return 0, 0, FuseAttr{}, -linuxEINVAL
+	}
+	childPath := path.Join(parentNode.path, path.Base(childName))
 	if m.isMountPath(childPath) || m.isSyntheticPath(childPath) {
 		return 0, 0, FuseAttr{}, -linuxEEXIST
 	}
@@ -420,7 +424,7 @@ func (m *mountedFS) Create(parent uint64, name string, flags uint32, mode uint32
 	if !ok {
 		return 0, 0, FuseAttr{}, -linuxEROFS
 	}
-	backendNodeID, fh, attr, errno := createBackend.Create(backendParent, name, flags, mode)
+	backendNodeID, fh, attr, errno := createBackend.Create(backendParent, childName, flags, mode)
 	if errno != 0 {
 		return 0, 0, FuseAttr{}, errno
 	}

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -43,8 +43,11 @@ type shareMount struct {
 }
 
 type mountedNode struct {
-	id   uint64
-	path string
+	id              uint64
+	path            string
+	backend         FSBackend
+	backendNodeID   uint64
+	backendResolved bool
 }
 
 type mountedHandle struct {
@@ -176,11 +179,21 @@ func (m *mountedFS) Lookup(parent uint64, name string) (uint64, FuseAttr, int32)
 	}
 
 	childPath := path.Join(parentNode.path, name)
-	attr, errno := m.resolveAttr(childPath)
+	if m.isSyntheticPath(childPath) {
+		attr := syntheticDirAttr()
+		id := m.ensureNode(childPath)
+		attr.Ino = id
+		return id, attr, 0
+	}
+	backend, backendNodeID, _, errno := m.resolveBackendNode(childPath)
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	id := m.ensureNode(childPath)
+	attr, errno := backend.GetAttr(backendNodeID)
+	if errno != 0 {
+		return 0, FuseAttr{}, errno
+	}
+	id := m.ensureResolvedNode(childPath, backend, backendNodeID)
 	attr.Ino = id
 	return id, attr, 0
 }
@@ -294,7 +307,7 @@ func (m *mountedFS) ReadDir(nodeID uint64, fh uint64, off uint64, maxBytes uint3
 				continue
 			}
 			childPath := path.Join(node.path, child.name)
-			childID := m.ensureNode(childPath)
+			childID := m.ensureResolvedNode(childPath, handle.backend, child.ino)
 			child.ino = childID
 			names[child.name] = child
 		}
@@ -367,8 +380,7 @@ func (m *mountedFS) Mkdir(parent uint64, name string, mode uint32) (uint64, Fuse
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	_ = nodeID
-	id := m.ensureNode(childPath)
+	id := m.ensureResolvedNode(childPath, backend, nodeID)
 	attr.Ino = id
 	return id, attr, 0
 }
@@ -428,7 +440,7 @@ func (m *mountedFS) Create(parent uint64, name string, flags uint32, mode uint32
 	if errno != 0 {
 		return 0, 0, FuseAttr{}, errno
 	}
-	id := m.ensureNode(childPath)
+	id := m.ensureResolvedNode(childPath, backend, backendNodeID)
 	attr.Ino = id
 	return id, m.storeHandle(backend, backendNodeID, fh, false), attr, 0
 }
@@ -605,6 +617,9 @@ func (m *mountedFS) resolveBackendNode(guestPath string) (FSBackend, uint64, *sh
 		return m.root, 1, nil, 0
 	}
 	mount := m.mountForPath(guestPath)
+	if node := m.nodeForPath(guestPath); node != nil && node.backendResolved {
+		return node.backend, node.backendNodeID, mount, 0
+	}
 	if mount == nil {
 		nodeID, _, errno := backendLookupPath(m.root, guestPath)
 		return m.root, nodeID, nil, errno
@@ -785,17 +800,39 @@ func (m *mountedFS) node(id uint64) *mountedNode {
 }
 
 func (m *mountedFS) ensureNode(guestPath string) uint64 {
+	return m.ensureResolvedNode(guestPath, nil, 0)
+}
+
+func (m *mountedFS) ensureResolvedNode(guestPath string, backend FSBackend, backendNodeID uint64) uint64 {
 	guestPath = cleanMountPath(guestPath)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if id, ok := m.pathToNode[guestPath]; ok {
+		if node := m.nodes[id]; node != nil && backend != nil {
+			node.backend = backend
+			node.backendNodeID = backendNodeID
+			node.backendResolved = true
+		}
 		return id
 	}
 	id := m.nextNodeID
 	m.nextNodeID++
-	m.nodes[id] = &mountedNode{id: id, path: guestPath}
+	m.nodes[id] = &mountedNode{
+		id:              id,
+		path:            guestPath,
+		backend:         backend,
+		backendNodeID:   backendNodeID,
+		backendResolved: backend != nil,
+	}
 	m.pathToNode[guestPath] = id
 	return id
+}
+
+func (m *mountedFS) nodeForPath(guestPath string) *mountedNode {
+	guestPath = cleanMountPath(guestPath)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.nodes[m.pathToNode[guestPath]]
 }
 
 func (m *mountedFS) removeNode(guestPath string) {

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -545,6 +545,30 @@ func (m *mountedFS) Flush(nodeID uint64, fh uint64, lockOwner uint64) int32 {
 	return flushBackend.Flush(handle.nodeID, handle.fh, lockOwner)
 }
 
+func (m *mountedFS) Fsync(nodeID uint64, fh uint64, flags uint32) int32 {
+	handle := m.handle(fh, false)
+	if handle == nil {
+		return -linuxEBADF
+	}
+	fsyncBackend, ok := handle.backend.(fsFsyncBackend)
+	if !ok {
+		return 0
+	}
+	return fsyncBackend.Fsync(handle.nodeID, handle.fh, flags)
+}
+
+func (m *mountedFS) FsyncDir(nodeID uint64, fh uint64, flags uint32) int32 {
+	handle := m.handle(fh, true)
+	if handle == nil {
+		return -linuxEBADF
+	}
+	fsyncBackend, ok := handle.backend.(fsFsyncDirBackend)
+	if !ok {
+		return 0
+	}
+	return fsyncBackend.FsyncDir(handle.nodeID, handle.fh, flags)
+}
+
 func (m *mountedFS) Lseek(nodeID uint64, fh uint64, offset uint64, whence uint32) (uint64, int32) {
 	handle := m.handle(fh, false)
 	if handle == nil {
@@ -874,4 +898,6 @@ var _ fsSetAttrBackend = (*mountedFS)(nil)
 var _ fsUnlinkBackend = (*mountedFS)(nil)
 var _ fsRenameBackend = (*mountedFS)(nil)
 var _ fsFlushBackend = (*mountedFS)(nil)
+var _ fsFsyncBackend = (*mountedFS)(nil)
+var _ fsFsyncDirBackend = (*mountedFS)(nil)
 var _ fsLseekBackend = (*mountedFS)(nil)

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -149,7 +149,7 @@ func (m *mountedFS) GetAttr(nodeID uint64) (FuseAttr, int32) {
 	if node == nil {
 		return FuseAttr{}, -linuxENOENT
 	}
-	attr, errno := m.resolveAttr(node.path)
+	attr, errno := m.resolveAttr(node)
 	if errno != 0 {
 		return FuseAttr{}, errno
 	}
@@ -203,7 +203,7 @@ func (m *mountedFS) Open(nodeID uint64, flags uint32) (uint64, int32) {
 	if node == nil {
 		return 0, -linuxENOENT
 	}
-	backend, backendNodeID, _, errno := m.resolveBackendNode(node.path)
+	backend, backendNodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno != 0 {
 		return 0, errno
 	}
@@ -235,7 +235,7 @@ func (m *mountedFS) GetXattr(nodeID uint64, name string) ([]byte, int32) {
 	if node == nil {
 		return nil, -linuxENOENT
 	}
-	backend, backendNodeID, _, errno := m.resolveBackendNode(node.path)
+	backend, backendNodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno != 0 {
 		return nil, errno
 	}
@@ -251,7 +251,7 @@ func (m *mountedFS) ListXattr(nodeID uint64) ([]byte, int32) {
 	if node == nil {
 		return nil, -linuxENOENT
 	}
-	backend, backendNodeID, _, errno := m.resolveBackendNode(node.path)
+	backend, backendNodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno != 0 {
 		return nil, errno
 	}
@@ -267,7 +267,7 @@ func (m *mountedFS) OpenDir(nodeID uint64, flags uint32) (uint64, int32) {
 	if node == nil {
 		return 0, -linuxENOENT
 	}
-	backend, backendNodeID, _, errno := m.resolveBackendNode(node.path)
+	backend, backendNodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno == 0 {
 		fh, errno := backend.OpenDir(backendNodeID, flags)
 		if errno != 0 {
@@ -340,7 +340,7 @@ func (m *mountedFS) Readlink(nodeID uint64) (string, int32) {
 	if node == nil {
 		return "", -linuxENOENT
 	}
-	backend, backendNodeID, _, errno := m.resolveBackendNode(node.path)
+	backend, backendNodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno != 0 {
 		return "", errno
 	}
@@ -352,7 +352,7 @@ func (m *mountedFS) StatFS(nodeID uint64) (uint64, uint64, uint64, uint64, uint6
 	if node == nil {
 		return 0, 0, 0, 0, 0, 0, 0, 0, -linuxENOENT
 	}
-	backend, backendNodeID, _, errno := m.resolveBackendNode(node.path)
+	backend, backendNodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno != 0 {
 		return m.root.StatFS(1)
 	}
@@ -597,18 +597,30 @@ func (m *mountedFS) Lseek(nodeID uint64, fh uint64, offset uint64, whence uint32
 	return lseekBackend.Lseek(handle.nodeID, handle.fh, offset, whence)
 }
 
-func (m *mountedFS) resolveAttr(guestPath string) (FuseAttr, int32) {
-	if guestPath == "/" {
+func (m *mountedFS) resolveAttr(node *mountedNode) (FuseAttr, int32) {
+	if node.path == "/" {
 		return m.root.GetAttr(1)
 	}
-	if m.isSyntheticPath(guestPath) {
+	if m.isSyntheticPath(node.path) {
 		return syntheticDirAttr(), 0
 	}
-	backend, nodeID, _, errno := m.resolveBackendNode(guestPath)
+	backend, nodeID, errno := m.resolveBackendNodeCached(node.path)
 	if errno != 0 {
 		return FuseAttr{}, errno
 	}
 	return backend.GetAttr(nodeID)
+}
+
+func (m *mountedFS) resolveBackendNodeCached(guestPath string) (FSBackend, uint64, int32) {
+	guestPath = cleanMountPath(guestPath)
+	if guestPath == "/" {
+		return m.root, 1, 0
+	}
+	if node := m.nodeForPath(guestPath); node != nil && node.backendResolved {
+		return node.backend, node.backendNodeID, 0
+	}
+	backend, nodeID, _, errno := m.resolveBackendNode(guestPath)
+	return backend, nodeID, errno
 }
 
 func (m *mountedFS) resolveBackendNode(guestPath string) (FSBackend, uint64, *shareMount, int32) {

--- a/internal/virtio/mountfs_test.go
+++ b/internal/virtio/mountfs_test.go
@@ -46,3 +46,91 @@ func TestMountedFSAddShareExposesFiles(t *testing.T) {
 		t.Fatalf("Read() = %q, want %q", string(data), "hello from share\n")
 	}
 }
+
+func TestMountedFSCreateUsesReturnedBackendNodeID(t *testing.T) {
+	t.Parallel()
+
+	share := &createOnlyFS{
+		backendNodeID: 99,
+		backendFH:     7,
+	}
+	backend := NewMountedFS(NewPassthroughFS(t.TempDir(), nil), []ShareMount{{
+		GuestPath: "/work",
+		Backend:   share,
+		Writable:  true,
+	}})
+
+	workID, _, errno := backend.Lookup(1, "work")
+	if errno != 0 {
+		t.Fatalf("Lookup(work) errno = %d", errno)
+	}
+	nodeID, fh, _, errno := backend.(fsCreateBackend).Create(workID, "created.txt", linuxOWRONLY|linuxOCREAT, 0o644)
+	if errno != 0 {
+		t.Fatalf("Create() errno = %d", errno)
+	}
+	if nodeID == 0 || fh == 0 {
+		t.Fatalf("Create() = node %d fh %d, want non-zero mounted IDs", nodeID, fh)
+	}
+	if share.lookupCalls != 0 {
+		t.Fatalf("Create() performed %d backend lookups after create, want 0", share.lookupCalls)
+	}
+	if wrote, errno := backend.(fsWriteBackend).Write(nodeID, fh, 0, []byte("ok"), 0); errno != 0 || wrote != 2 {
+		t.Fatalf("Write() = (%d, %d), want (2, 0)", wrote, errno)
+	}
+}
+
+type createOnlyFS struct {
+	backendNodeID uint64
+	backendFH     uint64
+	lookupCalls   int
+}
+
+func (f *createOnlyFS) Init() (uint32, uint32) { return 128 << 10, 0 }
+
+func (f *createOnlyFS) GetAttr(nodeID uint64) (FuseAttr, int32) {
+	return FuseAttr{Ino: nodeID, Mode: linuxSIFDIR | 0o755, NLink: 2}, 0
+}
+
+func (f *createOnlyFS) Lookup(parent uint64, name string) (uint64, FuseAttr, int32) {
+	f.lookupCalls++
+	return 0, FuseAttr{}, -linuxENOENT
+}
+
+func (f *createOnlyFS) Open(nodeID uint64, flags uint32) (uint64, int32) {
+	return 0, -linuxENOENT
+}
+
+func (f *createOnlyFS) Release(nodeID uint64, fh uint64) {}
+
+func (f *createOnlyFS) Read(nodeID uint64, fh uint64, off uint64, size uint32) ([]byte, int32) {
+	return nil, -linuxENOENT
+}
+
+func (f *createOnlyFS) OpenDir(nodeID uint64, flags uint32) (uint64, int32) {
+	return 0, -linuxENOENT
+}
+
+func (f *createOnlyFS) ReadDir(nodeID uint64, fh uint64, off uint64, maxBytes uint32) ([]byte, int32) {
+	return nil, -linuxENOENT
+}
+
+func (f *createOnlyFS) ReleaseDir(nodeID uint64, fh uint64) {}
+
+func (f *createOnlyFS) Readlink(nodeID uint64) (string, int32) {
+	return "", -linuxENOENT
+}
+
+func (f *createOnlyFS) StatFS(nodeID uint64) (blocks, bfree, bavail, files, ffree, bsize, frsize, namelen uint64, errno int32) {
+	return 0, 0, 0, 0, 0, 4096, 4096, 255, 0
+}
+
+func (f *createOnlyFS) Create(parent uint64, name string, flags uint32, mode uint32) (uint64, uint64, FuseAttr, int32) {
+	return f.backendNodeID, f.backendFH, FuseAttr{Ino: f.backendNodeID, Mode: linuxSIFREG | mode, NLink: 1}, 0
+}
+
+func (f *createOnlyFS) Write(nodeID uint64, fh uint64, off uint64, data []byte, flags uint32) (uint32, int32) {
+	if nodeID != f.backendNodeID || fh != f.backendFH {
+		return 0, -linuxEBADF
+	}
+	return uint32(len(data)), 0
+}

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -41,9 +41,6 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if b == nil || b.kernel == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
-	if req.CPUs > 1 {
-		return nil, fmt.Errorf("linux amd64 runtime currently supports only 1 CPU")
-	}
 	kernel, err := b.kernel.ReadKernel()
 	if err != nil {
 		return nil, err
@@ -83,7 +80,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
 	}
-	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, onEvent)
+	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.CPUs, req.Dmesg, fsdevs, onEvent)
 	if err != nil {
 		return nil, err
 	}
@@ -105,9 +102,6 @@ func (b *runtimeBackend) StartBlank(ctx context.Context, req client.StartInstanc
 func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
 	if b == nil || b.kernel == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
-	}
-	if req.CPUs > 1 {
-		return nil, fmt.Errorf("linux amd64 runtime currently supports only 1 CPU")
 	}
 	kernel, err := b.kernel.ReadKernel()
 	if err != nil {
@@ -136,7 +130,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
 	}
-	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, onEvent)
+	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.CPUs, req.Dmesg, fsdevs, onEvent)
 	if err != nil {
 		return nil, err
 	}
@@ -153,9 +147,6 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client.ExecResponse, error) {
 	if b == nil || b.kernel == nil {
 		return client.ExecResponse{}, fmt.Errorf("runtime backend is not configured")
-	}
-	if req.CPUs > 1 {
-		return client.ExecResponse{}, fmt.Errorf("linux amd64 runtime currently supports only 1 CPU")
 	}
 	kernel, err := b.kernel.ReadKernel()
 	if err != nil {
@@ -243,7 +234,7 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 			Cols:    req.Cols,
 			Rows:    req.Rows,
 		}
-		resp, serial, err := kvm.RunManagedExecWithFS(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, execReq)
+		resp, serial, err := kvm.RunManagedExecWithFS(ctx, kernel, initrd, req.MemoryMB, req.CPUs, req.Dmesg, fsdevs, execReq)
 		if err != nil && resp.Output == "" {
 			resp.Output = serial
 		}

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -93,6 +93,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		baseEnv: vmruntime.WithDefaultEnv(image.Config.Env),
 		workDir: workDir,
 		rootFS:  rootFS,
+		fsdevs:  fsdevs,
 		dmesg:   req.Dmesg,
 	}, nil
 }
@@ -144,6 +145,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		baseEnv: vmruntime.WithDefaultEnv(nil),
 		workDir: "/",
 		rootFS:  rootFS,
+		fsdevs:  fsdevs,
 		dmesg:   req.Dmesg,
 	}, nil
 }
@@ -431,10 +433,25 @@ type linuxInstance struct {
 	baseEnv     []string
 	workDir     string
 	rootFS      virtio.ShareMounter
+	fsdevs      []*virtio.FS
 	dmesg       bool
 	shareMu     sync.Mutex
 	shares      map[string]client.ShareMount
 	imageMounts map[string]string
+}
+
+func (i *linuxInstance) VirtioFSStats() []virtio.FSStats {
+	if i == nil || len(i.fsdevs) == 0 {
+		return nil
+	}
+	out := make([]virtio.FSStats, 0, len(i.fsdevs))
+	for _, fsdev := range i.fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		out = append(out, fsdev.Stats())
+	}
+	return out
 }
 
 func (i *linuxInstance) Exec(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -12,6 +12,7 @@ import (
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/hv"
+	"j5.nz/cc/internal/virtio"
 )
 
 const DefaultInstanceID = "default"
@@ -33,6 +34,10 @@ type Instance interface {
 	ExecStream(context.Context, client.ExecRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
 	Wait() error
 	Close() error
+}
+
+type virtioFSStatsProvider interface {
+	VirtioFSStats() []virtio.FSStats
 }
 
 type Manager struct {
@@ -348,6 +353,20 @@ func (m *Manager) StatusOf(id string) client.InstanceState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.statusLocked(id)
+}
+
+func (m *Manager) VirtioFSStats(id string) []virtio.FSStats {
+	id = instanceID(id)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.running == nil || m.running[id] == nil || m.running[id].instance == nil {
+		return nil
+	}
+	provider, ok := m.running[id].instance.(virtioFSStatsProvider)
+	if !ok {
+		return nil
+	}
+	return provider.VirtioFSStats()
 }
 
 func (m *Manager) Statuses() []client.InstanceState {

--- a/tools/fs_benchmark.py
+++ b/tools/fs_benchmark.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Benchmark host filesystem performance against CrumbleCracker shared I/O.
+
+The benchmark runs the same Python workload twice:
+
+1. directly on the host
+2. inside a CrumbleCracker VM against a writable shared host directory
+
+It is intentionally focused on patterns that show up in the fulltest data:
+many small files, metadata-heavy loops, sequential large-file I/O, and random
+4 KiB I/O inside a large file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYNEURODESK_SRC = REPO_ROOT / "pyneurodesk" / "src"
+if str(PYNEURODESK_SRC) not in sys.path:
+    sys.path.insert(0, str(PYNEURODESK_SRC))
+
+
+BENCHMARK_PROGRAM = r'''
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import random
+import shutil
+import time
+from pathlib import Path
+
+
+def now() -> float:
+    return time.perf_counter()
+
+
+def mb(value: float) -> float:
+    return value / (1024 * 1024)
+
+
+def timed(name: str, fn):
+    start = now()
+    extra = fn()
+    duration = now() - start
+    result = {"name": name, "seconds": duration}
+    if extra:
+        result.update(extra)
+    return result
+
+
+def write_all(path: Path, data: bytes) -> None:
+    with path.open("wb") as handle:
+        handle.write(data)
+
+
+def read_all(path: Path) -> int:
+    total = 0
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+    return total
+
+
+def fsync_file(path: Path) -> None:
+    with path.open("rb") as handle:
+        os.fsync(handle.fileno())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--work-dir", required=True)
+    parser.add_argument("--small-files", type=int, required=True)
+    parser.add_argument("--small-size", type=int, required=True)
+    parser.add_argument("--large-mb", type=int, required=True)
+    parser.add_argument("--block-kb", type=int, required=True)
+    parser.add_argument("--random-ops", type=int, required=True)
+    parser.add_argument("--random-block-kb", type=int, required=True)
+    parser.add_argument("--fsync", action="store_true")
+    parser.add_argument(
+        "--only",
+        choices=[
+            "small_create",
+            "small_stat",
+            "small_read",
+            "small_delete",
+            "large_sequential_write",
+            "large_sequential_read",
+            "large_random_read",
+            "large_random_write",
+        ],
+        action="append",
+        help="Run only the named benchmark section. Can be repeated.",
+    )
+    parser.add_argument("--label", required=True)
+    args = parser.parse_args()
+
+    root = Path(args.work_dir).resolve()
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True)
+
+    small_dir = root / "small"
+    small_dir.mkdir()
+    small_payload = b"x" * args.small_size
+    small_paths = [small_dir / f"file-{index:06d}.bin" for index in range(args.small_files)]
+
+    results = []
+    only = set(args.only or [])
+
+    def wants(name: str) -> bool:
+        return not only or name in only
+
+    if wants("small_create"):
+        results.append(timed("small_create", lambda: (
+        [write_all(path, small_payload) for path in small_paths],
+        {"files": args.small_files, "bytes": args.small_files * args.small_size},
+    )[1]))
+
+    if args.fsync and small_paths and wants("small_fsync_each"):
+        results.append(timed("small_fsync_each", lambda: (
+            [fsync_file(path) for path in small_paths],
+            {"files": args.small_files},
+        )[1]))
+
+    if wants("small_stat"):
+        results.append(timed("small_stat", lambda: {
+        "files": args.small_files,
+        "bytes": sum(path.stat().st_size for path in small_paths),
+    }))
+
+    if wants("small_read"):
+        results.append(timed("small_read", lambda: {
+        "files": args.small_files,
+        "bytes": sum(len(path.read_bytes()) for path in small_paths),
+    }))
+
+    if wants("small_delete"):
+        results.append(timed("small_delete", lambda: (
+        [path.unlink() for path in small_paths],
+        {"files": args.small_files},
+    )[1]))
+
+    large_path = root / "large.bin"
+    large_bytes = args.large_mb * 1024 * 1024
+    block = b"a" * (args.block_kb * 1024)
+    blocks = large_bytes // len(block)
+
+    def large_write() -> dict[str, int]:
+        with large_path.open("wb") as handle:
+            for _ in range(blocks):
+                handle.write(block)
+            remaining = large_bytes - blocks * len(block)
+            if remaining:
+                handle.write(block[:remaining])
+            if args.fsync:
+                os.fsync(handle.fileno())
+        return {"bytes": large_bytes}
+
+    if wants("large_sequential_write") or wants("large_sequential_read") or wants("large_random_read") or wants("large_random_write"):
+        if wants("large_sequential_write"):
+            results.append(timed("large_sequential_write", large_write))
+        else:
+            large_write()
+    if wants("large_sequential_read"):
+        results.append(timed("large_sequential_read", lambda: {"bytes": read_all(large_path)}))
+
+    random_block = b"r" * (args.random_block_kb * 1024)
+    max_offset = max(0, large_bytes - len(random_block))
+    offsets = [
+        random.randrange(0, max_offset + 1) if max_offset else 0
+        for _ in range(args.random_ops)
+    ]
+
+    def random_reads() -> dict[str, int]:
+        total = 0
+        with large_path.open("rb", buffering=0) as handle:
+            fd = handle.fileno()
+            for offset in offsets:
+                total += len(os.pread(fd, len(random_block), offset))
+        return {"ops": args.random_ops, "bytes": total}
+
+    def random_writes() -> dict[str, int]:
+        with large_path.open("r+b", buffering=0) as handle:
+            fd = handle.fileno()
+            for offset in offsets:
+                os.pwrite(fd, random_block, offset)
+            if args.fsync:
+                os.fsync(fd)
+        return {"ops": args.random_ops, "bytes": args.random_ops * len(random_block)}
+
+    if wants("large_random_read"):
+        results.append(timed("large_random_read", random_reads))
+    if wants("large_random_write"):
+        results.append(timed("large_random_write", random_writes))
+
+    for result in results:
+        seconds = result["seconds"]
+        bytes_value = result.get("bytes")
+        ops_value = result.get("ops") or result.get("files")
+        if bytes_value and seconds > 0:
+            result["mib_per_second"] = mb(bytes_value) / seconds
+        if ops_value and seconds > 0:
+            result["ops_per_second"] = ops_value / seconds
+
+    print(json.dumps({
+        "label": args.label,
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "work_dir": str(root),
+        "parameters": {
+            "small_files": args.small_files,
+            "small_size": args.small_size,
+            "large_mb": args.large_mb,
+            "block_kb": args.block_kb,
+            "random_ops": args.random_ops,
+            "random_block_kb": args.random_block_kb,
+            "fsync": args.fsync,
+            "only": sorted(only),
+        },
+        "results": results,
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark filesystem workloads on the host and inside CrumbleCracker."
+    )
+    parser.add_argument("--image-name", default="fsbench-python", help="CrumbleCracker image cache name")
+    parser.add_argument(
+        "--image-source",
+        default="python:3.12-alpine",
+        help="OCI image, local .simg/.sif, or CVMFS URL containing python3",
+    )
+    parser.add_argument("--cache-dir", type=Path, default=REPO_ROOT / ".tmp-fs-benchmark" / "cache")
+    parser.add_argument("--work-dir", type=Path, default=REPO_ROOT / ".tmp-fs-benchmark" / "work")
+    parser.add_argument("--ccvm", type=Path, default=None, help="Path to ccvm; built automatically when omitted")
+    parser.add_argument("--no-build-ccvm", action="store_true", help="Do not build ccvm automatically")
+    parser.add_argument("--memory-mb", type=int, default=2048)
+    parser.add_argument("--cpus", type=int, default=None)
+    parser.add_argument("--boot-timeout", type=float, default=60.0)
+    parser.add_argument("--small-files", type=int, default=5000)
+    parser.add_argument("--small-size", type=int, default=1024)
+    parser.add_argument("--large-mb", type=int, default=256)
+    parser.add_argument("--block-kb", type=int, default=1024)
+    parser.add_argument("--random-ops", type=int, default=8192)
+    parser.add_argument("--random-block-kb", type=int, default=4)
+    parser.add_argument("--fsync", action="store_true", help="Call fsync during write tests")
+    parser.add_argument(
+        "--only",
+        action="append",
+        help="Run only the named benchmark section. Can be repeated. Example: --only small_create",
+    )
+    parser.add_argument(
+        "--pprof-cpu-profile",
+        type=Path,
+        default=None,
+        help="Write a Go CPU profile from ccvm while the guest benchmark runs",
+    )
+    parser.add_argument("--pprof-seconds", type=int, default=35, help="CPU profile duration in seconds")
+    parser.add_argument("--keep-work-dir", action="store_true")
+    parser.add_argument("--output", type=Path, default=REPO_ROOT / "fs_benchmark_results.json")
+    return parser.parse_args()
+
+
+def source_type(source: str) -> str:
+    lowered = source.lower()
+    if lowered.endswith((".simg", ".sif")):
+        return "simg"
+    if lowered.startswith(("cvmfs://", "http+cvmfs://")) or "/cvmfs/" in lowered:
+        return "cvmfs"
+    return "oci"
+
+
+def ensure_ccvm(args: argparse.Namespace) -> Path | None:
+    if args.ccvm is not None:
+        path = args.ccvm.expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(path)
+        os.environ["PYNEURODESK_CCVM"] = str(path)
+        return path
+    for env_name in ("PYNEURODESK_CCVM", "CCX3_CCVM", "CCVM_BINARY"):
+        value = os.environ.get(env_name)
+        if value and Path(value).expanduser().exists():
+            return Path(value).expanduser().resolve()
+    if args.no_build_ccvm:
+        return None
+    out = REPO_ROOT / ".tmp-fs-benchmark" / "bin" / ("ccvm.exe" if os.name == "nt" else "ccvm")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[fsbench] building ccvm -> {out}", file=sys.stderr)
+    subprocess.run(["go", "build", "-tags", "embed_guestinit", "-o", str(out), "./cmd/ccvm"], cwd=REPO_ROOT, check=True)
+    os.environ["PYNEURODESK_CCVM"] = str(out)
+    return out
+
+
+def benchmark_args(label: str, work_dir: str, args: argparse.Namespace) -> list[str]:
+    command = [
+        "--label", label,
+        "--work-dir", work_dir,
+        "--small-files", str(args.small_files),
+        "--small-size", str(args.small_size),
+        "--large-mb", str(args.large_mb),
+        "--block-kb", str(args.block_kb),
+        "--random-ops", str(args.random_ops),
+        "--random-block-kb", str(args.random_block_kb),
+    ]
+    if args.fsync:
+        command.append("--fsync")
+    for name in args.only or []:
+        command.extend(["--only", name])
+    return command
+
+
+def start_cpu_profile(base_url: str, output: Path, seconds: int) -> threading.Thread:
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    def worker() -> None:
+        url = f"{base_url.rstrip('/')}/debug/pprof/profile?seconds={seconds}"
+        with urllib.request.urlopen(url, timeout=seconds + 15) as response:
+            output.write_bytes(response.read())
+
+    thread = threading.Thread(target=worker, name="ccvm-pprof-cpu", daemon=True)
+    thread.start()
+    return thread
+
+
+def fetch_virtiofs_stats(base_url: str) -> Any:
+    url = f"{base_url.rstrip('/')}/debug/virtiofs"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def diff_virtiofs_stats(before: Any, after: Any) -> Any:
+    if not isinstance(before, list) or not isinstance(after, list):
+        return None
+    before_by_tag = {item.get("tag", ""): item for item in before if isinstance(item, dict)}
+    out = []
+    for after_item in after:
+        if not isinstance(after_item, dict):
+            continue
+        tag = after_item.get("tag", "")
+        before_item = before_by_tag.get(tag, {})
+        delta = {
+            "tag": tag,
+            "mmio_reads": int(after_item.get("mmio_reads", 0)) - int(before_item.get("mmio_reads", 0)),
+            "mmio_writes": int(after_item.get("mmio_writes", 0)) - int(before_item.get("mmio_writes", 0)),
+            "fuse_requests": int(after_item.get("fuse_requests", 0)) - int(before_item.get("fuse_requests", 0)),
+            "interrupt_raises": int(after_item.get("interrupt_raises", 0)) - int(before_item.get("interrupt_raises", 0)),
+            "irq_transitions": int(after_item.get("irq_transitions", 0)) - int(before_item.get("irq_transitions", 0)),
+            "queue_notifies": [
+                int(after_item.get("queue_notifies", [0, 0])[0]) - int(before_item.get("queue_notifies", [0, 0])[0]),
+                int(after_item.get("queue_notifies", [0, 0])[1]) - int(before_item.get("queue_notifies", [0, 0])[1]),
+            ],
+            "fuse_ops": [],
+        }
+        before_ops = {
+            op.get("opcode"): op
+            for op in before_item.get("fuse_ops", [])
+            if isinstance(op, dict)
+        }
+        for after_op in after_item.get("fuse_ops", []):
+            if not isinstance(after_op, dict):
+                continue
+            opcode = after_op.get("opcode")
+            before_op = before_ops.get(opcode, {})
+            count = int(after_op.get("count", 0)) - int(before_op.get("count", 0))
+            total_nanos = int(after_op.get("total_nanos", 0)) - int(before_op.get("total_nanos", 0))
+            max_nanos = int(after_op.get("max_nanos", 0))
+            delta["fuse_ops"].append({
+                "opcode": opcode,
+                "name": after_op.get("name"),
+                "count": count,
+                "total_nanos": total_nanos,
+                "average_nanos": total_nanos // count if count else 0,
+                "max_nanos_after": max_nanos,
+            })
+        delta["fuse_ops"].sort(key=lambda op: op["count"], reverse=True)
+        out.append(delta)
+    return out
+
+
+def run_host(args: argparse.Namespace) -> dict[str, Any]:
+    host_root = args.work_dir / "host"
+    print(f"[fsbench] running host benchmark in {host_root}", file=sys.stderr)
+    proc = subprocess.run(
+        [sys.executable, "-c", BENCHMARK_PROGRAM, *benchmark_args("host", str(host_root), args)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def run_guest(args: argparse.Namespace) -> dict[str, Any]:
+    from pyneurodesk.api import start_daemon_for_cache_dir
+    from pyneurodesk.client import PyNeurodeskClient
+    from pyneurodesk.models import ImageSource, ImportImageRequest, ShareMount
+
+    guest_host_root = args.work_dir / "guest-share"
+    guest_host_root.mkdir(parents=True, exist_ok=True)
+    guest_script = guest_host_root / "fsbench_guest.py"
+    guest_script.write_text(BENCHMARK_PROGRAM)
+    mount = "/.share/fsbench"
+    guest_script_path = f"{mount}/fsbench_guest.py"
+    guest_work = f"{mount}/bench"
+
+    if args.pprof_cpu_profile is not None:
+        os.environ["CCX3_PPROF"] = "1"
+    print(f"[fsbench] starting ccvm daemon with cache {args.cache_dir}", file=sys.stderr)
+    state = start_daemon_for_cache_dir(args.cache_dir)
+    client = PyNeurodeskClient(state.base_url)
+    try:
+        if client.get_image(args.image_name) is None:
+            print(f"[fsbench] importing {args.image_name} from {args.image_source}", file=sys.stderr)
+            client.import_image(
+                args.image_name,
+                ImportImageRequest(
+                    source=ImageSource(type=source_type(args.image_source), path=args.image_source)
+                ),
+            )
+        print("[fsbench] preparing kernel, emulator, and image metadata", file=sys.stderr)
+        client.download_kernel()
+        client.prepare_image_emulator(args.image_name)
+        client.prepare_image_metadata(args.image_name)
+        print(f"[fsbench] starting VM for {args.image_name}", file=sys.stderr)
+        client.ensure_instance(
+            args.image_name,
+            timeout=args.boot_timeout,
+            memory_mb=args.memory_mb,
+            cpus=args.cpus,
+        )
+        stats_before = fetch_virtiofs_stats(str(client._client.base_url))
+        print(f"[fsbench] running guest benchmark in {guest_work}", file=sys.stderr)
+        profile_thread = None
+        if args.pprof_cpu_profile is not None:
+            print(
+                f"[fsbench] collecting ccvm CPU profile for {args.pprof_seconds}s -> {args.pprof_cpu_profile}",
+                file=sys.stderr,
+            )
+            profile_thread = start_cpu_profile(str(client._client.base_url), args.pprof_cpu_profile, args.pprof_seconds)
+            time.sleep(0.5)
+        result = client.run(
+            args.image_name,
+            ["python3", guest_script_path, *benchmark_args("crumblecracker", guest_work, args)],
+            shares=[ShareMount(source=str(guest_host_root.resolve()), mount=mount, writable=True)],
+            timeout=None,
+        )
+        if profile_thread is not None:
+            profile_thread.join(timeout=args.pprof_seconds + 20)
+        if result.exit_code != 0:
+            raise RuntimeError(f"guest benchmark failed with exit {result.exit_code}:\n{result.output}")
+        payload = json.loads(result.output)
+        stats_after = fetch_virtiofs_stats(str(client._client.base_url))
+        payload["virtiofs_stats_before"] = stats_before
+        payload["virtiofs_stats_after"] = stats_after
+        payload["virtiofs_stats_delta"] = diff_virtiofs_stats(stats_before, stats_after)
+        return payload
+    finally:
+        client.close()
+
+
+def summarize(host: dict[str, Any], guest: dict[str, Any]) -> list[dict[str, Any]]:
+    host_by_name = {item["name"]: item for item in host["results"]}
+    out = []
+    for guest_item in guest["results"]:
+        name = guest_item["name"]
+        host_item = host_by_name[name]
+        host_seconds = float(host_item["seconds"])
+        guest_seconds = float(guest_item["seconds"])
+        ratio = guest_seconds / host_seconds if host_seconds > 0 else None
+        out.append({
+            "name": name,
+            "host_seconds": host_seconds,
+            "crumblecracker_seconds": guest_seconds,
+            "ratio": ratio,
+            "overhead_percent": (ratio - 1.0) * 100.0 if ratio is not None else None,
+            "host_mib_per_second": host_item.get("mib_per_second"),
+            "crumblecracker_mib_per_second": guest_item.get("mib_per_second"),
+            "host_ops_per_second": host_item.get("ops_per_second"),
+            "crumblecracker_ops_per_second": guest_item.get("ops_per_second"),
+        })
+    return out
+
+
+def print_summary(summary: list[dict[str, Any]]) -> None:
+    print()
+    print("Filesystem benchmark summary")
+    print("----------------------------")
+    print(f"{'test':<28} {'host(s)':>10} {'cc(s)':>10} {'ratio':>9} {'overhead':>10}")
+    for item in summary:
+        ratio = item["ratio"]
+        overhead = item["overhead_percent"]
+        print(
+            f"{item['name']:<28} "
+            f"{item['host_seconds']:>10.3f} "
+            f"{item['crumblecracker_seconds']:>10.3f} "
+            f"{ratio:>9.2f} "
+            f"{overhead:>9.1f}%"
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    args.cache_dir = args.cache_dir.expanduser().resolve()
+    args.work_dir = args.work_dir.expanduser().resolve()
+    args.output = args.output.expanduser().resolve()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+
+    ensure_ccvm(args)
+    started = time.time()
+    host = run_host(args)
+    guest = run_guest(args)
+    summary = summarize(host, guest)
+    payload = {
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "elapsed_seconds": time.time() - started,
+        "host": host,
+        "crumblecracker": guest,
+        "summary": summary,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print_summary(summary)
+    print(f"\nwrote {args.output}")
+
+    if not args.keep_work_dir:
+        shutil.rmtree(args.work_dir / "host", ignore_errors=True)
+        shutil.rmtree(args.work_dir / "guest-share", ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fs_benchmark.py
+++ b/tools/fs_benchmark.py
@@ -14,6 +14,7 @@ many small files, metadata-heavy loops, sequential large-file I/O, and random
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import platform
@@ -38,6 +39,7 @@ BENCHMARK_PROGRAM = r'''
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import platform
@@ -63,6 +65,19 @@ def timed(name: str, fn):
     if extra:
         result.update(extra)
     return result
+
+
+def partition(items, parts: int):
+    parts = max(1, parts)
+    return [items[index::parts] for index in range(parts)]
+
+
+def run_parallel(items, workers: int, fn):
+    chunks = [chunk for chunk in partition(items, workers) if chunk]
+    if len(chunks) <= 1:
+        return [fn(chunks[0] if chunks else [])]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(chunks)) as executor:
+        return list(executor.map(fn, chunks))
 
 
 def write_all(path: Path, data: bytes) -> None:
@@ -95,6 +110,7 @@ def main() -> None:
     parser.add_argument("--block-kb", type=int, required=True)
     parser.add_argument("--random-ops", type=int, required=True)
     parser.add_argument("--random-block-kb", type=int, required=True)
+    parser.add_argument("--threads", type=int, default=1)
     parser.add_argument("--fsync", action="store_true")
     parser.add_argument(
         "--only",
@@ -123,6 +139,7 @@ def main() -> None:
     small_dir.mkdir()
     small_payload = b"x" * args.small_size
     small_paths = [small_dir / f"file-{index:06d}.bin" for index in range(args.small_files)]
+    threads = max(1, args.threads)
 
     results = []
     only = set(args.only or [])
@@ -131,34 +148,52 @@ def main() -> None:
         return not only or name in only
 
     if wants("small_create"):
-        results.append(timed("small_create", lambda: (
-        [write_all(path, small_payload) for path in small_paths],
-        {"files": args.small_files, "bytes": args.small_files * args.small_size},
-    )[1]))
+        def small_create() -> dict[str, int]:
+            def worker(paths):
+                for path in paths:
+                    write_all(path, small_payload)
+            run_parallel(small_paths, threads, worker)
+            return {"files": args.small_files, "bytes": args.small_files * args.small_size, "threads": threads}
+
+        results.append(timed("small_create", small_create))
 
     if args.fsync and small_paths and wants("small_fsync_each"):
-        results.append(timed("small_fsync_each", lambda: (
-            [fsync_file(path) for path in small_paths],
-            {"files": args.small_files},
-        )[1]))
+        def small_fsync_each() -> dict[str, int]:
+            def worker(paths):
+                for path in paths:
+                    fsync_file(path)
+            run_parallel(small_paths, threads, worker)
+            return {"files": args.small_files, "threads": threads}
+
+        results.append(timed("small_fsync_each", small_fsync_each))
 
     if wants("small_stat"):
-        results.append(timed("small_stat", lambda: {
-        "files": args.small_files,
-        "bytes": sum(path.stat().st_size for path in small_paths),
-    }))
+        def small_stat() -> dict[str, int]:
+            def worker(paths):
+                return sum(path.stat().st_size for path in paths)
+            total = sum(run_parallel(small_paths, threads, worker))
+            return {"files": args.small_files, "bytes": total, "threads": threads}
+
+        results.append(timed("small_stat", small_stat))
 
     if wants("small_read"):
-        results.append(timed("small_read", lambda: {
-        "files": args.small_files,
-        "bytes": sum(len(path.read_bytes()) for path in small_paths),
-    }))
+        def small_read() -> dict[str, int]:
+            def worker(paths):
+                return sum(len(path.read_bytes()) for path in paths)
+            total = sum(run_parallel(small_paths, threads, worker))
+            return {"files": args.small_files, "bytes": total, "threads": threads}
+
+        results.append(timed("small_read", small_read))
 
     if wants("small_delete"):
-        results.append(timed("small_delete", lambda: (
-        [path.unlink() for path in small_paths],
-        {"files": args.small_files},
-    )[1]))
+        def small_delete() -> dict[str, int]:
+            def worker(paths):
+                for path in paths:
+                    path.unlink()
+            run_parallel(small_paths, threads, worker)
+            return {"files": args.small_files, "threads": threads}
+
+        results.append(timed("small_delete", small_delete))
 
     large_path = root / "large.bin"
     large_bytes = args.large_mb * 1024 * 1024
@@ -192,21 +227,26 @@ def main() -> None:
     ]
 
     def random_reads() -> dict[str, int]:
-        total = 0
-        with large_path.open("rb", buffering=0) as handle:
-            fd = handle.fileno()
-            for offset in offsets:
-                total += len(os.pread(fd, len(random_block), offset))
-        return {"ops": args.random_ops, "bytes": total}
+        def worker(chunk):
+            total = 0
+            with large_path.open("rb", buffering=0) as handle:
+                fd = handle.fileno()
+                for offset in chunk:
+                    total += len(os.pread(fd, len(random_block), offset))
+            return total
+        total = sum(run_parallel(offsets, threads, worker))
+        return {"ops": args.random_ops, "bytes": total, "threads": threads}
 
     def random_writes() -> dict[str, int]:
-        with large_path.open("r+b", buffering=0) as handle:
-            fd = handle.fileno()
-            for offset in offsets:
-                os.pwrite(fd, random_block, offset)
-            if args.fsync:
-                os.fsync(fd)
-        return {"ops": args.random_ops, "bytes": args.random_ops * len(random_block)}
+        def worker(chunk):
+            with large_path.open("r+b", buffering=0) as handle:
+                fd = handle.fileno()
+                for offset in chunk:
+                    os.pwrite(fd, random_block, offset)
+                if args.fsync:
+                    os.fsync(fd)
+        run_parallel(offsets, threads, worker)
+        return {"ops": args.random_ops, "bytes": args.random_ops * len(random_block), "threads": threads}
 
     if wants("large_random_read"):
         results.append(timed("large_random_read", random_reads))
@@ -234,6 +274,7 @@ def main() -> None:
             "block_kb": args.block_kb,
             "random_ops": args.random_ops,
             "random_block_kb": args.random_block_kb,
+            "threads": threads,
             "fsync": args.fsync,
             "only": sorted(only),
         },
@@ -269,6 +310,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--block-kb", type=int, default=1024)
     parser.add_argument("--random-ops", type=int, default=8192)
     parser.add_argument("--random-block-kb", type=int, default=4)
+    parser.add_argument("--threads", type=int, default=1, help="Filesystem worker threads inside each benchmark process")
     parser.add_argument("--fsync", action="store_true", help="Call fsync during write tests")
     parser.add_argument(
         "--only",
@@ -327,6 +369,7 @@ def benchmark_args(label: str, work_dir: str, args: argparse.Namespace) -> list[
         "--block-kb", str(args.block_kb),
         "--random-ops", str(args.random_ops),
         "--random-block-kb", str(args.random_block_kb),
+        "--threads", str(args.threads),
     ]
     if args.fsync:
         command.append("--fsync")
@@ -374,10 +417,10 @@ def diff_virtiofs_stats(before: Any, after: Any) -> Any:
             "fuse_requests": int(after_item.get("fuse_requests", 0)) - int(before_item.get("fuse_requests", 0)),
             "interrupt_raises": int(after_item.get("interrupt_raises", 0)) - int(before_item.get("interrupt_raises", 0)),
             "irq_transitions": int(after_item.get("irq_transitions", 0)) - int(before_item.get("irq_transitions", 0)),
-            "queue_notifies": [
-                int(after_item.get("queue_notifies", [0, 0])[0]) - int(before_item.get("queue_notifies", [0, 0])[0]),
-                int(after_item.get("queue_notifies", [0, 0])[1]) - int(before_item.get("queue_notifies", [0, 0])[1]),
-            ],
+            "queue_notifies": diff_numeric_list(
+                before_item.get("queue_notifies", []),
+                after_item.get("queue_notifies", []),
+            ),
             "fuse_ops": [],
         }
         before_ops = {
@@ -404,6 +447,18 @@ def diff_virtiofs_stats(before: Any, after: Any) -> Any:
         delta["fuse_ops"].sort(key=lambda op: op["count"], reverse=True)
         out.append(delta)
     return out
+
+
+def diff_numeric_list(before: Any, after: Any) -> list[int]:
+    if not isinstance(before, list):
+        before = []
+    if not isinstance(after, list):
+        after = []
+    count = max(len(before), len(after))
+    return [
+        int(after[index] if index < len(after) else 0) - int(before[index] if index < len(before) else 0)
+        for index in range(count)
+    ]
 
 
 def run_host(args: argparse.Namespace) -> dict[str, Any]:

--- a/tools/fs_benchmark.py
+++ b/tools/fs_benchmark.py
@@ -323,6 +323,18 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Write a Go CPU profile from ccvm while the guest benchmark runs",
     )
+    parser.add_argument(
+        "--pprof-mutex-profile",
+        type=Path,
+        default=None,
+        help="Write a Go mutex profile from ccvm after the guest benchmark runs",
+    )
+    parser.add_argument(
+        "--pprof-block-profile",
+        type=Path,
+        default=None,
+        help="Write a Go block profile from ccvm after the guest benchmark runs",
+    )
     parser.add_argument("--pprof-seconds", type=int, default=35, help="CPU profile duration in seconds")
     parser.add_argument("--keep-work-dir", action="store_true")
     parser.add_argument("--output", type=Path, default=REPO_ROOT / "fs_benchmark_results.json")
@@ -389,6 +401,13 @@ def start_cpu_profile(base_url: str, output: Path, seconds: int) -> threading.Th
     thread = threading.Thread(target=worker, name="ccvm-pprof-cpu", daemon=True)
     thread.start()
     return thread
+
+
+def fetch_pprof_profile(base_url: str, profile_name: str, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    url = f"{base_url.rstrip('/')}/debug/pprof/{profile_name}?debug=0"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        output.write_bytes(response.read())
 
 
 def fetch_virtiofs_stats(base_url: str) -> Any:
@@ -486,7 +505,11 @@ def run_guest(args: argparse.Namespace) -> dict[str, Any]:
     guest_script_path = f"{mount}/fsbench_guest.py"
     guest_work = f"{mount}/bench"
 
-    if args.pprof_cpu_profile is not None:
+    if (
+        args.pprof_cpu_profile is not None
+        or args.pprof_mutex_profile is not None
+        or args.pprof_block_profile is not None
+    ):
         os.environ["CCX3_PPROF"] = "1"
     print(f"[fsbench] starting ccvm daemon with cache {args.cache_dir}", file=sys.stderr)
     state = start_daemon_for_cache_dir(args.cache_dir)
@@ -531,6 +554,12 @@ def run_guest(args: argparse.Namespace) -> dict[str, Any]:
             profile_thread.join(timeout=args.pprof_seconds + 20)
         if result.exit_code != 0:
             raise RuntimeError(f"guest benchmark failed with exit {result.exit_code}:\n{result.output}")
+        if args.pprof_mutex_profile is not None:
+            print(f"[fsbench] collecting ccvm mutex profile -> {args.pprof_mutex_profile}", file=sys.stderr)
+            fetch_pprof_profile(str(client._client.base_url), "mutex", args.pprof_mutex_profile)
+        if args.pprof_block_profile is not None:
+            print(f"[fsbench] collecting ccvm block profile -> {args.pprof_block_profile}", file=sys.stderr)
+            fetch_pprof_profile(str(client._client.base_url), "block", args.pprof_block_profile)
         payload = json.loads(result.output)
         stats_after = fetch_virtiofs_stats(str(client._client.base_url))
         payload["virtiofs_stats_before"] = stats_before

--- a/tools/fs_benchmark.py
+++ b/tools/fs_benchmark.py
@@ -441,7 +441,13 @@ def diff_virtiofs_stats(before: Any, after: Any) -> Any:
                 after_item.get("queue_notifies", []),
             ),
             "fuse_ops": [],
+            "stages": [],
         }
+        delta["stages"] = diff_timing_stats(
+            before_item.get("stages", []),
+            after_item.get("stages", []),
+            "name",
+        )
         before_ops = {
             op.get("opcode"): op
             for op in before_item.get("fuse_ops", [])
@@ -465,6 +471,34 @@ def diff_virtiofs_stats(before: Any, after: Any) -> Any:
             })
         delta["fuse_ops"].sort(key=lambda op: op["count"], reverse=True)
         out.append(delta)
+    return out
+
+
+def diff_timing_stats(before_items: Any, after_items: Any, key_name: str) -> list[dict[str, Any]]:
+    if not isinstance(before_items, list) or not isinstance(after_items, list):
+        return []
+    before_by_key = {
+        item.get(key_name): item
+        for item in before_items
+        if isinstance(item, dict)
+    }
+    out = []
+    for after_item in after_items:
+        if not isinstance(after_item, dict):
+            continue
+        key = after_item.get(key_name)
+        before_item = before_by_key.get(key, {})
+        count = int(after_item.get("count", 0)) - int(before_item.get("count", 0))
+        total_nanos = int(after_item.get("total_nanos", 0)) - int(before_item.get("total_nanos", 0))
+        item = {
+            key_name: key,
+            "count": count,
+            "total_nanos": total_nanos,
+            "average_nanos": total_nanos // count if count else 0,
+            "max_nanos_after": int(after_item.get("max_nanos", 0)),
+        }
+        out.append(item)
+    out.sort(key=lambda item: item["total_nanos"], reverse=True)
     return out
 
 


### PR DESCRIPTION
## Summary

This PR contains the current virtio-fs performance branch:

- fixes passthrough FUSE FLUSH durability semantics and adds explicit FSYNC/FSYNCDIR handling
- removes redundant mounted create lookup work
- optimizes virtio-fs/KVM hot paths and request stats accounting
- adds amd64 SMP boot support and virtio-fs multiqueue support
- adds a threaded filesystem benchmark mode
- reduces multi-vCPU exit/device lock contention by dispatching FUSE work outside the virtio-fs device lock and removing the outer KVM deviceMu
- adds mutex/block pprof capture options to the filesystem benchmark

## Benchmark signal

Latest 4-thread / 4-vCPU filesystem benchmark, comparing against the prior lockstats baseline on this branch:

- total guest time: 4.102868534s -> 3.602877898s, about 12.2% faster
- small_create: -25.7%
- small_stat: -46.5%
- small_read: -26.1%
- small_delete: -27.8%
- large_random_read: -14.3%

The mutex profile showed the main contended lock dropping from about 460ms delay to about 5ms after the vCPU exit/device lock split.

Known caveat: large_random_write regressed in this benchmark, so follow-up work should focus on write ordering/coalescing and completion batching rather than adding a coarse write lock.

## Validation

- go test ./internal/virtio ./internal/hv/kvm ./internal/vm ./cmd/ccvm
- python3 -m py_compile tools/fs_benchmark.py
- tools/fs_benchmark.py --threads 4 --cpus 4 --memory-mb 2048
