### PR TITLE
Add FreeBSD boot and managed runtime support

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/websocket"
 	"j5.nz/cc/client"
 	intcvmfs "j5.nz/cc/internal/cvmfs"
+	freebsdrootfs "j5.nz/cc/internal/freebsd/rootfs"
 	"j5.nz/cc/internal/hv/hvf"
 	"j5.nz/cc/internal/kernel/alpine"
 	"j5.nz/cc/internal/macos"
@@ -33,6 +34,10 @@ import (
 	openbsdrootfs "j5.nz/cc/internal/openbsd/rootfs"
 	"j5.nz/cc/internal/vm"
 )
+
+func isBuiltInBSDImage(name string) bool {
+	return openbsdrootfs.IsBuiltInImage(name) || freebsdrootfs.IsBuiltInImage(name)
+}
 
 var debugTiming = strings.TrimSpace(os.Getenv("CCX3_DEBUG_TIMING")) != ""
 var debugPprof = strings.TrimSpace(os.Getenv("CCX3_DEBUG_PPROF")) != ""
@@ -1124,9 +1129,9 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 		defer cancel()
 		timingLog("POST /vm/start decode took=%s", time.Since(start))
 		var startImage *oci.Image
-		openBSDImage := openbsdrootfs.IsBuiltInImage(req.Image)
+		builtInBSDImage := isBuiltInBSDImage(req.Image)
 		if imageName := strings.TrimSpace(req.Image); imageName != "" {
-			if openBSDImage {
+			if builtInBSDImage {
 				if wantsBootEventStream(r) {
 					writeBootEvent(w, client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", imageName)})
 				}
@@ -1163,7 +1168,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 			writeError(w, http.StatusServiceUnavailable, err)
 			return
 		}
-		if !openBSDImage && srvState.kernel.Status().Status != "downloaded" {
+		if !builtInBSDImage && srvState.kernel.Status().Status != "downloaded" {
 			if wantsBootEventStream(r) {
 				writeBootEvent(w, client.BootEvent{Kind: "status", Message: "ensuring kernel is available"})
 			}
@@ -1260,8 +1265,8 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 		bootCtx, cancel := context.WithTimeout(r.Context(), bootTimeout)
 		defer cancel()
 		timingLog("POST /vm decode took=%s image=%q", time.Since(start), req.Image)
-		openBSDImage := openbsdrootfs.IsBuiltInImage(req.Image)
-		if !openBSDImage {
+		builtInBSDImage := isBuiltInBSDImage(req.Image)
+		if !builtInBSDImage {
 			if _, err := srvState.images.Get(req.Image); err != nil {
 				if wantsBootEventStream(r) {
 					writeBootEvent(w, client.BootEvent{Kind: "error", Error: fmt.Sprintf("image %q is not available", req.Image)})
@@ -1285,7 +1290,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 			writeError(w, http.StatusServiceUnavailable, err)
 			return
 		}
-		if !openBSDImage && srvState.kernel.Status().Status != "downloaded" {
+		if !builtInBSDImage && srvState.kernel.Status().Status != "downloaded" {
 			if wantsBootEventStream(r) {
 				writeBootEvent(w, client.BootEvent{Kind: "status", Message: "ensuring kernel is available"})
 			}
@@ -1408,14 +1413,14 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
-		openBSDImage := openbsdrootfs.IsBuiltInImage(req.Image)
-		if req.Image != "" && !openBSDImage {
+		builtInBSDImage := isBuiltInBSDImage(req.Image)
+		if req.Image != "" && !builtInBSDImage {
 			if _, err := srvState.images.Open(req.Image); err != nil {
 				writeError(w, http.StatusBadRequest, fmt.Errorf("image %q is not available", req.Image))
 				return
 			}
 		}
-		if !openBSDImage && srvState.kernel.Status().Status != "downloaded" && (req.Image != "" || srvState.vms.Status().Status == "running") {
+		if !builtInBSDImage && srvState.kernel.Status().Status != "downloaded" && (req.Image != "" || srvState.vms.Status().Status == "running") {
 			if err := srvState.kernel.Ensure(r.Context()); err != nil {
 				writeError(w, http.StatusInternalServerError, err)
 				return

--- a/internal/cmd/freebsd-init/main.go
+++ b/internal/cmd/freebsd-init/main.go
@@ -1,0 +1,637 @@
+//go:build freebsd
+
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	readyMarker = "__CCX3_READY__"
+	beginMarker = "__CCX3_BEGIN__:"
+	outMarker   = "__CCX3_OUT__:"
+	errMarker   = "__CCX3_ERR__:"
+	ctlMarker   = "__CCX3_CTL__:"
+	exitMarker  = "__CCX3_EXIT__:"
+)
+
+type request struct {
+	Kind      string   `json:"kind,omitempty"`
+	ID        string   `json:"id"`
+	Command   []string `json:"command,omitempty"`
+	Env       []string `json:"env,omitempty"`
+	RootDir   string   `json:"root_dir,omitempty"`
+	Path      string   `json:"path,omitempty"`
+	Directory bool     `json:"directory,omitempty"`
+	WorkDir   string   `json:"workdir,omitempty"`
+	Stdin     []byte   `json:"stdin,omitempty"`
+	TTY       bool     `json:"tty,omitempty"`
+	ControlFD bool     `json:"control_fd,omitempty"`
+	Signal    string   `json:"signal,omitempty"`
+	Cols      int      `json:"cols,omitempty"`
+	Rows      int      `json:"rows,omitempty"`
+}
+
+type managedExec struct {
+	mu      sync.Mutex
+	stdin   io.WriteCloser
+	process *os.Process
+}
+
+func (m *managedExec) write(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stdin == nil {
+		return fmt.Errorf("stdin is closed")
+	}
+	_, err := m.stdin.Write(data)
+	return err
+}
+
+func (m *managedExec) close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stdin == nil {
+		return nil
+	}
+	err := m.stdin.Close()
+	m.stdin = nil
+	return err
+}
+
+func (m *managedExec) setProcess(p *os.Process) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.process = p
+}
+
+func (m *managedExec) signal(name string) error {
+	sig, err := parseSignal(name)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.process == nil {
+		return fmt.Errorf("process is not started")
+	}
+	if m.process.Pid > 0 {
+		if err := syscall.Kill(-m.process.Pid, sig); err == nil || errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+	}
+	return m.process.Signal(sig)
+}
+
+func main() {
+	if err := run(); err != nil {
+		writeConsole("ccx3-freebsd-init: " + err.Error() + "\n")
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+}
+
+func run() error {
+	_ = os.Chdir("/")
+	conn, err := connectControl()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	writeLine(conn, readyMarker)
+	return commandLoop(conn)
+}
+
+func connectControl() (net.Conn, error) {
+	var last error
+	for i := 0; i < 80; i++ {
+		conn, err := net.DialTimeout("tcp4", "10.42.0.1:10777", time.Second)
+		if err == nil {
+			return conn, nil
+		}
+		last = err
+		time.Sleep(250 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("connect control: %w", last)
+}
+
+func commandLoop(control net.Conn) error {
+	reader := bufio.NewReader(control)
+	active := map[string]*managedExec{}
+	pending := map[string]request{}
+	var mu sync.Mutex
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			return fmt.Errorf("read request: %w", err)
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var req request
+		if err := json.Unmarshal(line, &req); err != nil {
+			writeConsole("ccx3-freebsd-init: decode request: " + err.Error() + "\n")
+			continue
+		}
+		if req.Kind == "" {
+			req.Kind = "exec"
+		}
+		switch req.Kind {
+		case "exec":
+			if req.ID == "" || len(req.Command) == 0 {
+				continue
+			}
+			if len(req.Stdin) != 0 {
+				startExecWithReader(control, req, io.NopCloser(bytes.NewReader(req.Stdin)), nil, func() {})
+				continue
+			}
+			if req.TTY || req.ControlFD {
+				stdinR, stdinW := io.Pipe()
+				managed := &managedExec{stdin: stdinW}
+				mu.Lock()
+				active[req.ID] = managed
+				mu.Unlock()
+				go runExec(control, req, stdinR, managed, func() {
+					_ = managed.close()
+					mu.Lock()
+					delete(active, req.ID)
+					mu.Unlock()
+				})
+				continue
+			}
+			mu.Lock()
+			pending[req.ID] = req
+			mu.Unlock()
+		case "sync":
+			go runSync(control, req.ID)
+		case "fs_mkdir":
+			go runMkdir(control, req)
+		case "fs_write":
+			go runWrite(control, req)
+		case "fs_extract":
+			if len(req.Stdin) > 0 {
+				go runExtract(control, req, io.NopCloser(bytes.NewReader(req.Stdin)), func() {})
+				continue
+			}
+			stdinR, stdinW := io.Pipe()
+			managed := &managedExec{stdin: stdinW}
+			mu.Lock()
+			active[req.ID] = managed
+			mu.Unlock()
+			go runExtract(control, req, stdinR, func() {
+				_ = managed.close()
+				mu.Lock()
+				delete(active, req.ID)
+				mu.Unlock()
+			})
+		case "fs_archive":
+			go runArchive(control, req)
+		case "stdin":
+			mu.Lock()
+			pendingReq, pendingOK := pending[req.ID]
+			if pendingOK {
+				delete(pending, req.ID)
+			}
+			mu.Unlock()
+			if pendingOK {
+				stdinR, stdinW := io.Pipe()
+				managed := &managedExec{stdin: stdinW}
+				mu.Lock()
+				active[req.ID] = managed
+				mu.Unlock()
+				go runExec(control, pendingReq, stdinR, managed, func() {
+					_ = managed.close()
+					mu.Lock()
+					delete(active, req.ID)
+					mu.Unlock()
+				})
+				_ = managed.write(req.Stdin)
+				continue
+			}
+			mu.Lock()
+			managed := active[req.ID]
+			mu.Unlock()
+			if managed != nil {
+				_ = managed.write(req.Stdin)
+			}
+		case "stdin_close":
+			mu.Lock()
+			pendingReq, pendingOK := pending[req.ID]
+			if pendingOK {
+				delete(pending, req.ID)
+			}
+			mu.Unlock()
+			if pendingOK {
+				startExecWithReader(control, pendingReq, io.NopCloser(bytes.NewReader(nil)), nil, func() {})
+				continue
+			}
+			mu.Lock()
+			managed := active[req.ID]
+			mu.Unlock()
+			if managed != nil {
+				_ = managed.close()
+			}
+		case "signal":
+			mu.Lock()
+			managed := active[req.ID]
+			mu.Unlock()
+			if managed != nil {
+				_ = managed.signal(req.Signal)
+			}
+		}
+	}
+}
+
+func startExecWithReader(control net.Conn, req request, stdin io.ReadCloser, managed *managedExec, cleanup func()) {
+	go runExec(control, req, stdin, managed, cleanup)
+}
+
+func runExec(control io.Writer, req request, stdin io.ReadCloser, managed *managedExec, cleanup func()) {
+	defer cleanup()
+	writeLine(control, beginMarker+req.ID)
+	cmd := exec.Command(req.Command[0], req.Command[1:]...)
+	if req.WorkDir != "" {
+		cmd.Dir = rootPath(req.RootDir, req.WorkDir)
+	}
+	if len(req.Env) != 0 {
+		cmd.Env = req.Env
+	}
+	cmd.Stdin = stdin
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var controlR, controlW *os.File
+	if req.ControlFD {
+		var err error
+		controlR, controlW, err = os.Pipe()
+		if err != nil {
+			if managed != nil {
+				_ = managed.close()
+			}
+			_ = stdoutW.Close()
+			_ = stderrW.Close()
+			writeErr(control, req.ID, fmt.Errorf("open control fd: %w", err))
+			writeLine(control, exitMarker+req.ID+":126")
+			return
+		}
+		cmd.ExtraFiles = append(cmd.ExtraFiles, controlW)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go copyMarked(&wg, control, outMarker, req.ID, stdoutR)
+	go copyMarked(&wg, control, errMarker, req.ID, stderrR)
+	if controlR != nil {
+		wg.Add(1)
+		go copyMarked(&wg, control, ctlMarker, req.ID, controlR)
+	}
+	if err := cmd.Start(); err != nil {
+		if managed != nil {
+			_ = managed.close()
+		}
+		if controlR != nil {
+			_ = controlR.Close()
+		}
+		if controlW != nil {
+			_ = controlW.Close()
+		}
+		_ = stdoutW.Close()
+		_ = stderrW.Close()
+		wg.Wait()
+		writeErr(control, req.ID, err)
+		writeLine(control, exitMarker+req.ID+":126")
+		return
+	}
+	if controlW != nil {
+		_ = controlW.Close()
+	}
+	if managed != nil {
+		managed.setProcess(cmd.Process)
+	}
+	waitErr := cmd.Wait()
+	_ = stdin.Close()
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	wg.Wait()
+	if controlR != nil {
+		_ = controlR.Close()
+	}
+	code := 0
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+		} else {
+			writeErr(control, req.ID, waitErr)
+			code = 126
+		}
+	}
+	writeLine(control, exitMarker+req.ID+":"+itoa(code))
+}
+
+func runSync(control io.Writer, id string) {
+	writeLine(control, beginMarker+id)
+	syscall.Sync()
+	writeLine(control, exitMarker+id+":0")
+}
+
+func runMkdir(control io.Writer, req request) {
+	writeLine(control, beginMarker+req.ID)
+	code := 0
+	target := rootPath(req.RootDir, firstNonEmpty(req.Path, "."))
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		writeErr(control, req.ID, err)
+		code = 1
+	}
+	writeLine(control, exitMarker+req.ID+":"+itoa(code))
+}
+
+func runWrite(control io.Writer, req request) {
+	writeLine(control, beginMarker+req.ID)
+	code := 0
+	if strings.TrimSpace(req.Path) == "" {
+		writeErr(control, req.ID, fmt.Errorf("destination path is required"))
+		code = 1
+	} else {
+		target := rootPath(req.RootDir, req.Path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			writeErr(control, req.ID, err)
+			code = 1
+		} else if err := os.WriteFile(target, req.Stdin, 0o644); err != nil {
+			writeErr(control, req.ID, err)
+			code = 1
+		}
+	}
+	writeLine(control, exitMarker+req.ID+":"+itoa(code))
+}
+
+func runExtract(control io.Writer, req request, r io.ReadCloser, cleanup func()) {
+	defer cleanup()
+	defer r.Close()
+	writeLine(control, beginMarker+req.ID)
+	code := 0
+	if err := extractTarToPath(r, req.RootDir, req.Path, req.Directory); err != nil {
+		writeErr(control, req.ID, err)
+		code = 1
+	}
+	writeLine(control, exitMarker+req.ID+":"+itoa(code))
+}
+
+func runArchive(control io.Writer, req request) {
+	writeLine(control, beginMarker+req.ID)
+	code := 0
+	if err := archivePath(control, req.ID, req.RootDir, req.Path); err != nil {
+		writeErr(control, req.ID, err)
+		code = 1
+	}
+	writeLine(control, exitMarker+req.ID+":"+itoa(code))
+}
+
+func archivePath(control io.Writer, id, rootDir, src string) error {
+	if strings.TrimSpace(src) == "" {
+		return fmt.Errorf("source path is required")
+	}
+	src = rootPath(rootDir, src)
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		err := writePathTar(pw, src, filepath.Base(src), info)
+		_ = pw.CloseWithError(err)
+	}()
+	var buf [32768]byte
+	for {
+		n, err := pr.Read(buf[:])
+		if n > 0 {
+			writeBytes(control, outMarker, id, buf[:n])
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func writePathTar(w io.Writer, src, rootName string, rootInfo os.FileInfo) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+	return filepath.WalkDir(src, func(filePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(filepath.Dir(src), filePath)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			rel = rootName
+			info = rootInfo
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(rel)
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		file, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+}
+
+func extractTarToPath(r io.Reader, rootDir, dst string, dstDir bool) error {
+	if strings.TrimSpace(dst) == "" {
+		return fmt.Errorf("destination path is required")
+	}
+	dst = rootPath(rootDir, dst)
+	if info, err := os.Stat(dst); err == nil && info.IsDir() {
+		dstDir = true
+	}
+	tr := tar.NewReader(r)
+	sawEntry := false
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			if !sawEntry {
+				return fmt.Errorf("archive is empty")
+			}
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		sawEntry = true
+		target, err := tarTarget(dst, dstDir, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode).Perm()); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(header.Mode).Perm())
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(file, tr)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		}
+	}
+}
+
+func tarTarget(dst string, dstDir bool, name string) (string, error) {
+	cleanName := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(name, "/")))
+	if cleanName == "." || cleanName == ".." || strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("unsafe tar path %q", name)
+	}
+	if dstDir {
+		return filepath.Join(dst, cleanName), nil
+	}
+	parts := strings.SplitN(cleanName, string(filepath.Separator), 2)
+	if len(parts) == 1 {
+		return dst, nil
+	}
+	return filepath.Join(dst, parts[1]), nil
+}
+
+func copyMarked(wg *sync.WaitGroup, control io.Writer, marker, id string, r io.Reader) {
+	defer wg.Done()
+	var buf [4096]byte
+	for {
+		n, err := r.Read(buf[:])
+		if n > 0 {
+			writeBytes(control, marker, id, buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func writeErr(control io.Writer, id string, err error) {
+	writeBytes(control, errMarker, id, []byte("ccx3-freebsd-init: "+err.Error()+"\n"))
+}
+
+func writeBytes(control io.Writer, marker, id string, data []byte) {
+	writeLine(control, marker+id+":"+base64.StdEncoding.EncodeToString(data))
+}
+
+var protocolMu sync.Mutex
+
+func writeLine(w io.Writer, line string) {
+	protocolMu.Lock()
+	defer protocolMu.Unlock()
+	_, _ = io.WriteString(w, line+"\n")
+}
+
+func writeConsole(s string) {
+	if console, err := os.OpenFile("/dev/console", os.O_RDWR, 0); err == nil {
+		defer console.Close()
+		_, _ = console.WriteString(s)
+		return
+	}
+	_, _ = os.Stderr.WriteString(s)
+}
+
+func rootPath(rootDir, name string) string {
+	cleanRoot := filepath.Clean("/" + strings.TrimPrefix(strings.TrimSpace(rootDir), "/"))
+	if cleanRoot == "/" {
+		cleanRoot = ""
+	}
+	cleanName := filepath.Clean("/" + strings.TrimPrefix(strings.TrimSpace(name), "/"))
+	return filepath.Join(cleanRoot, cleanName)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func parseSignal(name string) (syscall.Signal, error) {
+	switch strings.ToUpper(strings.TrimPrefix(strings.TrimSpace(name), "SIG")) {
+	case "", "TERM":
+		return syscall.SIGTERM, nil
+	case "KILL":
+		return syscall.SIGKILL, nil
+	case "INT":
+		return syscall.SIGINT, nil
+	case "HUP":
+		return syscall.SIGHUP, nil
+	default:
+		return 0, fmt.Errorf("unsupported signal %q", name)
+	}
+}
+
+func itoa(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/freebsd/boot/amd64/acpi.go
+++ b/internal/freebsd/boot/amd64/acpi.go
@@ -260,6 +260,7 @@ func buildBootFADT(facs, dsdt uint64) []byte {
 		acpiPM1EventPort   = 0x400
 		acpiPM1ControlPort = 0x404
 		fadtFlagWBINVD     = 1 << 0
+		fadtBootArchNoVGA  = 1 << 2
 	)
 	body := make([]byte, fadtBodyLength)
 	binary.LittleEndian.PutUint32(body[0:], uint32(facs))
@@ -270,6 +271,7 @@ func buildBootFADT(facs, dsdt uint64) []byte {
 	binary.LittleEndian.PutUint32(body[28:], acpiPM1ControlPort)
 	body[52] = 4
 	body[53] = 2
+	binary.LittleEndian.PutUint16(body[73:], fadtBootArchNoVGA)
 	binary.LittleEndian.PutUint32(body[76:], fadtFlagWBINVD)
 	binary.LittleEndian.PutUint64(body[96:], facs)
 	binary.LittleEndian.PutUint64(body[104:], dsdt)

--- a/internal/freebsd/boot/amd64/acpi.go
+++ b/internal/freebsd/boot/amd64/acpi.go
@@ -20,7 +20,7 @@ func installBootACPI(memory []byte, numCPUs int) (uint64, error) {
 	}
 	writer := acpiTableWriter{base: acpiTableAddress}
 	facs := writer.appendRaw(buildBootFACS())
-	dsdt := writer.append("DSDT", 2, "CCKVMDSD", nil)
+	dsdt := writer.append("DSDT", 2, "CCKVMDSD", buildBootDSDT())
 	fadt := writer.append("FACP", 6, "CCKVMFAD", buildBootFADT(facs, dsdt))
 	madt := writer.append("APIC", 3, "CCKVMAPC", buildBootMADT(numCPUs))
 	xsdt := writer.append("XSDT", 1, "CCKVMXSD", buildBootXSDT([]uint64{fadt, madt}))
@@ -80,6 +80,33 @@ func buildBootXSDT(entries []uint64) []byte {
 	return body
 }
 
+func buildBootDSDT() []byte {
+	pciBody := appendNameDWord(nil, "_HID", 0x030ad041) // PNP0A03 PCI bus.
+	pciBody = appendNameIntegerZero(pciBody, "_ADR")
+	pciBody = appendNameIntegerZero(pciBody, "_BBN")
+	pciBody = appendNameBuffer(pciBody, "_CRS", buildBootPCIResources())
+	device := append([]byte{0x5b, 0x82}, amlPkg(4+len(pciBody))...)
+	device = append(device, 'P', 'C', 'I', '0')
+	device = append(device, pciBody...)
+
+	scopeBody := device
+	scope := append([]byte{0x10}, amlPkg(5+len(scopeBody))...)
+	scope = append(scope, '\\', '_', 'S', 'B', '_')
+	scope = append(scope, scopeBody...)
+	return scope
+}
+
+func buildBootPCIResources() []byte {
+	var out []byte
+	out = appendWordAddressSpace(out, 2, 0, 0, 0, 0xff, 0, 0x100)  // Bus 0.
+	out = appendIOPortDescriptor(out, 0x0cf8, 0x0cf8, 1, 8)        // PCI config address.
+	out = appendWordIOAddressSpace(out, 0x0000, 0x0cf7, 0, 0x0cf8) // Low I/O below PCI config.
+	out = appendWordIOAddressSpace(out, 0x0d00, 0xffff, 0, 0xf300) // I/O window above PCI config.
+	out = appendDWordMemoryAddressSpace(out, 0x80000000, 0xfebfffff, 0, 0x7ec00000)
+	out = append(out, 0x79, 0x00) // End tag.
+	return out
+}
+
 func buildBootMADT(numCPUs int) []byte {
 	var body []byte
 	body = binary.LittleEndian.AppendUint32(body, acpiLocalAPICAddress)
@@ -94,6 +121,93 @@ func buildBootMADT(numCPUs int) []byte {
 	body = appendMADTInterruptOverride(body, 0, 2, 0)
 	body = appendMADTLocalAPICNMI(body)
 	return body
+}
+
+func appendNameDWord(out []byte, name string, value uint32) []byte {
+	out = append(out, 0x08)
+	out = append(out, acpiFixedString(name, 4)...)
+	out = append(out, 0x0c)
+	return binary.LittleEndian.AppendUint32(out, value)
+}
+
+func appendNameIntegerZero(out []byte, name string) []byte {
+	out = append(out, 0x08)
+	out = append(out, acpiFixedString(name, 4)...)
+	return append(out, 0x00)
+}
+
+func appendNameBuffer(out []byte, name string, data []byte) []byte {
+	out = append(out, 0x08)
+	out = append(out, acpiFixedString(name, 4)...)
+	out = append(out, 0x11)
+	body := append([]byte{0x0a, byte(len(data))}, data...)
+	out = append(out, amlPkg(len(body))...)
+	return append(out, body...)
+}
+
+func amlPkg(length int) []byte {
+	encodedLen := 1
+	for {
+		total := length + encodedLen
+		nextEncodedLen := 1
+		switch {
+		case total < 0x40:
+			nextEncodedLen = 1
+		case total < 0x1000:
+			nextEncodedLen = 2
+		case total < 0x100000:
+			nextEncodedLen = 3
+		default:
+			nextEncodedLen = 4
+		}
+		if nextEncodedLen == encodedLen {
+			length = total
+			break
+		}
+		encodedLen = nextEncodedLen
+	}
+	if length < 0x40 {
+		return []byte{byte(length)}
+	}
+	if length < 0x1000 {
+		return []byte{byte(0x40 | (length & 0x0f)), byte(length >> 4)}
+	}
+	if length < 0x100000 {
+		return []byte{byte(0x80 | (length & 0x0f)), byte(length >> 4), byte(length >> 12)}
+	}
+	return []byte{byte(0xc0 | (length & 0x0f)), byte(length >> 4), byte(length >> 12), byte(length >> 20)}
+}
+
+func appendIOPortDescriptor(out []byte, min, max uint16, align, length byte) []byte {
+	out = append(out, 0x47, 0x01)
+	out = binary.LittleEndian.AppendUint16(out, min)
+	out = binary.LittleEndian.AppendUint16(out, max)
+	out = append(out, align, length)
+	return out
+}
+
+func appendWordAddressSpace(out []byte, resourceType, flags, typeFlags byte, min, max, translation, length uint16) []byte {
+	out = append(out, 0x88, 0x0d, 0x00, resourceType, flags, typeFlags)
+	out = binary.LittleEndian.AppendUint16(out, 0)
+	out = binary.LittleEndian.AppendUint16(out, min)
+	out = binary.LittleEndian.AppendUint16(out, max)
+	out = binary.LittleEndian.AppendUint16(out, translation)
+	out = binary.LittleEndian.AppendUint16(out, length)
+	return out
+}
+
+func appendWordIOAddressSpace(out []byte, min, max, translation, length uint16) []byte {
+	return appendWordAddressSpace(out, 1, 0x00, 0x03, min, max, translation, length)
+}
+
+func appendDWordMemoryAddressSpace(out []byte, min, max, translation, length uint32) []byte {
+	out = append(out, 0x87, 0x17, 0x00, 0, 0x00, 0x06)
+	out = binary.LittleEndian.AppendUint32(out, 0)
+	out = binary.LittleEndian.AppendUint32(out, min)
+	out = binary.LittleEndian.AppendUint32(out, max)
+	out = binary.LittleEndian.AppendUint32(out, translation)
+	out = binary.LittleEndian.AppendUint32(out, length)
+	return out
 }
 
 func appendMADTInterruptOverride(body []byte, irq byte, gsi uint32, flags uint16) []byte {

--- a/internal/freebsd/boot/amd64/acpi.go
+++ b/internal/freebsd/boot/amd64/acpi.go
@@ -1,0 +1,192 @@
+package amd64
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	acpiRSDPAddress  = 0x000e0000
+	acpiTableAddress = 0x000e1000
+
+	acpiLocalAPICAddress = 0xfee00000
+	acpiIOAPICAddress    = 0xfec00000
+	acpiHPETAddress      = 0xfed00000
+)
+
+func installBootACPI(memory []byte, numCPUs int) (uint64, error) {
+	if numCPUs < 1 {
+		numCPUs = 1
+	}
+	writer := acpiTableWriter{base: acpiTableAddress}
+	facs := writer.appendRaw(buildBootFACS())
+	dsdt := writer.append("DSDT", 2, "CCKVMDSD", nil)
+	fadt := writer.append("FACP", 6, "CCKVMFAD", buildBootFADT(facs, dsdt))
+	madt := writer.append("APIC", 3, "CCKVMAPC", buildBootMADT(numCPUs))
+	xsdt := writer.append("XSDT", 1, "CCKVMXSD", buildBootXSDT([]uint64{fadt, madt}))
+	if err := writeAt(memory, acpiTableAddress, writer.data); err != nil {
+		return 0, fmt.Errorf("write ACPI tables: %w", err)
+	}
+	if err := writeAt(memory, acpiRSDPAddress, buildBootRSDP(xsdt)); err != nil {
+		return 0, fmt.Errorf("write ACPI RSDP: %w", err)
+	}
+	return acpiRSDPAddress, nil
+}
+
+type acpiTableWriter struct {
+	base uint64
+	data []byte
+}
+
+func (w *acpiTableWriter) append(signature string, revision byte, tableID string, body []byte) uint64 {
+	addr := w.base + uint64(len(w.data))
+	table := buildACPITable(signature, revision, tableID, body)
+	w.data = append(w.data, table...)
+	for len(w.data)%16 != 0 {
+		w.data = append(w.data, 0)
+	}
+	return addr
+}
+
+func (w *acpiTableWriter) appendRaw(table []byte) uint64 {
+	addr := w.base + uint64(len(w.data))
+	w.data = append(w.data, table...)
+	for len(w.data)%16 != 0 {
+		w.data = append(w.data, 0)
+	}
+	return addr
+}
+
+func buildACPITable(signature string, revision byte, tableID string, body []byte) []byte {
+	table := make([]byte, 36+len(body))
+	copy(table[0:4], acpiFixedString(signature, 4))
+	binary.LittleEndian.PutUint32(table[4:], uint32(len(table)))
+	table[8] = revision
+	copy(table[10:16], acpiFixedString("CCKVM ", 6))
+	copy(table[16:24], acpiFixedString(tableID, 8))
+	binary.LittleEndian.PutUint32(table[24:], 1)
+	copy(table[28:32], acpiFixedString("CC  ", 4))
+	binary.LittleEndian.PutUint32(table[32:], 1)
+	copy(table[36:], body)
+	table[9] = checksum(table)
+	return table
+}
+
+func buildBootXSDT(entries []uint64) []byte {
+	body := make([]byte, 8*len(entries))
+	for i, entry := range entries {
+		binary.LittleEndian.PutUint64(body[i*8:], entry)
+	}
+	return body
+}
+
+func buildBootMADT(numCPUs int) []byte {
+	var body []byte
+	body = binary.LittleEndian.AppendUint32(body, acpiLocalAPICAddress)
+	body = binary.LittleEndian.AppendUint32(body, 1)
+	for cpu := 0; cpu < numCPUs && cpu < 255; cpu++ {
+		body = append(body, 0, 8, byte(cpu), byte(cpu))
+		body = binary.LittleEndian.AppendUint32(body, 1)
+	}
+	body = append(body, 1, 12, 0, 0)
+	body = binary.LittleEndian.AppendUint32(body, acpiIOAPICAddress)
+	body = binary.LittleEndian.AppendUint32(body, 0)
+	body = appendMADTInterruptOverride(body, 0, 2, 0)
+	body = appendMADTLocalAPICNMI(body)
+	return body
+}
+
+func appendMADTInterruptOverride(body []byte, irq byte, gsi uint32, flags uint16) []byte {
+	body = append(body, 2, 10, 0, irq)
+	body = binary.LittleEndian.AppendUint32(body, gsi)
+	body = binary.LittleEndian.AppendUint16(body, flags)
+	return body
+}
+
+func appendMADTLocalAPICNMI(body []byte) []byte {
+	body = append(body, 4, 6, 0xff)
+	body = binary.LittleEndian.AppendUint16(body, 0)
+	body = append(body, 1)
+	return body
+}
+
+func buildBootHPET() []byte {
+	const (
+		hpetClockPeriodFemtoseconds = 10_000_000
+		hpetVendorID                = 0x8086
+		hpetNumTimers               = 3
+	)
+	var body []byte
+	id := uint32(1)
+	id |= uint32(hpetNumTimers-1) << 8
+	id |= 1 << 13
+	id |= uint32(hpetVendorID) << 16
+	body = binary.LittleEndian.AppendUint32(body, id)
+	body = append(body, 0, 64, 0, 0)
+	body = binary.LittleEndian.AppendUint64(body, acpiHPETAddress)
+	body = append(body, 0)
+	body = binary.LittleEndian.AppendUint16(body, 0x0080)
+	body = append(body, 0)
+	_ = hpetClockPeriodFemtoseconds
+	return body
+}
+
+func buildBootFACS() []byte {
+	facs := make([]byte, 64)
+	copy(facs[0:4], "FACS")
+	binary.LittleEndian.PutUint32(facs[4:], uint32(len(facs)))
+	binary.LittleEndian.PutUint32(facs[8:], 1)
+	return facs
+}
+
+func buildBootFADT(facs, dsdt uint64) []byte {
+	const (
+		fadtBodyLength     = 276 - 36
+		sciIRQ             = 9
+		acpiPM1EventPort   = 0x400
+		acpiPM1ControlPort = 0x404
+		fadtFlagWBINVD     = 1 << 0
+	)
+	body := make([]byte, fadtBodyLength)
+	binary.LittleEndian.PutUint32(body[0:], uint32(facs))
+	binary.LittleEndian.PutUint32(body[4:], uint32(dsdt))
+	body[9] = 0 // Unspecified preferred PM profile.
+	binary.LittleEndian.PutUint16(body[10:], sciIRQ)
+	binary.LittleEndian.PutUint32(body[20:], acpiPM1EventPort)
+	binary.LittleEndian.PutUint32(body[28:], acpiPM1ControlPort)
+	body[52] = 4
+	body[53] = 2
+	binary.LittleEndian.PutUint32(body[76:], fadtFlagWBINVD)
+	binary.LittleEndian.PutUint64(body[96:], facs)
+	binary.LittleEndian.PutUint64(body[104:], dsdt)
+	return body
+}
+
+func buildBootRSDP(xsdt uint64) []byte {
+	rsdp := make([]byte, 36)
+	copy(rsdp[0:8], "RSD PTR ")
+	copy(rsdp[9:15], "CCKVM ")
+	rsdp[15] = 2
+	binary.LittleEndian.PutUint32(rsdp[20:], uint32(len(rsdp)))
+	binary.LittleEndian.PutUint64(rsdp[24:], xsdt)
+	rsdp[8] = checksum(rsdp[:20])
+	rsdp[32] = checksum(rsdp)
+	return rsdp
+}
+
+func acpiFixedString(value string, size int) []byte {
+	out := make([]byte, size)
+	for i := range out {
+		out[i] = ' '
+	}
+	copy(out, value)
+	return out
+}
+
+func checksum(data []byte) byte {
+	var sum byte
+	for _, b := range data {
+		sum += b
+	}
+	return -sum
+}

--- a/internal/freebsd/boot/amd64/plan.go
+++ b/internal/freebsd/boot/amd64/plan.go
@@ -1,0 +1,472 @@
+package amd64
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	defaultStackGPA    = 0x00007000
+	defaultMetadataGPA = 0x02000000
+	defaultPagingGPA   = 0x00090000
+
+	pageSize = 4096
+	wordSize = 8
+
+	kernBase  = 0xffffffff80000000
+	kernStart = kernBase + 0x200000
+
+	modInfoEnd      = 0x0000
+	modInfoName     = 0x0001
+	modInfoType     = 0x0002
+	modInfoAddr     = 0x0003
+	modInfoSize     = 0x0004
+	modInfoMetadata = 0x8000
+
+	modInfoMDEnvp    = 0x0006
+	modInfoMDHowto   = 0x0007
+	modInfoMDKernEnd = 0x0008
+	modInfoMDModulep = 0x1006
+	modInfoMDSMAP    = 0x1001
+
+	freeBSDKernelType = "elf kernel"
+	freeBSDKernelName = "/boot/kernel/kernel"
+
+	rbVerbose  = 0x0800
+	rbSerial   = 0x1000
+	rbMultiple = 0x20000000
+
+	smapTypeMemory   = 1
+	smapTypeReserved = 2
+
+	lowMemoryLimit = 3 << 30
+	highMemoryBase = 4 << 30
+)
+
+type BootOptions struct {
+	MemorySize  uint64
+	NumCPUs     int
+	StackGPA    uint64
+	MetadataGPA uint64
+	PagingGPA   uint64
+	Howto       uint32
+	Environment []string
+}
+
+type BootPlan struct {
+	EntryGVA     uint64
+	StackGPA     uint64
+	MetadataGPA  uint64
+	MetadataLen  uint32
+	PagingGPA    uint64
+	KernelEndGPA uint64
+	KernEnd      uint32
+}
+
+type smapEntry struct {
+	base   uint64
+	length uint64
+	typ    uint32
+}
+
+func PrepareBoot(memory []byte, kernel []byte, opts BootOptions) (*BootPlan, error) {
+	if len(memory) == 0 {
+		return nil, errors.New("guest memory is empty")
+	}
+	if len(kernel) == 0 {
+		return nil, errors.New("kernel file is empty")
+	}
+	if opts.MemorySize == 0 {
+		opts.MemorySize = uint64(len(memory))
+	}
+	if opts.StackGPA == 0 {
+		opts.StackGPA = defaultStackGPA
+	}
+	if opts.PagingGPA == 0 {
+		opts.PagingGPA = defaultPagingGPA
+	}
+
+	entry, kernelStart, kernelEnd, err := loadELF(memory, kernel)
+	if err != nil {
+		return nil, err
+	}
+	if opts.MetadataGPA == 0 {
+		opts.MetadataGPA = defaultMetadataGPA
+		if opts.MetadataGPA < kernelEnd {
+			opts.MetadataGPA = alignUp(kernelEnd, pageSize)
+		}
+	}
+	if err := installSMBIOS(memory); err != nil {
+		return nil, err
+	}
+	if _, err := installBootACPI(memory, opts.NumCPUs); err != nil {
+		return nil, err
+	}
+	if entry < kernStart {
+		return nil, fmt.Errorf("unsupported FreeBSD kernel entry %#x", entry)
+	}
+
+	metadata, kernEnd, err := buildMetadata(kernelStart, kernelEnd, opts.MetadataGPA, opts.Howto|rbVerbose|rbSerial|rbMultiple, opts.Environment, defaultSMAP(opts.MemorySize))
+	if err != nil {
+		return nil, err
+	}
+	if err := writeAt(memory, opts.MetadataGPA, metadata); err != nil {
+		return nil, fmt.Errorf("write FreeBSD metadata: %w", err)
+	}
+
+	stack := buildStack(uint32(opts.MetadataGPA), kernEnd)
+	stackGPA := opts.StackGPA - uint64(len(stack))
+	if stackGPA >= opts.StackGPA {
+		return nil, errors.New("invalid FreeBSD stack placement")
+	}
+	if err := writeAt(memory, stackGPA, stack); err != nil {
+		return nil, fmt.Errorf("write FreeBSD boot stack: %w", err)
+	}
+
+	return &BootPlan{
+		EntryGVA:     entry,
+		StackGPA:     stackGPA,
+		MetadataGPA:  opts.MetadataGPA,
+		MetadataLen:  uint32(len(metadata)),
+		PagingGPA:    opts.PagingGPA,
+		KernelEndGPA: kernelEnd,
+		KernEnd:      kernEnd,
+	}, nil
+}
+
+func loadELF(memory []byte, kernel []byte) (entry, kernelStart, kernelEnd uint64, err error) {
+	f, err := elf.NewFile(bytes.NewReader(kernel))
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("parse FreeBSD kernel ELF: %w", err)
+	}
+	defer f.Close()
+	if f.FileHeader.Class != elf.ELFCLASS64 || f.FileHeader.Data != elf.ELFDATA2LSB || f.FileHeader.Machine != elf.EM_X86_64 {
+		return 0, 0, 0, fmt.Errorf("unsupported FreeBSD kernel ELF class=%v data=%v machine=%v", f.FileHeader.Class, f.FileHeader.Data, f.FileHeader.Machine)
+	}
+	kernelStart = ^uint64(0)
+	for _, prog := range f.Progs {
+		if prog.Type != elf.PT_LOAD || prog.Memsz == 0 {
+			continue
+		}
+		if prog.Paddr+prog.Memsz > uint64(len(memory)) {
+			return 0, 0, 0, fmt.Errorf("kernel segment paddr=%#x memsz=%#x exceeds guest memory %#x", prog.Paddr, prog.Memsz, len(memory))
+		}
+		seg := memory[prog.Paddr : prog.Paddr+prog.Memsz]
+		clear(seg)
+		if prog.Filesz != 0 {
+			if _, err := io.ReadFull(prog.Open(), seg[:prog.Filesz]); err != nil {
+				return 0, 0, 0, fmt.Errorf("read kernel segment at %#x: %w", prog.Paddr, err)
+			}
+		}
+		if prog.Paddr < kernelStart {
+			kernelStart = prog.Paddr
+		}
+		if end := alignUp(prog.Paddr+prog.Memsz, pageSize); end > kernelEnd {
+			kernelEnd = end
+		}
+	}
+	if kernelEnd == 0 {
+		return 0, 0, 0, errors.New("FreeBSD kernel has no loadable segments")
+	}
+	if err := applyRelocations(f, memory); err != nil {
+		return 0, 0, 0, err
+	}
+	return f.Entry, kernelStart, kernelEnd, nil
+}
+
+func applyRelocations(f *elf.File, memory []byte) error {
+	for _, section := range f.Sections {
+		if section.Type != elf.SHT_RELA {
+			continue
+		}
+		symbols, err := linkedSymbols(f, section)
+		if err != nil {
+			return fmt.Errorf("read symbols for %s: %w", section.Name, err)
+		}
+		data, err := section.Data()
+		if err != nil {
+			return fmt.Errorf("read relocations %s: %w", section.Name, err)
+		}
+		if len(data)%24 != 0 {
+			return fmt.Errorf("relocation section %s has invalid size %d", section.Name, len(data))
+		}
+		for off := 0; off < len(data); off += 24 {
+			relocOff := f.ByteOrder.Uint64(data[off:])
+			info := f.ByteOrder.Uint64(data[off+8:])
+			addend := int64(f.ByteOrder.Uint64(data[off+16:]))
+			symIndex := info >> 32
+			relocType := elf.R_X86_64(info & 0xffffffff)
+			var symValue uint64
+			if symIndex != 0 {
+				if symIndex >= uint64(len(symbols)) {
+					return fmt.Errorf("%s relocation references symbol %d beyond %d", section.Name, symIndex, len(symbols))
+				}
+				symValue = symbols[symIndex].Value
+			}
+			if err := applyRelocation(memory, relocOff, relocType, symValue, addend); err != nil {
+				return fmt.Errorf("%s relocation at %#x: %w", section.Name, relocOff, err)
+			}
+		}
+	}
+	return nil
+}
+
+func linkedSymbols(f *elf.File, section *elf.Section) ([]elf.Symbol, error) {
+	if section.Link == 0 || int(section.Link) >= len(f.Sections) {
+		return nil, fmt.Errorf("invalid linked symbol table %d", section.Link)
+	}
+	symSection := f.Sections[section.Link]
+	data, err := symSection.Data()
+	if err != nil {
+		return nil, err
+	}
+	if symSection.Entsize == 0 {
+		symSection.Entsize = 24
+	}
+	if len(data)%int(symSection.Entsize) != 0 {
+		return nil, fmt.Errorf("symbol table %s has invalid size %d", symSection.Name, len(data))
+	}
+	symbols := make([]elf.Symbol, len(data)/int(symSection.Entsize))
+	for i := range symbols {
+		off := i * int(symSection.Entsize)
+		if off+24 > len(data) {
+			return nil, fmt.Errorf("short symbol %d in %s", i, symSection.Name)
+		}
+		symbols[i].Info = data[off+4]
+		symbols[i].Other = data[off+5]
+		symbols[i].Section = elf.SectionIndex(f.ByteOrder.Uint16(data[off+6:]))
+		symbols[i].Value = f.ByteOrder.Uint64(data[off+8:])
+		symbols[i].Size = f.ByteOrder.Uint64(data[off+16:])
+	}
+	return symbols, nil
+}
+
+func applyRelocation(memory []byte, relocOff uint64, relocType elf.R_X86_64, symValue uint64, addend int64) error {
+	phys, err := freeBSDVirtualToPhysical(relocOff)
+	if err != nil {
+		return err
+	}
+	if phys+8 > uint64(len(memory)) {
+		return fmt.Errorf("target exceeds guest memory")
+	}
+	value := int64(symValue) + addend
+	switch relocType {
+	case elf.R_X86_64_64, elf.R_X86_64_JMP_SLOT:
+		binary.LittleEndian.PutUint64(memory[phys:phys+8], uint64(value))
+	case elf.R_X86_64_PLT32, elf.R_X86_64_PC32:
+		pcValue := value - int64(relocOff)
+		if int64(int32(pcValue)) != pcValue {
+			return fmt.Errorf("pc-relative relocation overflows int32: %#x", pcValue)
+		}
+		binary.LittleEndian.PutUint32(memory[phys:phys+4], uint32(int32(pcValue)))
+	case elf.R_X86_64_32S:
+		if int64(int32(value)) != value {
+			return fmt.Errorf("signed 32-bit relocation overflows: %#x", value)
+		}
+		binary.LittleEndian.PutUint32(memory[phys:phys+4], uint32(int32(value)))
+	case elf.R_X86_64_NONE:
+		return nil
+	default:
+		return fmt.Errorf("unsupported relocation type %s", relocType)
+	}
+	return nil
+}
+
+func freeBSDVirtualToPhysical(addr uint64) (uint64, error) {
+	if addr < kernBase {
+		return addr, nil
+	}
+	return addr - kernBase, nil
+}
+
+func buildMetadata(kernelStart, kernelEnd, metadataGPA uint64, howto uint32, env []string, smap []smapEntry) ([]byte, uint32, error) {
+	envBytes := buildEnv(env)
+	envGPA := alignUp(metadataGPA+0x1000, pageSize)
+	kernEnd := uint32(alignUp(envGPA+uint64(len(envBytes)), pageSize))
+	records := metadataBuilder{}
+	records.addString(modInfoName, freeBSDKernelName)
+	records.addString(modInfoType, freeBSDKernelType)
+	records.addUint64(modInfoAddr, kernelStart)
+	records.addUint64(modInfoSize, kernelEnd-kernelStart)
+	records.addUint32(modInfoMetadata|modInfoMDHowto, howto)
+	records.addUint64(modInfoMetadata|modInfoMDEnvp, envGPA)
+	records.addUint64(modInfoMetadata|modInfoMDKernEnd, uint64(kernEnd))
+	records.addBytes(modInfoMetadata|modInfoMDSMAP, encodeSMAP(smap))
+	records.addUint64(modInfoMetadata|modInfoMDModulep, metadataGPA)
+	records.addEnd()
+
+	metadata := records.bytes()
+	if len(metadata) > pageSize {
+		return nil, 0, fmt.Errorf("FreeBSD metadata too large: %d", len(metadata))
+	}
+	outLen := int(envGPA-metadataGPA) + len(envBytes)
+	out := make([]byte, outLen)
+	copy(out, metadata)
+	copy(out[envGPA-metadataGPA:], envBytes)
+	return out, kernEnd, nil
+}
+
+type metadataBuilder struct {
+	buf []byte
+}
+
+func (b *metadataBuilder) addString(typ uint32, value string) {
+	data := append([]byte(value), 0)
+	b.addBytes(typ, data)
+}
+
+func (b *metadataBuilder) addUint32(typ uint32, value uint32) {
+	var data [4]byte
+	binary.LittleEndian.PutUint32(data[:], value)
+	b.addBytes(typ, data[:])
+}
+
+func (b *metadataBuilder) addUint64(typ uint32, value uint64) {
+	var data [8]byte
+	binary.LittleEndian.PutUint64(data[:], value)
+	b.addBytes(typ, data[:])
+}
+
+func (b *metadataBuilder) addBytes(typ uint32, data []byte) {
+	b.buf = binary.LittleEndian.AppendUint32(b.buf, typ)
+	b.buf = binary.LittleEndian.AppendUint32(b.buf, uint32(len(data)))
+	b.buf = append(b.buf, data...)
+	for len(b.buf)%wordSize != 0 {
+		b.buf = append(b.buf, 0)
+	}
+}
+
+func (b *metadataBuilder) addEnd() {
+	b.buf = binary.LittleEndian.AppendUint32(b.buf, modInfoEnd)
+	b.buf = binary.LittleEndian.AppendUint32(b.buf, modInfoEnd)
+}
+
+func (b *metadataBuilder) bytes() []byte {
+	return append([]byte(nil), b.buf...)
+}
+
+func buildEnv(values []string) []byte {
+	if len(values) == 0 {
+		values = []string{
+			"console=comconsole",
+			"comconsole_speed=115200",
+			"comconsole_port=0x3f8",
+			"boot_serial=YES",
+			"boot_multicons=YES",
+			"boot_verbose=YES",
+			"hint.uart.0.at=isa",
+			"hint.uart.0.port=0x3f8",
+			"hint.uart.0.irq=4",
+			"hint.uart.0.flags=0x10",
+			"hint.smbios.0.disabled=1",
+			"smbios.memory.enabled=0",
+			"vfs.root.mountfrom=ufs:/dev/vtbd0",
+		}
+	}
+	var out []byte
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		out = append(out, value...)
+		out = append(out, 0)
+	}
+	out = append(out, 0)
+	return out
+}
+
+func encodeSMAP(entries []smapEntry) []byte {
+	out := make([]byte, 0, len(entries)*20)
+	for _, entry := range entries {
+		out = binary.LittleEndian.AppendUint64(out, entry.base)
+		out = binary.LittleEndian.AppendUint64(out, entry.length)
+		out = binary.LittleEndian.AppendUint32(out, entry.typ)
+	}
+	return out
+}
+
+func defaultSMAP(memorySize uint64) []smapEntry {
+	entries := []smapEntry{
+		{base: 0, length: 0x9fc00, typ: smapTypeMemory},
+		{base: 0x9fc00, length: 0x60400, typ: smapTypeReserved},
+	}
+	lowSize := memorySize
+	if lowSize > lowMemoryLimit {
+		lowSize = lowMemoryLimit
+	}
+	if lowSize > 0x100000 {
+		entries = append(entries, smapEntry{base: 0x100000, length: lowSize - 0x100000, typ: smapTypeMemory})
+	}
+	if memorySize > lowMemoryLimit {
+		entries = append(entries, smapEntry{base: lowMemoryLimit, length: highMemoryBase - lowMemoryLimit, typ: smapTypeReserved})
+		entries = append(entries, smapEntry{base: highMemoryBase, length: memorySize - lowMemoryLimit, typ: smapTypeMemory})
+	}
+	return entries
+}
+
+func buildStack(modulep, kernEnd uint32) []byte {
+	var stack []byte
+	stack = binary.LittleEndian.AppendUint32(stack, 0)
+	stack = binary.LittleEndian.AppendUint32(stack, modulep)
+	stack = binary.LittleEndian.AppendUint32(stack, kernEnd)
+	stack = binary.LittleEndian.AppendUint32(stack, 0)
+	return stack
+}
+
+func installSMBIOS(memory []byte) error {
+	const (
+		epsAddr   = 0x000f0000
+		tableAddr = 0x000f0100
+	)
+	table := []byte{
+		127, 4, 0, 0, // End-of-table structure.
+		0, 0,
+	}
+	if err := writeAt(memory, tableAddr, table); err != nil {
+		return fmt.Errorf("write SMBIOS table: %w", err)
+	}
+	eps := make([]byte, 31)
+	copy(eps[0:4], "_SM_")
+	eps[5] = byte(len(eps))
+	eps[6] = 2
+	eps[7] = 8
+	binary.LittleEndian.PutUint16(eps[8:10], 4)
+	copy(eps[16:21], "_DMI_")
+	binary.LittleEndian.PutUint16(eps[22:24], uint16(len(table)))
+	binary.LittleEndian.PutUint32(eps[24:28], tableAddr)
+	binary.LittleEndian.PutUint16(eps[28:30], 1)
+	eps[30] = 0x28
+	eps[21] = checksumByte(eps[16:31])
+	eps[4] = checksumByte(eps)
+	if err := writeAt(memory, epsAddr, eps); err != nil {
+		return fmt.Errorf("write SMBIOS entry point: %w", err)
+	}
+	return nil
+}
+
+func checksumByte(data []byte) byte {
+	var sum byte
+	for _, b := range data {
+		sum += b
+	}
+	return -sum
+}
+
+func alignUp(v, align uint64) uint64 {
+	if align == 0 {
+		return v
+	}
+	return (v + align - 1) &^ (align - 1)
+}
+
+func writeAt(memory []byte, addr uint64, data []byte) error {
+	if addr > uint64(len(memory)) || uint64(len(data)) > uint64(len(memory))-addr {
+		return fmt.Errorf("write addr=%#x len=%#x exceeds memory %#x", addr, len(data), len(memory))
+	}
+	copy(memory[addr:], data)
+	return nil
+}

--- a/internal/freebsd/boot/amd64/plan.go
+++ b/internal/freebsd/boot/amd64/plan.go
@@ -2,6 +2,7 @@ package amd64
 
 import (
 	"bytes"
+	"crypto/rand"
 	"debug/elf"
 	"encoding/binary"
 	"errors"
@@ -33,8 +34,10 @@ const (
 	modInfoMDModulep = 0x1006
 	modInfoMDSMAP    = 0x1001
 
-	freeBSDKernelType = "elf kernel"
-	freeBSDKernelName = "/boot/kernel/kernel"
+	freeBSDKernelType          = "elf kernel"
+	freeBSDKernelName          = "/boot/kernel/kernel"
+	freeBSDBootEntropyType     = "boot_entropy_cache"
+	freeBSDPlatformEntropyType = "boot_entropy_platform"
 
 	rbVerbose  = 0x0800
 	rbSerial   = 0x1000
@@ -55,6 +58,7 @@ type BootOptions struct {
 	PagingGPA   uint64
 	Howto       uint32
 	Environment []string
+	Entropy     []byte
 }
 
 type BootPlan struct {
@@ -110,7 +114,15 @@ func PrepareBoot(memory []byte, kernel []byte, opts BootOptions) (*BootPlan, err
 		return nil, fmt.Errorf("unsupported FreeBSD kernel entry %#x", entry)
 	}
 
-	metadata, kernEnd, err := buildMetadata(kernelStart, kernelEnd, opts.MetadataGPA, opts.Howto|rbVerbose|rbSerial|rbMultiple, opts.Environment, defaultSMAP(opts.MemorySize))
+	entropy := opts.Entropy
+	if len(entropy) == 0 {
+		entropy = make([]byte, 4096)
+		if _, err := rand.Read(entropy); err != nil {
+			return nil, fmt.Errorf("generate FreeBSD boot entropy: %w", err)
+		}
+	}
+
+	metadata, kernEnd, err := buildMetadata(kernelStart, kernelEnd, opts.MetadataGPA, opts.Howto|rbSerial|rbMultiple, opts.Environment, entropy, defaultSMAP(opts.MemorySize))
 	if err != nil {
 		return nil, err
 	}
@@ -283,10 +295,12 @@ func freeBSDVirtualToPhysical(addr uint64) (uint64, error) {
 	return addr - kernBase, nil
 }
 
-func buildMetadata(kernelStart, kernelEnd, metadataGPA uint64, howto uint32, env []string, smap []smapEntry) ([]byte, uint32, error) {
+func buildMetadata(kernelStart, kernelEnd, metadataGPA uint64, howto uint32, env []string, entropy []byte, smap []smapEntry) ([]byte, uint32, error) {
 	envBytes := buildEnv(env)
 	envGPA := alignUp(metadataGPA+0x1000, pageSize)
-	kernEnd := uint32(alignUp(envGPA+uint64(len(envBytes)), pageSize))
+	entropyGPA := alignUp(envGPA+uint64(len(envBytes)), 16)
+	platformEntropyGPA := alignUp(entropyGPA+uint64(len(entropy)), 16)
+	kernEnd := uint32(alignUp(platformEntropyGPA+uint64(len(entropy)), pageSize))
 	records := metadataBuilder{}
 	records.addString(modInfoName, freeBSDKernelName)
 	records.addString(modInfoType, freeBSDKernelType)
@@ -297,16 +311,24 @@ func buildMetadata(kernelStart, kernelEnd, metadataGPA uint64, howto uint32, env
 	records.addUint64(modInfoMetadata|modInfoMDKernEnd, uint64(kernEnd))
 	records.addBytes(modInfoMetadata|modInfoMDSMAP, encodeSMAP(smap))
 	records.addUint64(modInfoMetadata|modInfoMDModulep, metadataGPA)
+	if len(entropy) > 0 {
+		records.addPreload(freeBSDKernelName+".entropy", freeBSDBootEntropyType, entropyGPA, uint64(len(entropy)))
+		records.addPreload(freeBSDKernelName+".platform_entropy", freeBSDPlatformEntropyType, platformEntropyGPA, uint64(len(entropy)))
+	}
 	records.addEnd()
 
 	metadata := records.bytes()
 	if len(metadata) > pageSize {
 		return nil, 0, fmt.Errorf("FreeBSD metadata too large: %d", len(metadata))
 	}
-	outLen := int(envGPA-metadataGPA) + len(envBytes)
+	outLen := int(uint64(kernEnd) - metadataGPA)
 	out := make([]byte, outLen)
 	copy(out, metadata)
 	copy(out[envGPA-metadataGPA:], envBytes)
+	if len(entropy) > 0 {
+		copy(out[entropyGPA-metadataGPA:], entropy)
+		copy(out[platformEntropyGPA-metadataGPA:], entropy)
+	}
 	return out, kernEnd, nil
 }
 
@@ -329,6 +351,13 @@ func (b *metadataBuilder) addUint64(typ uint32, value uint64) {
 	var data [8]byte
 	binary.LittleEndian.PutUint64(data[:], value)
 	b.addBytes(typ, data[:])
+}
+
+func (b *metadataBuilder) addPreload(name, typ string, addr, size uint64) {
+	b.addString(modInfoName, name)
+	b.addString(modInfoType, typ)
+	b.addUint64(modInfoAddr, addr)
+	b.addUint64(modInfoSize, size)
 }
 
 func (b *metadataBuilder) addBytes(typ uint32, data []byte) {
@@ -357,7 +386,7 @@ func buildEnv(values []string) []byte {
 			"comconsole_port=0x3f8",
 			"boot_serial=YES",
 			"boot_multicons=YES",
-			"boot_verbose=YES",
+			"hw.vga.textmode=1",
 			"hint.uart.0.at=isa",
 			"hint.uart.0.port=0x3f8",
 			"hint.uart.0.irq=4",

--- a/internal/freebsd/boot/amd64/plan_test.go
+++ b/internal/freebsd/boot/amd64/plan_test.go
@@ -6,15 +6,18 @@ import (
 )
 
 func TestBuildMetadataContainsSMAP(t *testing.T) {
-	metadata, _, err := buildMetadata(0x200000, 0x2000000, 0x2000000, rbSerial, nil, defaultSMAP(1024<<20))
+	metadata, _, err := buildMetadata(0x200000, 0x2000000, 0x2000000, rbSerial, nil, []byte("test-entropy"), defaultSMAP(1024<<20))
 	if err != nil {
 		t.Fatal(err)
 	}
 	foundType := false
 	foundSMAP := false
+	foundEntropy := false
+	foundPlatformEntropy := false
 	for off := 0; off+8 <= len(metadata); {
 		typ := binary.LittleEndian.Uint32(metadata[off:])
 		size := binary.LittleEndian.Uint32(metadata[off+4:])
+		value := metadata[off+8 : off+8+int(size)]
 		t.Logf("record off=%#x type=%#x size=%d", off, typ, size)
 		if typ == 0 && size == 0 {
 			break
@@ -24,6 +27,12 @@ func TestBuildMetadataContainsSMAP(t *testing.T) {
 		}
 		if typ == modInfoMetadata|modInfoMDSMAP {
 			foundSMAP = true
+		}
+		if typ == modInfoType && string(value[:len(value)-1]) == freeBSDBootEntropyType {
+			foundEntropy = true
+		}
+		if typ == modInfoType && string(value[:len(value)-1]) == freeBSDPlatformEntropyType {
+			foundPlatformEntropy = true
 		}
 		next := off + 8 + int(size)
 		for next%wordSize != 0 {
@@ -36,5 +45,20 @@ func TestBuildMetadataContainsSMAP(t *testing.T) {
 	}
 	if !foundSMAP {
 		t.Fatalf("metadata does not contain SMAP")
+	}
+	if !foundEntropy {
+		t.Fatalf("metadata does not contain boot entropy preload")
+	}
+	if !foundPlatformEntropy {
+		t.Fatalf("metadata does not contain platform entropy preload")
+	}
+}
+
+func TestBuildBootFADTMarksNoVGA(t *testing.T) {
+	const fadtBootArchNoVGA = 1 << 2
+	body := buildBootFADT(0x1000, 0x2000)
+	flags := binary.LittleEndian.Uint16(body[73:])
+	if flags&fadtBootArchNoVGA == 0 {
+		t.Fatalf("FADT boot architecture flags = %#x, want NO_VGA", flags)
 	}
 }

--- a/internal/freebsd/boot/amd64/plan_test.go
+++ b/internal/freebsd/boot/amd64/plan_test.go
@@ -1,0 +1,40 @@
+package amd64
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestBuildMetadataContainsSMAP(t *testing.T) {
+	metadata, _, err := buildMetadata(0x200000, 0x2000000, 0x2000000, rbSerial, nil, defaultSMAP(1024<<20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundType := false
+	foundSMAP := false
+	for off := 0; off+8 <= len(metadata); {
+		typ := binary.LittleEndian.Uint32(metadata[off:])
+		size := binary.LittleEndian.Uint32(metadata[off+4:])
+		t.Logf("record off=%#x type=%#x size=%d", off, typ, size)
+		if typ == 0 && size == 0 {
+			break
+		}
+		if typ == modInfoType {
+			foundType = true
+		}
+		if typ == modInfoMetadata|modInfoMDSMAP {
+			foundSMAP = true
+		}
+		next := off + 8 + int(size)
+		for next%wordSize != 0 {
+			next++
+		}
+		off = next
+	}
+	if !foundType {
+		t.Fatalf("metadata does not contain MODINFO_TYPE")
+	}
+	if !foundSMAP {
+		t.Fatalf("metadata does not contain SMAP")
+	}
+}

--- a/internal/freebsd/guestinit/guestinit.go
+++ b/internal/freebsd/guestinit/guestinit.go
@@ -1,0 +1,41 @@
+package guestinit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+func Build(ctx context.Context, cacheDir string) ([]byte, error) {
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.MkdirTemp("", "cc-freebsd-guestinit-*")
+		if err != nil {
+			return nil, fmt.Errorf("create guest init cache: %w", err)
+		}
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create guest init cache: %w", err)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("locate FreeBSD guest init package")
+	}
+	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	out := filepath.Join(cacheDir, "guest-init-freebsd-amd64")
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", out, "./internal/cmd/freebsd-init")
+	cmd.Env = append(os.Environ(), "GOOS=freebsd", "GOARCH=amd64", "CGO_ENABLED=0")
+	cmd.Dir = moduleRoot
+	data, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("build FreeBSD guest init: %w\n%s", err, data)
+	}
+	bin, err := os.ReadFile(out)
+	if err != nil {
+		return nil, fmt.Errorf("read FreeBSD guest init: %w", err)
+	}
+	return bin, nil
+}

--- a/internal/freebsd/rootfs/rootfs.go
+++ b/internal/freebsd/rootfs/rootfs.go
@@ -337,7 +337,10 @@ func versionNoDot(version string) string {
 }
 
 const managedInitScript = `#!/bin/sh
+/sbin/mount -u -o rw / || :
 /sbin/mount -t devfs devfs /dev || :
+/bin/chmod 1777 /tmp || :
+/bin/chmod 700 /root || :
 /sbin/ifconfig vtnet0 inet 10.42.0.2 netmask 255.255.255.0 up || {
 	while :; do /bin/sleep 3600; done
 }

--- a/internal/freebsd/rootfs/rootfs.go
+++ b/internal/freebsd/rootfs/rootfs.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ulikunitz/xz"
+	freebsdguestinit "j5.nz/cc/internal/freebsd/guestinit"
 	"j5.nz/cc/internal/fsimage"
 	ffsimage "j5.nz/cc/internal/fsimage/ffs"
 	"j5.nz/cc/internal/imagefs"
@@ -70,7 +71,11 @@ func BuildManagedRuntime(ctx context.Context, cfg Config) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	root, closeRoot, err := buildManagedRoot(ctx, baseTXZ, []byte(managedInitScript))
+	initBin, err := freebsdguestinit.Build(ctx, filepath.Join(cfg.CacheDir, "guestinit"))
+	if err != nil {
+		return nil, err
+	}
+	root, closeRoot, err := buildManagedRoot(ctx, baseTXZ, initBin)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +92,12 @@ func BuildManagedRuntime(ctx context.Context, cfg Config) (*Runtime, error) {
 	return &Runtime{Kernel: kernel, Root: region, RootFS: root, close: closeRoot}, nil
 }
 
-func BuildManagedRoot(ctx context.Context, baseSetPath string, init []byte) (imagefs.Directory, error) {
-	root, _, err := buildManagedRoot(ctx, baseSetPath, init)
+func BuildManagedRoot(ctx context.Context, baseSetPath string, initBin []byte) (imagefs.Directory, error) {
+	root, _, err := buildManagedRoot(ctx, baseSetPath, initBin)
 	return root, err
 }
 
-func buildManagedRoot(ctx context.Context, baseSetPath string, init []byte) (imagefs.Directory, func() error, error) {
+func buildManagedRoot(ctx context.Context, baseSetPath string, initBin []byte) (imagefs.Directory, func() error, error) {
 	root, closeRoot, err := buildBaseRoot(ctx, baseSetPath)
 	if err != nil {
 		return nil, nil, err
@@ -103,7 +108,8 @@ func buildManagedRoot(ctx context.Context, baseSetPath string, init []byte) (ima
 		mode fs.FileMode
 		data []byte
 	}{
-		{"/sbin/init", 0o755, init},
+		{"/sbin/init", 0o755, []byte(managedInitScript)},
+		{"/sbin/cc-freebsd-init", 0o755, initBin},
 		{"/etc/fstab", 0o644, []byte("/dev/vtbd0 / ufs rw 1 1\n")},
 		{"/etc/rc.conf", 0o644, []byte("hostname=\"cc-freebsd\"\nifconfig_vtnet0=\"inet 10.42.0.2 netmask 255.255.255.0\"\ndefaultrouter=\"10.42.0.1\"\n")},
 		{"/etc/resolv.conf", 0o644, []byte("nameserver 10.42.0.1\n")},
@@ -137,33 +143,82 @@ func BuildBaseRoot(ctx context.Context, baseSetPath string) (imagefs.Directory, 
 }
 
 func buildBaseRoot(ctx context.Context, baseSetPath string) (imagefs.Directory, func() error, error) {
-	f, err := os.Open(baseSetPath)
+	baseTar, err := ensureDecompressedTar(ctx, baseSetPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("open FreeBSD base set %s: %w", baseSetPath, err)
+		return nil, nil, err
 	}
-	defer f.Close()
-	xzr, err := xz.NewReader(f)
+	tfs, err := imagefs.NewSeekableTarFS(ctx, baseTar)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read FreeBSD base xz %s: %w", baseSetPath, err)
-	}
-	tfs, err := imagefs.NewTarFS(ctx, xzr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("read FreeBSD base set %s: %w", baseSetPath, err)
+		return nil, nil, fmt.Errorf("read FreeBSD base set %s: %w", baseTar, err)
 	}
 	return tfs.Root(), tfs.Close, nil
 }
 
+func ensureDecompressedTar(ctx context.Context, source string) (string, error) {
+	target := strings.TrimSuffix(source, filepath.Ext(source)) + ".tar"
+	if st, err := os.Stat(target); err == nil && st.Size() > 0 {
+		if src, srcErr := os.Stat(source); srcErr == nil && !st.ModTime().Before(src.ModTime()) {
+			return target, nil
+		}
+	}
+	f, err := os.Open(source)
+	if err != nil {
+		return "", fmt.Errorf("open FreeBSD release set %s: %w", source, err)
+	}
+	defer f.Close()
+	xzr, err := xz.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("read FreeBSD release xz %s: %w", source, err)
+	}
+	tmp := target + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("create decompressed FreeBSD release set %s: %w", tmp, err)
+	}
+	_, copyErr := io.Copy(out, contextReader{ctx: ctx, r: xzr})
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("decompress FreeBSD release set %s: %w", source, copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("close decompressed FreeBSD release set %s: %w", tmp, closeErr)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("install decompressed FreeBSD release set %s: %w", target, err)
+	}
+	return target, nil
+}
+
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
 func ExtractKernel(kernelSetPath string) ([]byte, error) {
+	kernelTar, err := ensureDecompressedTar(context.Background(), kernelSetPath)
+	if err != nil {
+		return nil, err
+	}
+	return extractKernelFromTar(kernelTar)
+}
+
+func extractKernelFromTar(kernelSetPath string) ([]byte, error) {
 	f, err := os.Open(kernelSetPath)
 	if err != nil {
 		return nil, fmt.Errorf("open FreeBSD kernel set %s: %w", kernelSetPath, err)
 	}
 	defer f.Close()
-	xzr, err := xz.NewReader(f)
-	if err != nil {
-		return nil, fmt.Errorf("read FreeBSD kernel xz %s: %w", kernelSetPath, err)
-	}
-	tr := tar.NewReader(xzr)
+	tr := tar.NewReader(f)
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -283,8 +338,9 @@ func versionNoDot(version string) string {
 
 const managedInitScript = `#!/bin/sh
 /sbin/mount -t devfs devfs /dev || :
-echo FREEBSD_FULL_BASE_INIT_OK >/dev/console 2>&1 || :
-while :; do
-	/bin/sleep 3600
-done
+/sbin/ifconfig vtnet0 inet 10.42.0.2 netmask 255.255.255.0 up || {
+	while :; do /bin/sleep 3600; done
+}
+/sbin/route add default 10.42.0.1 || true
+exec /sbin/cc-freebsd-init
 `

--- a/internal/freebsd/rootfs/rootfs.go
+++ b/internal/freebsd/rootfs/rootfs.go
@@ -1,0 +1,290 @@
+package rootfs
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ulikunitz/xz"
+	"j5.nz/cc/internal/fsimage"
+	ffsimage "j5.nz/cc/internal/fsimage/ffs"
+	"j5.nz/cc/internal/imagefs"
+)
+
+const (
+	BuiltInImageName = "@freebsd"
+	defaultVersion   = "15.1"
+	defaultArch      = "amd64"
+	defaultMirror    = "https://mirror.aarnet.edu.au/pub/FreeBSD/releases"
+)
+
+type Config struct {
+	CacheDir string
+	Version  string
+	Arch     string
+	Mirror   string
+}
+
+type Runtime struct {
+	Kernel []byte
+	Root   fsimage.FilesystemRegion
+	RootFS imagefs.Directory
+	close  func() error
+}
+
+func (r *Runtime) Close() error {
+	if r == nil || r.close == nil {
+		return nil
+	}
+	return r.close()
+}
+
+func IsBuiltInImage(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case BuiltInImageName, "freebsd":
+		return true
+	default:
+		return false
+	}
+}
+
+func BuildManagedRuntime(ctx context.Context, cfg Config) (*Runtime, error) {
+	cfg = normalizeConfig(cfg)
+	kernelTXZ, err := ensureArtifact(ctx, cfg, "kernel.txz")
+	if err != nil {
+		return nil, err
+	}
+	baseTXZ, err := ensureArtifact(ctx, cfg, "base.txz")
+	if err != nil {
+		return nil, err
+	}
+	kernel, err := ExtractKernel(kernelTXZ)
+	if err != nil {
+		return nil, err
+	}
+	root, closeRoot, err := buildManagedRoot(ctx, baseTXZ, []byte(managedInitScript))
+	if err != nil {
+		return nil, err
+	}
+	region, err := fsimage.Build(ctx, root, fsimage.Options{
+		Type:              fsimage.TypeFFS,
+		FFSLayout:         ffsimage.LayoutRaw,
+		DeterministicTime: time.Unix(1700000000, 0),
+		ExtraBytes:        128 << 20,
+	})
+	if err != nil {
+		_ = closeRoot()
+		return nil, fmt.Errorf("build FreeBSD FFS root: %w", err)
+	}
+	return &Runtime{Kernel: kernel, Root: region, RootFS: root, close: closeRoot}, nil
+}
+
+func BuildManagedRoot(ctx context.Context, baseSetPath string, init []byte) (imagefs.Directory, error) {
+	root, _, err := buildManagedRoot(ctx, baseSetPath, init)
+	return root, err
+}
+
+func buildManagedRoot(ctx context.Context, baseSetPath string, init []byte) (imagefs.Directory, func() error, error) {
+	root, closeRoot, err := buildBaseRoot(ctx, baseSetPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	overlay := imagefs.NewOverlay(root)
+	for _, file := range []struct {
+		path string
+		mode fs.FileMode
+		data []byte
+	}{
+		{"/sbin/init", 0o755, init},
+		{"/etc/fstab", 0o644, []byte("/dev/vtbd0 / ufs rw 1 1\n")},
+		{"/etc/rc.conf", 0o644, []byte("hostname=\"cc-freebsd\"\nifconfig_vtnet0=\"inet 10.42.0.2 netmask 255.255.255.0\"\ndefaultrouter=\"10.42.0.1\"\n")},
+		{"/etc/resolv.conf", 0o644, []byte("nameserver 10.42.0.1\n")},
+		{"/etc/hosts", 0o644, []byte("127.0.0.1 localhost\n10.42.0.2 cc-freebsd\n")},
+	} {
+		if err := overlay.AddFile(file.path, file.mode, file.data); err != nil {
+			_ = closeRoot()
+			return nil, nil, fmt.Errorf("overlay %s: %w", file.path, err)
+		}
+	}
+	for _, dev := range []struct {
+		path string
+		mode fs.FileMode
+		rdev uint32
+	}{
+		{"/dev/console", fs.ModeDevice | fs.ModeCharDevice | 0o600, 0},
+		{"/dev/null", fs.ModeDevice | fs.ModeCharDevice | 0o666, 2},
+		{"/dev/zero", fs.ModeDevice | fs.ModeCharDevice | 0o666, 12},
+	} {
+		if err := overlay.AddDevice(dev.path, dev.mode, dev.rdev); err != nil {
+			_ = closeRoot()
+			return nil, nil, fmt.Errorf("add %s: %w", dev.path, err)
+		}
+	}
+	return overlay.Root(), closeRoot, nil
+}
+
+func BuildBaseRoot(ctx context.Context, baseSetPath string) (imagefs.Directory, error) {
+	root, _, err := buildBaseRoot(ctx, baseSetPath)
+	return root, err
+}
+
+func buildBaseRoot(ctx context.Context, baseSetPath string) (imagefs.Directory, func() error, error) {
+	f, err := os.Open(baseSetPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open FreeBSD base set %s: %w", baseSetPath, err)
+	}
+	defer f.Close()
+	xzr, err := xz.NewReader(f)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read FreeBSD base xz %s: %w", baseSetPath, err)
+	}
+	tfs, err := imagefs.NewTarFS(ctx, xzr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read FreeBSD base set %s: %w", baseSetPath, err)
+	}
+	return tfs.Root(), tfs.Close, nil
+}
+
+func ExtractKernel(kernelSetPath string) ([]byte, error) {
+	f, err := os.Open(kernelSetPath)
+	if err != nil {
+		return nil, fmt.Errorf("open FreeBSD kernel set %s: %w", kernelSetPath, err)
+	}
+	defer f.Close()
+	xzr, err := xz.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("read FreeBSD kernel xz %s: %w", kernelSetPath, err)
+	}
+	tr := tar.NewReader(xzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("FreeBSD kernel set %s does not contain boot/kernel/kernel", kernelSetPath)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read FreeBSD kernel set: %w", err)
+		}
+		if cleanTarPath(hdr.Name) != "/boot/kernel/kernel" {
+			continue
+		}
+		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+			return nil, fmt.Errorf("FreeBSD kernel entry has tar type %q", hdr.Typeflag)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("read FreeBSD kernel payload: %w", err)
+		}
+		return data, nil
+	}
+}
+
+func normalizeConfig(cfg Config) Config {
+	if cfg.Version == "" {
+		cfg.Version = defaultVersion
+	}
+	if cfg.Arch == "" {
+		cfg.Arch = defaultArch
+	}
+	if cfg.Mirror == "" {
+		cfg.Mirror = defaultMirror
+	}
+	if cfg.CacheDir == "" {
+		cfg.CacheDir = filepath.Join(os.TempDir(), "cc-freebsd")
+	}
+	cfg.Mirror = strings.TrimRight(cfg.Mirror, "/")
+	return cfg
+}
+
+func ensureArtifact(ctx context.Context, cfg Config, name string) (string, error) {
+	if local := localFixturePath(cfg, name); local != "" {
+		return local, nil
+	}
+	dir := filepath.Join(cfg.CacheDir, "freebsd", cfg.Version, cfg.Arch)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create FreeBSD cache dir: %w", err)
+	}
+	target := filepath.Join(dir, name)
+	if st, err := os.Stat(target); err == nil && st.Size() > 0 {
+		return target, nil
+	}
+	url := cfg.Mirror + "/" + cfg.Arch + "/" + cfg.Version + "-RELEASE/" + name
+	if err := downloadFile(ctx, url, target); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func localFixturePath(cfg Config, name string) string {
+	for _, candidate := range []string{
+		filepath.Join("local", "freebsd"+versionNoDot(cfg.Version)+"-"+cfg.Arch, name),
+		filepath.Join(".cache", "freebsd"+versionNoDot(cfg.Version), name),
+	} {
+		if st, err := os.Stat(candidate); err == nil && st.Size() > 0 {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func downloadFile(ctx context.Context, url, target string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create FreeBSD download request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected HTTP status %s", url, resp.Status)
+	}
+	tmp := target + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmp, err)
+	}
+	_, copyErr := io.Copy(out, resp.Body)
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write %s: %w", tmp, copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close %s: %w", tmp, closeErr)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("install %s: %w", target, err)
+	}
+	return nil
+}
+
+func cleanTarPath(name string) string {
+	clean := path.Clean("/" + strings.TrimPrefix(name, "/"))
+	if clean == "." {
+		return "/"
+	}
+	return clean
+}
+
+func versionNoDot(version string) string {
+	return strings.ReplaceAll(version, ".", "")
+}
+
+const managedInitScript = `#!/bin/sh
+/sbin/mount -t devfs devfs /dev || :
+echo FREEBSD_FULL_BASE_INIT_OK >/dev/console 2>&1 || :
+while :; do
+	/bin/sleep 3600
+done
+`

--- a/internal/freebsd/rootfs/rootfs_test.go
+++ b/internal/freebsd/rootfs/rootfs_test.go
@@ -58,7 +58,8 @@ func TestBuildManagedRootFromFreeBSDBaseSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := initEntry.File.ReadAt(0, 256)
+	initSize, _ := initEntry.File.Stat()
+	data, err := initEntry.File.ReadAt(0, uint32(initSize))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/freebsd/rootfs/rootfs_test.go
+++ b/internal/freebsd/rootfs/rootfs_test.go
@@ -26,6 +26,10 @@ func TestExtractKernelFromFreeBSDReleaseSet(t *testing.T) {
 	if len(kernel) < 4 || string(kernel[:4]) != "\x7fELF" {
 		t.Fatalf("kernel does not start with ELF magic: %x", kernel[:min(len(kernel), 4)])
 	}
+	kernelTar := strings.TrimSuffix(kernelTXZ, filepath.Ext(kernelTXZ)) + ".tar"
+	if st, err := os.Stat(kernelTar); err != nil || st.Size() == 0 {
+		t.Fatalf("decompressed kernel tar was not cached: stat=%v err=%v", st, err)
+	}
 }
 
 func TestBuildManagedRootFromFreeBSDBaseSet(t *testing.T) {
@@ -41,7 +45,11 @@ func TestBuildManagedRootFromFreeBSDBaseSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, guestPath := range []string{"/bin/sh", "/sbin/init", "/etc/fstab", "/dev/console"} {
+	baseTar := strings.TrimSuffix(baseTXZ, filepath.Ext(baseTXZ)) + ".tar"
+	if st, err := os.Stat(baseTar); err != nil || st.Size() == 0 {
+		t.Fatalf("decompressed base tar was not cached: stat=%v err=%v", st, err)
+	}
+	for _, guestPath := range []string{"/bin/sh", "/sbin/init", "/sbin/cc-freebsd-init", "/etc/fstab", "/dev/console"} {
 		if _, err := imagefs.LookupPath(root, guestPath); err != nil {
 			t.Fatalf("lookup %s: %v", guestPath, err)
 		}
@@ -50,12 +58,23 @@ func TestBuildManagedRootFromFreeBSDBaseSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := initEntry.File.ReadAt(0, 64)
+	data, err := initEntry.File.ReadAt(0, 256)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "test init") {
+	if !strings.Contains(string(data), "cc-freebsd-init") {
 		t.Fatalf("unexpected /sbin/init overlay: %q", data)
+	}
+	agentEntry, err := imagefs.LookupPath(root, "/sbin/cc-freebsd-init")
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentData, err := agentEntry.File.ReadAt(0, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(agentData), "test init") {
+		t.Fatalf("unexpected /sbin/cc-freebsd-init overlay: %q", agentData)
 	}
 }
 

--- a/internal/freebsd/rootfs/rootfs_test.go
+++ b/internal/freebsd/rootfs/rootfs_test.go
@@ -1,0 +1,148 @@
+package rootfs
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ulikunitz/xz"
+	"j5.nz/cc/internal/imagefs"
+)
+
+func TestExtractKernelFromFreeBSDReleaseSet(t *testing.T) {
+	kernelTXZ := writeTXZFixture(t, []tarFixtureEntry{
+		{name: "boot/kernel/kernel", mode: 0o555, data: []byte("\x7fELFfreebsd-kernel")},
+	})
+	kernel, err := ExtractKernel(kernelTXZ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kernel) < 4 || string(kernel[:4]) != "\x7fELF" {
+		t.Fatalf("kernel does not start with ELF magic: %x", kernel[:min(len(kernel), 4)])
+	}
+}
+
+func TestBuildManagedRootFromFreeBSDBaseSet(t *testing.T) {
+	baseTXZ := writeTXZFixture(t, []tarFixtureEntry{
+		{name: "bin", mode: 0o755, dir: true},
+		{name: "bin/sh", mode: 0o555, data: []byte("#!/bin/sh\n")},
+		{name: "sbin", mode: 0o755, dir: true},
+		{name: "sbin/init", mode: 0o555, data: []byte("base init\n")},
+		{name: "etc", mode: 0o755, dir: true},
+		{name: "dev", mode: 0o755, dir: true},
+	})
+	root, err := BuildManagedRoot(context.Background(), baseTXZ, []byte("#!/bin/sh\necho test init\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, guestPath := range []string{"/bin/sh", "/sbin/init", "/etc/fstab", "/dev/console"} {
+		if _, err := imagefs.LookupPath(root, guestPath); err != nil {
+			t.Fatalf("lookup %s: %v", guestPath, err)
+		}
+	}
+	initEntry, err := imagefs.LookupPath(root, "/sbin/init")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := initEntry.File.ReadAt(0, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "test init") {
+		t.Fatalf("unexpected /sbin/init overlay: %q", data)
+	}
+}
+
+func TestBuildManagedRuntimeFromFreeBSDReleaseSets(t *testing.T) {
+	if _, ok := os.LookupEnv("CC_TEST_FREEBSD_ROOTFS"); !ok {
+		t.Skip("set CC_TEST_FREEBSD_ROOTFS=1 to build the full FreeBSD rootfs")
+	}
+	rt, err := BuildManagedRuntime(context.Background(), Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	if len(rt.Kernel) < 4 || string(rt.Kernel[:4]) != "\x7fELF" {
+		t.Fatalf("kernel does not start with ELF magic")
+	}
+	if rt.Root == nil || rt.Root.Size() == 0 {
+		t.Fatal("root filesystem was not built")
+	}
+}
+
+type tarFixtureEntry struct {
+	name string
+	mode int64
+	dir  bool
+	data []byte
+}
+
+func writeTXZFixture(t *testing.T, entries []tarFixtureEntry) string {
+	t.Helper()
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	for _, entry := range entries {
+		typ := byte(tar.TypeReg)
+		size := int64(len(entry.data))
+		name := strings.TrimPrefix(entry.name, "/")
+		if entry.dir {
+			typ = tar.TypeDir
+			size = 0
+			name = strings.TrimSuffix(name, "/") + "/"
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     entry.mode,
+			Size:     size,
+			Typeflag: typ,
+			ModTime:  time.Unix(1700000000, 0),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if !entry.dir {
+			if _, err := io.Copy(tw, bytes.NewReader(entry.data)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var xzBuf bytes.Buffer
+	xzw, err := xz.NewWriter(&xzBuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(xzw, bytes.NewReader(tarBuf.Bytes())); err != nil {
+		t.Fatal(err)
+	}
+	if err := xzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "fixture.txz")
+	if err := os.WriteFile(out, xzBuf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func localFreeBSDFixture(t *testing.T, name string) string {
+	t.Helper()
+	for _, candidate := range []string{
+		filepath.Join(".cache", "freebsd151", name),
+		filepath.Join("..", "..", "..", ".cache", "freebsd151", name),
+		filepath.Join("local", "freebsd151-amd64", name),
+	} {
+		if st, err := os.Stat(candidate); err == nil && st.Size() > 0 {
+			return candidate
+		}
+	}
+	t.Skipf("FreeBSD fixture %s not present", name)
+	return ""
+}

--- a/internal/fsimage/ffs/build.go
+++ b/internal/fsimage/ffs/build.go
@@ -184,12 +184,13 @@ func cylinderGroupSize(ipg, fpg uint32) uint32 {
 
 type UFS1Dinode [ffsInodeSize]byte
 
-func (d *UFS1Dinode) SetMode(mode uint16)     { binary.LittleEndian.PutUint16(d[0:2], mode) }
-func (d *UFS1Dinode) SetNlink(n uint16)       { binary.LittleEndian.PutUint16(d[2:4], n) }
-func (d *UFS1Dinode) SetSize(size uint64)     { binary.LittleEndian.PutUint64(d[8:16], size) }
-func (d *UFS1Dinode) SetAccessTime(ts uint32) { binary.LittleEndian.PutUint32(d[16:20], ts) }
-func (d *UFS1Dinode) SetModifyTime(ts uint32) { binary.LittleEndian.PutUint32(d[24:28], ts) }
-func (d *UFS1Dinode) SetChangeTime(ts uint32) { binary.LittleEndian.PutUint32(d[32:36], ts) }
+func (d *UFS1Dinode) SetMode(mode uint16)      { binary.LittleEndian.PutUint16(d[0:2], mode) }
+func (d *UFS1Dinode) SetNlink(n uint16)        { binary.LittleEndian.PutUint16(d[2:4], n) }
+func (d *UFS1Dinode) SetDirDepth(depth uint32) { binary.LittleEndian.PutUint32(d[4:8], depth) }
+func (d *UFS1Dinode) SetSize(size uint64)      { binary.LittleEndian.PutUint64(d[8:16], size) }
+func (d *UFS1Dinode) SetAccessTime(ts uint32)  { binary.LittleEndian.PutUint32(d[16:20], ts) }
+func (d *UFS1Dinode) SetModifyTime(ts uint32)  { binary.LittleEndian.PutUint32(d[24:28], ts) }
+func (d *UFS1Dinode) SetChangeTime(ts uint32)  { binary.LittleEndian.PutUint32(d[32:36], ts) }
 func (d *UFS1Dinode) SetDirectBlock(i int, b uint32) {
 	binary.LittleEndian.PutUint32(d[40+i*4:44+i*4], b)
 }
@@ -336,6 +337,7 @@ type ffsNode struct {
 	rdev       uint32
 	modTime    time.Time
 	size       uint64
+	depth      uint32
 	file       imagefs.File
 	target     string
 	parent     *ffsNode
@@ -538,7 +540,11 @@ func (b *ffsBuilder) collectDir(dir imagefs.Directory, guestPath string, parent 
 	}
 	mode := ifdir | uint16(dir.Stat().Perm())
 	uid, gid := dir.Owner()
-	node := &ffsNode{name: name, ino: b.allocIno(), mode: mode, uid: uid, gid: gid, parent: parent, modTime: dir.ModTime()}
+	depth := uint32(0)
+	if parent != nil {
+		depth = parent.depth + 1
+	}
+	node := &ffsNode{name: name, ino: b.allocIno(), mode: mode, uid: uid, gid: gid, parent: parent, modTime: dir.ModTime(), depth: depth}
 	children, err := dir.ReadDir()
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", guestPath, err)
@@ -823,6 +829,9 @@ func (b *ffsBuilder) writeInode(node *ffsNode) {
 	var ino UFS1Dinode
 	ino.SetMode(node.mode)
 	ino.SetNlink(uint16(b.linkCount(node)))
+	if node.mode&ifmt == ifdir {
+		ino.SetDirDepth(node.depth)
+	}
 	ino.SetSize(node.size)
 	t := uint32(b.now)
 	if !node.modTime.IsZero() {
@@ -942,7 +951,7 @@ func (b *ffsBuilder) writeSuperblocks(rootNode *ffsNode) {
 	for cgx := uint32(0); cgx < b.cgCount; cgx++ {
 		base, end := b.cgRange(cgx)
 		if base+ffsSBlkNo+uint32(len(sb))/ffsFSize <= end {
-			_, _ = b.vm.WriteAt(sb[:], b.fsOffset+int64((base+ffsSBlkNo)*ffsFSize))
+			_, _ = b.vm.WriteAt(sb[:], b.fsOffset+fragByteOffset(base+ffsSBlkNo))
 		}
 	}
 	b.writeCylinderSummary(rootNode)
@@ -964,7 +973,7 @@ func (b *ffsBuilder) writeCylinderSummary(rootNode *ffsNode) {
 		binary.LittleEndian.PutUint32(summary[off+8:off+12], nifree)
 		binary.LittleEndian.PutUint32(summary[off+12:off+16], nffree)
 	}
-	_, _ = b.vm.WriteAt(summary[:], b.fsOffset+int64(b.dataStart*ffsFSize))
+	_, _ = b.vm.WriteAt(summary[:], b.fsOffset+fragByteOffset(b.dataStart))
 }
 
 func (b *ffsBuilder) writeCylinderGroups(rootNode *ffsNode) {
@@ -987,8 +996,11 @@ func (b *ffsBuilder) writeCylinderGroup(cgx uint32, rootNode *ffsNode) {
 	}
 	nextfreeoff := freeoff + uint32((b.cgFrags+7)/8)
 	ncyl := uint16(1)
-	if cgx != 0 && cgx == b.cgCount-1 && cgFrags < b.cgFrags {
-		ncyl = 0
+	if cgx == b.cgCount-1 && cgFrags < b.cgFrags {
+		ncyl = uint16((cgFrags + b.cgFrags - 1) / b.cgFrags)
+		if ncyl == 0 {
+			ncyl = 1
+		}
 	}
 	cg.SetHeader(cgx, b.now, b.ipg, cgFrags, ncyl)
 	cg.SetSummary(ndir, nbfree, b.ipg-uint32(countUsedInos(b.usedInosForCG(cgx))), nffree)
@@ -1008,7 +1020,7 @@ func (b *ffsBuilder) writeCylinderGroup(cgx uint32, rootNode *ffsNode) {
 		cg.SetFragSummary(uint32(size), count)
 	}
 	cg.SetBlockTotals(btotoff, boff, nbfree)
-	_, _ = b.vm.WriteAt(cg[:], b.fsOffset+int64((base+ffsCBlkNo)*ffsFSize))
+	_, _ = b.vm.WriteAt(cg[:], b.fsOffset+fragByteOffset(base+ffsCBlkNo))
 }
 
 func (b *ffsBuilder) freeFragmentRunsRange(start, limit uint32) [ffsFrag]uint32 {
@@ -1141,7 +1153,7 @@ func (b *ffsBuilder) usedInosForCG(cgx uint32) []bool {
 func (b *ffsBuilder) inodeOffset(ino uint32) int64 {
 	cgx := ino / b.ipg
 	local := ino % b.ipg
-	return b.fsOffset + int64((cgx*b.cgFrags+ffsIBlkNo)*ffsFSize+local*ffsInodeSize)
+	return b.fsOffset + fragByteOffset(cgx*b.cgFrags+ffsIBlkNo) + int64(local)*int64(ffsInodeSize)
 }
 
 func encodeFFSDir(node *ffsNode) []byte {
@@ -1245,6 +1257,10 @@ func roundUp(v, align int64) int64 {
 
 func roundUpFrag(v, frag uint32) uint32 {
 	return ((v + frag - 1) / frag) * frag
+}
+
+func fragByteOffset(frag uint32) int64 {
+	return int64(frag) * int64(ffsFSize)
 }
 
 func countUsedInos(inos []bool) int {

--- a/internal/fsimage/ffs/build.go
+++ b/internal/fsimage/ffs/build.go
@@ -20,6 +20,7 @@ type Options struct {
 	SizeBytes         int64
 	ExtraBytes        int64
 	DeterministicTime time.Time
+	Layout            Layout
 }
 
 const (
@@ -69,6 +70,13 @@ const (
 	ifreg  = 0o100000
 	iflnk  = 0o120000
 	ifsock = 0o140000
+)
+
+type Layout string
+
+const (
+	LayoutOpenBSDDisk Layout = ""
+	LayoutRaw         Layout = "raw"
 )
 
 type Superblock [8192]byte
@@ -382,6 +390,14 @@ func Build(ctx context.Context, root imagefs.Directory, opts Options) (*ffsimgvm
 	}
 	fsOffset := int64(ffsPartLBA * ffsSectorSize)
 	totalSize := fsOffset + fsSize
+	switch opts.Layout {
+	case LayoutOpenBSDDisk:
+	case LayoutRaw:
+		fsOffset = 0
+		totalSize = fsSize
+	default:
+		return nil, fmt.Errorf("unsupported FFS layout %q", opts.Layout)
+	}
 	cgFrags := uint32(fsSize / ffsFSize)
 	if cgFrags > ffsMaxFPG {
 		cgFrags = ffsMaxFPG
@@ -448,8 +464,10 @@ func Build(ctx context.Context, root imagefs.Directory, opts Options) (*ffsimgvm
 	if err := b.writeTree(rootNode); err != nil {
 		return nil, err
 	}
-	b.writeMBR()
-	b.writeDisklabel()
+	if opts.Layout == LayoutOpenBSDDisk {
+		b.writeMBR()
+		b.writeDisklabel()
+	}
 	b.writeSuperblocks(rootNode)
 	b.writeCylinderGroups(rootNode)
 	return b.vm, nil

--- a/internal/fsimage/ffs/build_test.go
+++ b/internal/fsimage/ffs/build_test.go
@@ -109,6 +109,41 @@ func TestBuildFFSRawLayoutStartsAtBlockDeviceRoot(t *testing.T) {
 	}
 }
 
+func TestBuildFFSRawLayoutLargeCylinderGroupsAtFreeBSDOffsets(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "sbin"))
+	mustWriteMode(t, filepath.Join(root, "sbin", "init"), "hello freebsd\n", 0o755)
+	img, err := Build(context.Background(), imagefs.NewHostFS(root, nil), Options{
+		SizeBytes:         5 << 30,
+		DeterministicTime: time.Unix(1234, 0),
+		Layout:            LayoutRaw,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sb [ffsBSize]byte
+	if _, err := img.ReadAt(sb[:], ffsSBOFF); err != nil {
+		t.Fatal(err)
+	}
+	fpg := binary.LittleEndian.Uint32(sb[188:192])
+	if fpg == 0 {
+		t.Fatal("superblock fs_fpg is zero")
+	}
+	for cgx := uint32(0); cgx < 4; cgx++ {
+		var cg [ffsBSize]byte
+		off := int64((cgx*fpg + ffsCBlkNo) * ffsFSize)
+		if _, err := img.ReadAt(cg[:], off); err != nil {
+			t.Fatalf("read cg %d at %d: %v", cgx, off, err)
+		}
+		if got := binary.LittleEndian.Uint32(cg[4:8]); got != cgMagic {
+			t.Fatalf("cg %d magic at FreeBSD offset = %#x, want %#x", cgx, got, cgMagic)
+		}
+		if got := binary.LittleEndian.Uint32(cg[12:16]); got != cgx {
+			t.Fatalf("cg %d cgx at FreeBSD offset = %d", cgx, got)
+		}
+	}
+}
+
 func TestBuildFFSLazilyMapsRegularFiles(t *testing.T) {
 	file := &lazyTestFile{data: []byte("lazy payload\n")}
 	root := lazyTestDir{entries: map[string]imagefs.Entry{

--- a/internal/fsimage/ffs/build_test.go
+++ b/internal/fsimage/ffs/build_test.go
@@ -79,6 +79,36 @@ func TestBuildFFSWritesOpenBSDRoot(t *testing.T) {
 	}
 }
 
+func TestBuildFFSRawLayoutStartsAtBlockDeviceRoot(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "sbin"))
+	mustWriteMode(t, filepath.Join(root, "sbin", "init"), "hello freebsd\n", 0o755)
+	img, err := Build(context.Background(), imagefs.NewHostFS(root, nil), Options{
+		SizeBytes:         16 << 20,
+		DeterministicTime: time.Unix(1234, 0),
+		Layout:            LayoutRaw,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, img.Size())
+	if _, err := img.ReadAt(data, 0); err != nil {
+		t.Fatal(err)
+	}
+	if got := binary.LittleEndian.Uint32(data[ffsSBOFF+1372 : ffsSBOFF+1376]); got != ffsMagic {
+		t.Fatalf("raw superblock magic = %#x, want %#x", got, ffsMagic)
+	}
+	labelOff := ffsPartLBA*ffsSectorSize + ffsSectorSize
+	if got := binary.LittleEndian.Uint32(data[labelOff : labelOff+4]); got == dlMagic {
+		t.Fatalf("raw layout unexpectedly wrote OpenBSD disklabel magic %#x", got)
+	}
+	reader := newRawFFSTestReader(t, data)
+	initIno := reader.lookupPath("/sbin/init")
+	if got := string(reader.fileData(initIno)); got != "hello freebsd\n" {
+		t.Fatalf("/sbin/init contents = %q", got)
+	}
+}
+
 func TestBuildFFSLazilyMapsRegularFiles(t *testing.T) {
 	file := &lazyTestFile{data: []byte("lazy payload\n")}
 	root := lazyTestDir{entries: map[string]imagefs.Entry{
@@ -445,6 +475,20 @@ type ffsTestReader struct {
 func newFFSTestReader(t *testing.T, data []byte) *ffsTestReader {
 	t.Helper()
 	return newFFSTestReaderAt(t, bytes.NewReader(data))
+}
+
+func newRawFFSTestReader(t *testing.T, data []byte) *ffsTestReader {
+	t.Helper()
+	sb := make([]byte, ffsSBOFF+192)
+	copy(sb, data[:len(sb)])
+	return &ffsTestReader{
+		t:     t,
+		data:  bytes.NewReader(data),
+		base:  0,
+		fsize: int(binary.LittleEndian.Uint32(sb[ffsSBOFF+52 : ffsSBOFF+56])),
+		ipg:   binary.LittleEndian.Uint32(sb[ffsSBOFF+184 : ffsSBOFF+188]),
+		fpg:   binary.LittleEndian.Uint32(sb[ffsSBOFF+188 : ffsSBOFF+192]),
+	}
 }
 
 func newFFSTestReaderAt(t *testing.T, data io.ReaderAt) *ffsTestReader {

--- a/internal/fsimage/fsimage.go
+++ b/internal/fsimage/fsimage.go
@@ -30,6 +30,7 @@ type Options struct {
 	ExtraBytes        int64
 	DeterministicTime time.Time
 	Ext4UUID          ext4.UUID
+	FFSLayout         ffsimage.Layout
 	FATType           string
 	FATVolumeSerial   *uint32
 }
@@ -140,6 +141,7 @@ func ffsOptions(opts Options) ffsimage.Options {
 		SizeBytes:         opts.SizeBytes,
 		ExtraBytes:        opts.ExtraBytes,
 		DeterministicTime: opts.DeterministicTime,
+		Layout:            opts.FFSLayout,
 	}
 }
 

--- a/internal/hv/kvm/bindings_linux_amd64.go
+++ b/internal/hv/kvm/bindings_linux_amd64.go
@@ -32,6 +32,7 @@ const (
 	kvmSetSregs            = 0x4138ae84
 	kvmSetMSRS             = 0x4008ae89
 	kvmSetCpuid2           = 0x4008ae90
+	kvmGetTSCKHz           = 0xaea3
 )
 
 const (
@@ -141,6 +142,17 @@ func getSupportedCPUID(kvmFd int) (*kvmCPUID2, error) {
 func setVCPUID(vcpuFd int, cpuid *kvmCPUID2) error {
 	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetCpuid2), uintptr(unsafe.Pointer(cpuid)))
 	return err
+}
+
+func getVCPUTSCKHz(vcpuFd int) (uint32, error) {
+	value, err := ioctlInt(vcpuFd, kvmGetTSCKHz)
+	if err != nil {
+		return 0, err
+	}
+	if value <= 0 {
+		return 0, unix.EINVAL
+	}
+	return uint32(value), nil
 }
 
 func setVCPUMSR(vcpuFd int, index uint32, value uint64) error {
@@ -268,6 +280,39 @@ func setCPUIDBrandString(cpuid *kvmCPUID2, brand string) {
 		entry.Ecx = le32(encoded[off+8:])
 		entry.Edx = le32(encoded[off+12:])
 	}
+}
+
+func setCPUIDKVMHypervisorFrequency(cpuid *kvmCPUID2, tscKHz uint32) {
+	if cpuid == nil || tscKHz == 0 {
+		return
+	}
+	base := ensureCPUIDEntry(cpuid, 0x40000000, 0)
+	if base == nil {
+		return
+	}
+	base.Flags &^= kvmCPUIDFlagSignificantIndex
+	if base.Eax < 0x40000010 {
+		base.Eax = 0x40000010
+	}
+	copyCPUIDString12(base, "KVMKVMKVM\x00\x00\x00")
+
+	frequency := ensureCPUIDEntry(cpuid, 0x40000010, 0)
+	if frequency == nil {
+		return
+	}
+	frequency.Flags &^= kvmCPUIDFlagSignificantIndex
+	frequency.Eax = tscKHz
+	frequency.Ebx = 0
+	frequency.Ecx = 0
+	frequency.Edx = 0
+}
+
+func copyCPUIDString12(entry *kvmCPUIDEntry2, value string) {
+	var encoded [12]byte
+	copy(encoded[:], value)
+	entry.Ebx = le32(encoded[0:])
+	entry.Ecx = le32(encoded[4:])
+	entry.Edx = le32(encoded[8:])
 }
 
 func hostCPUBrandString() string {

--- a/internal/hv/kvm/bootstrap_linux_amd64.go
+++ b/internal/hv/kvm/bootstrap_linux_amd64.go
@@ -148,6 +148,9 @@ func (b *Bootstrap) InitVCPUWithTopology(vmfd, vcpufd, id, cpus int) error {
 	}
 	setCPUIDTopology(cpuid, id, cpus)
 	setCPUIDBrandString(cpuid, hostCPUBrandString())
+	if tscKHz, err := getVCPUTSCKHz(vcpufd); err == nil {
+		setCPUIDKVMHypervisorFrequency(cpuid, tscKHz)
+	}
 	return setVCPUID(vcpufd, cpuid)
 }
 

--- a/internal/hv/kvm/cpuid_linux_amd64_test.go
+++ b/internal/hv/kvm/cpuid_linux_amd64_test.go
@@ -1,0 +1,61 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestSetCPUIDKVMHypervisorFrequency(t *testing.T) {
+	cpuid := newTestCPUID(t)
+
+	setCPUIDKVMHypervisorFrequency(cpuid, 2_918_287)
+
+	base := findCPUIDEntry(t, cpuid, 0x40000000, 0)
+	if base.Eax < 0x40000010 {
+		t.Fatalf("hypervisor max leaf = %#x, want at least 0x40000010", base.Eax)
+	}
+	if got := cpuidString12(base); got != "KVMKVMKVM\x00\x00\x00" {
+		t.Fatalf("hypervisor vendor = %q", got)
+	}
+	freq := findCPUIDEntry(t, cpuid, 0x40000010, 0)
+	if freq.Eax != 2_918_287 {
+		t.Fatalf("TSC frequency leaf eax = %d, want 2918287", freq.Eax)
+	}
+}
+
+func newTestCPUID(t *testing.T) *kvmCPUID2 {
+	t.Helper()
+	size := unsafe.Sizeof(kvmCPUID2{}) + unsafe.Sizeof(kvmCPUIDEntry2{})*cpuidMaxEntries
+	buf := make([]byte, size)
+	cpuid := (*kvmCPUID2)(unsafe.Pointer(&buf[0]))
+	cpuid.Nr = 0
+	return cpuid
+}
+
+func findCPUIDEntry(t *testing.T, cpuid *kvmCPUID2, function, index uint32) kvmCPUIDEntry2 {
+	t.Helper()
+	for _, entry := range cpuidEntries(cpuid) {
+		if entry.Function == function && entry.Index == index {
+			return entry
+		}
+	}
+	t.Fatalf("missing CPUID leaf %#x index %#x", function, index)
+	return kvmCPUIDEntry2{}
+}
+
+func cpuidString12(entry kvmCPUIDEntry2) string {
+	var out [12]byte
+	putLE32(out[0:], entry.Ebx)
+	putLE32(out[4:], entry.Ecx)
+	putLE32(out[8:], entry.Edx)
+	return string(out[:])
+}
+
+func putLE32(out []byte, value uint32) {
+	out[0] = byte(value)
+	out[1] = byte(value >> 8)
+	out[2] = byte(value >> 16)
+	out[3] = byte(value >> 24)
+}

--- a/internal/hv/kvm/freebsd_boot_linux_amd64.go
+++ b/internal/hv/kvm/freebsd_boot_linux_amd64.go
@@ -1,0 +1,145 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"j5.nz/cc/internal/amd64vm"
+	freebsdamd64 "j5.nz/cc/internal/freebsd/boot/amd64"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+)
+
+func BootFreeBSDKernelToMarker(ctx context.Context, kernel []byte, memoryMB uint64, marker string) (string, error) {
+	if strings.TrimSpace(marker) == "" {
+		return "", fmt.Errorf("boot marker is required")
+	}
+	return bootFreeBSDToCondition(ctx, kernel, memoryMB, nil, nil, nil, func(serial string) bool {
+		return strings.Contains(serial, marker)
+	})
+}
+
+func BootFreeBSDKernelToMarkerWithPCIBlockNetConsole(ctx context.Context, kernel []byte, memoryMB uint64, marker string, block *virtio.Block, netdev *virtio.Net, input func(string) []byte) (string, error) {
+	if strings.TrimSpace(marker) == "" {
+		return "", fmt.Errorf("boot marker is required")
+	}
+	return bootFreeBSDToCondition(ctx, kernel, memoryMB, []*virtio.Block{block}, netdev, input, func(serial string) bool {
+		return strings.Contains(serial, marker)
+	})
+}
+
+func BootFreeBSDKernelToSerial(ctx context.Context, kernel []byte, memoryMB uint64) (string, error) {
+	return bootFreeBSDToCondition(ctx, kernel, memoryMB, nil, nil, nil, func(serial string) bool {
+		return serial != ""
+	})
+}
+
+func bootFreeBSDToCondition(ctx context.Context, kernel []byte, memoryMB uint64, blocks []*virtio.Block, netdev *virtio.Net, input func(string) []byte, done func(string) bool) (string, error) {
+	vm, err := NewVM()
+	if err != nil {
+		return "", err
+	}
+	defer vm.Close()
+
+	mem, err := mapAMD64GuestMemory(vm, memoryMB)
+	if err != nil {
+		return "", fmt.Errorf("map guest memory: %w", err)
+	}
+
+	var serialOut bytes.Buffer
+	uart := serial.NewUART8250(amd64vm.COM1Base, 0, &serialOut)
+	uart.AttachIRQ(vm, amd64vm.COM1IRQ)
+	var pci *PCIBus
+	var pciDevices []*PCIDevice
+	for i, block := range blocks {
+		if block == nil {
+			continue
+		}
+		block.Attach(vm, vm)
+		pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(uint8(1+i), uint16(0x1000+i*0x100), uint8(10+i), block))
+	}
+	if netdev != nil {
+		netdev.Attach(vm, vm)
+		netIndex := len(pciDevices) + 1
+		pciDevices = append(pciDevices, NewVirtioNetPCIDevice(uint8(netIndex), uint16(0x1000+netIndex*0x100), uint8(10+netIndex), netdev))
+	}
+	if len(pciDevices) > 0 {
+		pci = NewPCIBus(pciDevices...)
+	}
+	plan, err := freebsdamd64.PrepareBoot(mem, kernel, freebsdamd64.BootOptions{
+		MemorySize: amd64vm.MemorySizeBytes(memoryMB),
+	})
+	if err != nil {
+		return "", fmt.Errorf("prepare FreeBSD boot: %w", err)
+	}
+	if err := vm.SetFreeBSDLongMode(plan.EntryGVA, plan.StackGPA, plan.PagingGPA); err != nil {
+		return "", fmt.Errorf("set FreeBSD long mode: %w", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	vm.SetVCPUTID(0, unix.Gettid())
+	defer vm.SetVCPUTID(0, 0)
+	cancelDone := make(chan struct{})
+	defer close(cancelDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			vm.RequestImmediateExit()
+		case <-cancelDone:
+		}
+	}()
+
+	var exit Exit
+	for step := 0; ; step++ {
+		if err := ctx.Err(); err != nil {
+			if done(serialOut.String()) {
+				return serialOut.String(), nil
+			}
+			return serialOut.String(), err
+		}
+		if err := vm.RunVCPUInterruptible(0, &exit); err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return serialOut.String(), fmt.Errorf("run step %d: %w", step, err)
+		}
+		if done(serialOut.String()) {
+			return serialOut.String(), nil
+		}
+		if input != nil {
+			if data := input(serialOut.String()); len(data) != 0 {
+				go func(data []byte) {
+					_ = uart.InjectRXBytes(data)
+				}(append([]byte(nil), data...))
+			}
+		}
+		switch exit.Reason {
+		case ExitIO:
+			if err := handleBootIOWithPCI(func(ioExit IOExit) error {
+				return handleBootIO(uart, ioExit)
+			}, pci, exit.IO); err != nil {
+				return serialOut.String(), err
+			}
+		case ExitMMIO:
+			return serialOut.String(), fmt.Errorf("unhandled FreeBSD mmio addr=%#x len=%d write=%v", exit.MMIO.Addr, exit.MMIO.Len, exit.MMIO.Write)
+		case ExitHLT:
+			return serialOut.String(), fmt.Errorf("FreeBSD guest halted before marker")
+		case ExitShutdown:
+			pc, _ := vm.GetPC()
+			return serialOut.String(), fmt.Errorf("FreeBSD guest shut down before marker at pc=%#x", pc)
+		case ExitSystemEvent:
+			return serialOut.String(), fmt.Errorf("unexpected system event %d before marker", exit.SystemEvent)
+		default:
+			pc, _ := vm.GetPC()
+			return serialOut.String(), fmt.Errorf("unexpected exit reason %d at pc=%#x", exit.Reason, pc)
+		}
+	}
+}

--- a/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
+++ b/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
@@ -11,6 +11,8 @@ import (
 
 	"j5.nz/cc/client"
 	freebsdrootfs "j5.nz/cc/internal/freebsd/rootfs"
+	"j5.nz/cc/internal/fsimage"
+	ffsimage "j5.nz/cc/internal/fsimage/ffs"
 	"j5.nz/cc/internal/virtio"
 )
 
@@ -94,5 +96,130 @@ func TestFreeBSDManagedSessionExec(t *testing.T) {
 	}
 	if resp.ExitCode != 0 || strings.TrimSpace(resp.Output) != "freebsd-managed:FreeBSD:copy:stdin-ok" {
 		t.Fatalf("FreeBSD exec response = code %d output %q", resp.ExitCode, resp.Output)
+	}
+	resp, err = session.Exec(ctx, client.ExecRequest{
+		Command: []string{"/bin/sh", "-c", strings.Join([]string{
+			"set -eu",
+			"mount | grep -E ' on /(tmp|root) ' && exit 1 || true",
+			"printf write-ok > /tmp/cc-freebsd-write-test",
+			"printf root-write-ok > /root/cc-freebsd-root-write-test",
+			"cat /tmp/cc-freebsd-write-test",
+			"printf ':'",
+			"cat /root/cc-freebsd-root-write-test",
+		}, "\n")},
+		WorkDir: "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("FreeBSD managed write exec: %v", err)
+	}
+	if resp.ExitCode != 0 || strings.TrimSpace(resp.Output) != "write-ok:root-write-ok" {
+		t.Fatalf("FreeBSD write response = code %d output %q", resp.ExitCode, resp.Output)
+	}
+}
+
+func TestFreeBSDManagedSessionFsckFFSGeneratedRootOnSecondDisk(t *testing.T) {
+	if os.Getenv("CC_TEST_FREEBSD_ROOTFS") == "" {
+		t.Skip("set CC_TEST_FREEBSD_ROOTFS=1 to build and fsck the full FreeBSD rootfs")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	t.Log("building FreeBSD managed runtime")
+	rt, err := freebsdrootfs.BuildManagedRuntime(ctx, freebsdrootfs.Config{})
+	if err != nil {
+		t.Fatalf("build FreeBSD runtime: %v", err)
+	}
+	defer rt.Close()
+
+	t.Log("building FreeBSD fsck candidate root")
+	candidateRegion, err := fsimage.Build(ctx, rt.RootFS, fsimage.Options{
+		Type:              fsimage.TypeFFS,
+		FFSLayout:         ffsimage.LayoutRaw,
+		DeterministicTime: time.Unix(1700000001, 0),
+		ExtraBytes:        128 << 20,
+	})
+	if err != nil {
+		t.Fatalf("build FreeBSD fsck candidate root: %v", err)
+	}
+
+	t.Log("booting FreeBSD managed session with candidate root on vtbd1")
+	session, err := StartFreeBSDManagedSession(ctx, FreeBSDManagedConfig{
+		Kernel:      rt.Kernel,
+		Root:        rt.Root,
+		ExtraBlocks: []virtio.BlockBackend{candidateRegion},
+		MemoryMB:    1024,
+	}, nil)
+	if err != nil {
+		t.Fatalf("start FreeBSD managed fsck session: %v", err)
+	}
+	defer session.Close()
+
+	resp, err := session.Exec(ctx, client.ExecRequest{
+		Command: []string{"/bin/sh", "-c", "/sbin/fsck_ffs -fn /dev/vtbd1"},
+		WorkDir: "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("FreeBSD pre-write fsck exec: %v", err)
+	}
+	assertFreeBSDFsckClean(t, "pre-write", resp)
+
+	resp, err = session.Exec(ctx, client.ExecRequest{
+		Command: []string{"/bin/sh", "-c", strings.Join([]string{
+			"set -eu",
+			"mkdir -p /tmp/cc-ufs-write",
+			"mount -t ufs /dev/vtbd1 /tmp/cc-ufs-write",
+			"trap 'umount /tmp/cc-ufs-write || true' EXIT",
+			"mkdir -p /tmp/cc-ufs-write/cc-write-test/nested",
+			"printf 'freebsd-write-ok' > /tmp/cc-ufs-write/cc-write-test/nested/payload.txt",
+			"dd if=/dev/zero bs=4096 count=3 2>/dev/null | tr '\\000' A > /tmp/cc-ufs-write/cc-write-test/nested/blob.bin",
+			"sync",
+			"cat /tmp/cc-ufs-write/cc-write-test/nested/payload.txt",
+			"test \"$(wc -c < /tmp/cc-ufs-write/cc-write-test/nested/blob.bin | tr -d ' ')\" = 12288",
+			"umount /tmp/cc-ufs-write",
+			"trap - EXIT",
+		}, "\n")},
+		WorkDir: "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("FreeBSD write/mount exec: %v", err)
+	}
+	if resp.ExitCode != 0 || !strings.Contains(resp.Output, "freebsd-write-ok") {
+		t.Fatalf("FreeBSD write/mount response = code %d output:\n%s", resp.ExitCode, resp.Output)
+	}
+
+	resp, err = session.Exec(ctx, client.ExecRequest{
+		Command: []string{"/bin/sh", "-c", "/sbin/fsck_ffs -fn /dev/vtbd1"},
+		WorkDir: "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("FreeBSD post-write fsck exec: %v", err)
+	}
+	assertFreeBSDFsckClean(t, "post-write", resp)
+}
+
+func assertFreeBSDFsckClean(t *testing.T, label string, resp client.ExecResponse) {
+	t.Helper()
+	t.Logf("FreeBSD %s fsck_ffs output:\n%s", label, resp.Output)
+	if resp.ExitCode != 0 {
+		t.Fatalf("FreeBSD %s fsck_ffs exit code = %d output:\n%s", label, resp.ExitCode, resp.Output)
+	}
+	for _, bad := range []string{
+		"BAD SUPER BLOCK",
+		"INCORRECT",
+		"UNREF",
+		"BAD/DUP",
+		"FREE BLK COUNT(S) WRONG",
+		"SUMMARY INFORMATION BAD",
+		"BLK(S) MISSING IN BIT MAPS",
+		"FILE SYSTEM WAS MODIFIED",
+		"INTEGRITY CHECK FAILED",
+		"REBUILD CYLINDER GROUP",
+		"MARKED",
+		"failed:",
+		"PHASE 5 SKIPPED",
+		"UPDATE FILESYSTEM",
+	} {
+		if strings.Contains(resp.Output, bad) {
+			t.Fatalf("FreeBSD %s fsck_ffs found FFS inconsistency %q:\n%s", label, bad, resp.Output)
+		}
 	}
 }

--- a/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
+++ b/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
@@ -5,8 +5,12 @@ package kvm
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
+
+	freebsdrootfs "j5.nz/cc/internal/freebsd/rootfs"
+	"j5.nz/cc/internal/virtio"
 )
 
 func TestBootFreeBSDKernelToSerialFromEnv(t *testing.T) {
@@ -20,7 +24,11 @@ func TestBootFreeBSDKernelToSerialFromEnv(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	serial, err := BootFreeBSDKernelToMarker(ctx, kernel, 1024, "FreeBSD")
+	marker := os.Getenv("CC_FREEBSD_MARKER")
+	if marker == "" {
+		marker = "FreeBSD"
+	}
+	serial, err := BootFreeBSDKernelToMarker(ctx, kernel, 1024, marker)
 	if err != nil {
 		t.Fatalf("boot FreeBSD kernel: %v\nserial:\n%s", err, serial)
 	}
@@ -28,4 +36,29 @@ func TestBootFreeBSDKernelToSerialFromEnv(t *testing.T) {
 		t.Fatalf("expected serial output")
 	}
 	t.Logf("serial:\n%s", serial)
+}
+
+func TestBootFreeBSDFullBaseRootFromReleaseSets(t *testing.T) {
+	if os.Getenv("CC_TEST_FREEBSD_ROOTFS") == "" {
+		t.Skip("set CC_TEST_FREEBSD_ROOTFS=1 to build and boot the full FreeBSD rootfs")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	rt, err := freebsdrootfs.BuildManagedRuntime(ctx, freebsdrootfs.Config{})
+	if err != nil {
+		t.Fatalf("build FreeBSD runtime: %v", err)
+	}
+	defer rt.Close()
+	block := virtio.NewBlock(0, 0x1000, 10, rt.Root)
+	serial, err := BootFreeBSDKernelToMarkerWithPCIBlockNetConsole(ctx, rt.Kernel, 1024, "random: unblocking device.", block, nil, nil)
+	t.Logf("serial tail:\n%s", tailString(serial, 8192))
+	if err != nil {
+		t.Fatalf("boot FreeBSD full base root: %v\nserial:\n%s", err, serial)
+	}
+	if !strings.Contains(serial, "start_init: trying /sbin/init") {
+		t.Fatalf("FreeBSD did not start /sbin/init:\n%s", serial)
+	}
+	if strings.Contains(serial, "init died") {
+		t.Fatalf("FreeBSD init died:\n%s", serial)
+	}
 }

--- a/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
+++ b/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"j5.nz/cc/client"
 	freebsdrootfs "j5.nz/cc/internal/freebsd/rootfs"
 	"j5.nz/cc/internal/virtio"
 )
@@ -60,5 +61,38 @@ func TestBootFreeBSDFullBaseRootFromReleaseSets(t *testing.T) {
 	}
 	if strings.Contains(serial, "init died") {
 		t.Fatalf("FreeBSD init died:\n%s", serial)
+	}
+}
+
+func TestFreeBSDManagedSessionExec(t *testing.T) {
+	if os.Getenv("CC_TEST_FREEBSD_ROOTFS") == "" {
+		t.Skip("set CC_TEST_FREEBSD_ROOTFS=1 to build and boot the full FreeBSD rootfs")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	rt, err := freebsdrootfs.BuildManagedRuntime(ctx, freebsdrootfs.Config{})
+	if err != nil {
+		t.Fatalf("build FreeBSD runtime: %v", err)
+	}
+	defer rt.Close()
+	session, err := StartFreeBSDManagedSession(ctx, FreeBSDManagedConfig{
+		Kernel:   rt.Kernel,
+		Root:     rt.Root,
+		MemoryMB: 1024,
+	}, nil)
+	if err != nil {
+		t.Fatalf("start FreeBSD managed session: %v", err)
+	}
+	defer session.Close()
+	resp, err := session.Exec(ctx, client.ExecRequest{
+		Command: []string{"/bin/sh", "-c", "printf 'freebsd-managed:'; printf %s \"$(uname -s)\"; printf ':copy:'; cat"},
+		Stdin:   []byte("stdin-ok"),
+		WorkDir: "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("FreeBSD managed exec: %v", err)
+	}
+	if resp.ExitCode != 0 || strings.TrimSpace(resp.Output) != "freebsd-managed:FreeBSD:copy:stdin-ok" {
+		t.Fatalf("FreeBSD exec response = code %d output %q", resp.ExitCode, resp.Output)
 	}
 }

--- a/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
+++ b/internal/hv/kvm/freebsd_boot_linux_amd64_test.go
@@ -1,0 +1,31 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestBootFreeBSDKernelToSerialFromEnv(t *testing.T) {
+	kernelPath := os.Getenv("CC_FREEBSD_KERNEL")
+	if kernelPath == "" {
+		t.Skip("CC_FREEBSD_KERNEL is not set")
+	}
+	kernel, err := os.ReadFile(kernelPath)
+	if err != nil {
+		t.Fatalf("read kernel: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	serial, err := BootFreeBSDKernelToMarker(ctx, kernel, 1024, "FreeBSD")
+	if err != nil {
+		t.Fatalf("boot FreeBSD kernel: %v\nserial:\n%s", err, serial)
+	}
+	if serial == "" {
+		t.Fatalf("expected serial output")
+	}
+	t.Logf("serial:\n%s", serial)
+}

--- a/internal/hv/kvm/freebsd_session_linux_amd64.go
+++ b/internal/hv/kvm/freebsd_session_linux_amd64.go
@@ -24,10 +24,11 @@ import (
 const freeBSDControlPort = 10777
 
 type FreeBSDManagedConfig struct {
-	Kernel   []byte
-	Root     virtio.BlockBackend
-	MemoryMB uint64
-	Dmesg    bool
+	Kernel      []byte
+	Root        virtio.BlockBackend
+	ExtraBlocks []virtio.BlockBackend
+	MemoryMB    uint64
+	Dmesg       bool
 }
 
 func StartFreeBSDManagedSession(ctx context.Context, cfg FreeBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
@@ -93,13 +94,25 @@ func StartFreeBSDManagedSession(ctx context.Context, cfg FreeBSDManagedConfig, o
 	uart := serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter)
 	uart.AttachIRQ(kvmVM, amd64vm.COM1IRQ)
 
+	var pciDevices []*PCIDevice
 	block := virtio.NewBlock(0, 0x1000, 10, cfg.Root)
 	block.Attach(kvmVM, kvmVM)
+	pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(1, 0x1000, 10, block))
+	for i, backend := range cfg.ExtraBlocks {
+		if backend == nil {
+			continue
+		}
+		dev := uint8(2 + i)
+		ioBase := uint16(0x1100 + i*0x100)
+		irq := uint8(11 + i)
+		extraBlock := virtio.NewBlock(0, 0x1000, uint32(irq), backend)
+		extraBlock.Attach(kvmVM, kvmVM)
+		pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(dev, ioBase, irq, extraBlock))
+	}
 	netdev.Attach(kvmVM, kvmVM)
-	pci := NewPCIBus(
-		NewVirtioBlockPCIDevice(1, 0x1000, 10, block),
-		NewVirtioNetPCIDevice(2, 0x1100, 11, netdev),
-	)
+	netIndex := len(pciDevices) + 1
+	pciDevices = append(pciDevices, NewVirtioNetPCIDevice(uint8(netIndex), uint16(0x1000+netIndex*0x100), uint8(10+netIndex), netdev))
+	pci := NewPCIBus(pciDevices...)
 
 	plan, err := freebsdamd64.PrepareBoot(mem, cfg.Kernel, freebsdamd64.BootOptions{
 		MemorySize: amd64vm.MemorySizeBytes(cfg.MemoryMB),

--- a/internal/hv/kvm/freebsd_session_linux_amd64.go
+++ b/internal/hv/kvm/freebsd_session_linux_amd64.go
@@ -1,0 +1,260 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/amd64vm"
+	freebsdamd64 "j5.nz/cc/internal/freebsd/boot/amd64"
+	"j5.nz/cc/internal/netstack"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const freeBSDControlPort = 10777
+
+type FreeBSDManagedConfig struct {
+	Kernel   []byte
+	Root     virtio.BlockBackend
+	MemoryMB uint64
+	Dmesg    bool
+}
+
+func StartFreeBSDManagedSession(ctx context.Context, cfg FreeBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	cfg, err := normalizeFreeBSDManagedConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	netdev, stack := newFreeBSDManagedNet()
+	ln, err := stack.ListenInternal("tcp", fmt.Sprintf(":%d", freeBSDControlPort))
+	if err != nil {
+		stack.Close()
+		return nil, fmt.Errorf("listen FreeBSD control tcp: %w", err)
+	}
+
+	var kvmVM *VM
+	var cancel context.CancelFunc
+	var bootWriter *vmruntime.BootEventWriter
+	cleanupStartup := func() {
+		if cancel != nil {
+			cancel()
+		}
+		_ = ln.Close()
+		stack.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		if kvmVM != nil {
+			kvmVM.Close()
+		}
+	}
+
+	connCh := make(chan net.Conn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+
+	kvmVM, err = NewVM()
+	if err != nil {
+		cleanupStartup()
+		return nil, err
+	}
+	mem, err := mapAMD64GuestMemory(kvmVM, cfg.MemoryMB)
+	if err != nil {
+		cleanupStartup()
+		return nil, fmt.Errorf("map guest memory: %w", err)
+	}
+
+	serialOut := vmruntime.NewSerialTranscript()
+	var serialWriter io.Writer = serialOut
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = io.MultiWriter(serialOut, bootWriter)
+	}
+	uart := serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter)
+	uart.AttachIRQ(kvmVM, amd64vm.COM1IRQ)
+
+	block := virtio.NewBlock(0, 0x1000, 10, cfg.Root)
+	block.Attach(kvmVM, kvmVM)
+	netdev.Attach(kvmVM, kvmVM)
+	pci := NewPCIBus(
+		NewVirtioBlockPCIDevice(1, 0x1000, 10, block),
+		NewVirtioNetPCIDevice(2, 0x1100, 11, netdev),
+	)
+
+	plan, err := freebsdamd64.PrepareBoot(mem, cfg.Kernel, freebsdamd64.BootOptions{
+		MemorySize: amd64vm.MemorySizeBytes(cfg.MemoryMB),
+	})
+	if err != nil {
+		cleanupStartup()
+		return nil, fmt.Errorf("prepare FreeBSD boot: %w", err)
+	}
+	if err := kvmVM.SetFreeBSDLongMode(plan.EntryGVA, plan.StackGPA, plan.PagingGPA); err != nil {
+		cleanupStartup()
+		return nil, fmt.Errorf("set FreeBSD long mode: %w", err)
+	}
+
+	runCtx, runCancel := context.WithCancel(context.Background())
+	cancel = runCancel
+	doneCh := make(chan error, 1)
+	vmForRun := kvmVM
+	kvmVM = nil
+	go func() {
+		defer vmForRun.Close()
+		doneCh <- runFreeBSDManagedVM(runCtx, vmForRun, uart, pci, serialOut)
+	}()
+
+	var control net.Conn
+	select {
+	case err := <-acceptErrCh:
+		cleanupStartup()
+		return nil, freeBSDStartupError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+	case err := <-doneCh:
+		cleanupStartup()
+		return nil, freeBSDStartupError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		cleanupStartup()
+		err := fmt.Errorf("FreeBSD guest did not connect to control TCP port %d before startup deadline: %w", freeBSDControlPort, ctx.Err())
+		return nil, freeBSDStartupError(err, serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		_ = control.Close()
+		cleanupStartup()
+		err = fmt.Errorf("FreeBSD control connection did not report ready marker %q: %w", vmruntime.InstanceReadyMarker, err)
+		return nil, freeBSDStartupError(err, serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		_ = control.Close()
+		cleanupStartup()
+		return nil, freeBSDStartupError(fmt.Errorf("FreeBSD guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+
+	return &ManagedSession{
+		cancel:     cancel,
+		doneCh:     doneCh,
+		control:    control,
+		listener:   ln,
+		bootWriter: bootWriter,
+		transcript: controlTranscript,
+		serialOut:  serialOut,
+		cleanup: func() {
+			_ = stack.Close()
+		},
+		dmesg: cfg.Dmesg,
+	}, nil
+}
+
+func normalizeFreeBSDManagedConfig(cfg FreeBSDManagedConfig) (FreeBSDManagedConfig, error) {
+	if len(cfg.Kernel) == 0 {
+		return FreeBSDManagedConfig{}, fmt.Errorf("FreeBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return FreeBSDManagedConfig{}, fmt.Errorf("FreeBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 1024
+	}
+	return cfg, nil
+}
+
+func freeBSDStartupError(err error, serialText, controlText string) error {
+	return transcriptError(err, serialText, controlText)
+}
+
+func runFreeBSDManagedVM(ctx context.Context, vm *VM, uart *serial.UART8250, pci *PCIBus, serialOut *vmruntime.SerialTranscript) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	vm.SetVCPUTID(0, unix.Gettid())
+	defer vm.SetVCPUTID(0, 0)
+	cancelDone := make(chan struct{})
+	defer close(cancelDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			vm.RequestImmediateExit()
+		case <-cancelDone:
+		}
+	}()
+
+	var exit Exit
+	for step := 0; ; step++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := vm.RunVCPUInterruptible(0, &exit); err != nil {
+			if errorsIsEINTR(err) {
+				continue
+			}
+			return fmt.Errorf("run step %d: %w", step, err)
+		}
+		switch exit.Reason {
+		case ExitIO:
+			if err := handleBootIOWithPCI(func(ioExit IOExit) error {
+				return handleBootIO(uart, ioExit)
+			}, pci, exit.IO); err != nil {
+				return err
+			}
+		case ExitMMIO:
+			return fmt.Errorf("unhandled FreeBSD mmio addr=%#x len=%d write=%v", exit.MMIO.Addr, exit.MMIO.Len, exit.MMIO.Write)
+		case ExitHLT:
+			return fmt.Errorf("FreeBSD guest halted\nserial:\n%s", serialOut.String())
+		case ExitShutdown:
+			return fmt.Errorf("FreeBSD guest shut down\nserial:\n%s", serialOut.String())
+		case ExitSystemEvent:
+			return fmt.Errorf("unexpected system event %d\nserial:\n%s", exit.SystemEvent, serialOut.String())
+		default:
+			pc, _ := vm.GetPC()
+			return fmt.Errorf("unexpected exit reason %d at pc=%#x\nserial:\n%s", exit.Reason, pc, serialOut.String())
+		}
+	}
+}
+
+type freeBSDManagedNetBackend struct {
+	iface *netstack.NetworkInterface
+}
+
+func (b freeBSDManagedNetBackend) HandleTxPacket(packet []byte) error {
+	return b.iface.DeliverGuestPacket(packet, true)
+}
+
+func newFreeBSDManagedNet() (*virtio.Net, *netstack.NetStack) {
+	mac := net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}
+	stack := netstack.New(slog.Default())
+	_ = stack.SetGuestMAC(mac)
+	_ = stack.SetGuestIPv4(net.IPv4(10, 42, 0, 2))
+	iface, _ := stack.AttachNetworkInterface()
+	dev := virtio.NewNet(0, 0x1000, 11, mac, freeBSDManagedNetBackend{iface: iface})
+	dev.DisableMergeRX = true
+	iface.AttachVirtioBackend(func(frame []byte) error {
+		copied := append([]byte(nil), frame...)
+		go func() {
+			_ = dev.EnqueueRxPacketOwned(copied)
+		}()
+		return nil
+	})
+	return dev, stack
+}

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -608,6 +608,53 @@ func (v *VM) SetLongMode(entry, zeroPage, stack, pagingBase uint64) error {
 	})
 }
 
+func (v *VM) SetFreeBSDLongMode(entry, stack, pagingBase uint64) error {
+	if v == nil || len(v.vcpus) == 0 {
+		return fmt.Errorf("missing bootstrap vcpu")
+	}
+	if err := v.setupFreeBSDPageTables(pagingBase, 4); err != nil {
+		return err
+	}
+	bsp := v.vcpus[0]
+	sregs, err := getSRegs(bsp.fd)
+	if err != nil {
+		return err
+	}
+	const (
+		cr0PE   = 1 << 0
+		cr0MP   = 1 << 1
+		cr0ET   = 1 << 4
+		cr0NE   = 1 << 5
+		cr0WP   = 1 << 16
+		cr0AM   = 1 << 18
+		cr0PG   = 1 << 31
+		cr4PAE  = 1 << 5
+		eferLME = 1 << 8
+		eferLMA = 1 << 10
+	)
+	sregs.Cr3 = pagingBase
+	sregs.Cr4 |= cr4PAE
+	sregs.Cr0 |= cr0PE | cr0MP | cr0ET | cr0NE | cr0WP | cr0AM | cr0PG
+	sregs.Efer = eferLME | eferLMA
+
+	code := kvmSegment{Base: 0, Limit: 0xffffffff, Selector: 0x8, Type: 11, Present: 1, S: 1, L: 1, G: 1}
+	data := kvmSegment{Base: 0, Limit: 0xffffffff, Selector: 0x10, Type: 3, Present: 1, S: 1, Db: 1, G: 1}
+	sregs.Cs = code
+	sregs.Ds = data
+	sregs.Es = data
+	sregs.Fs = data
+	sregs.Gs = data
+	sregs.Ss = data
+	if err := setSRegs(bsp.fd, &sregs); err != nil {
+		return err
+	}
+	return setRegs(bsp.fd, &kvmRegs{
+		Rip:    entry,
+		Rsp:    stack,
+		Rflags: 0x2,
+	})
+}
+
 func (v *VM) SetProtectedMode32(entry, stack uint64) error {
 	if v == nil || len(v.vcpus) == 0 {
 		return fmt.Errorf("missing bootstrap vcpu")
@@ -669,6 +716,31 @@ func (v *VM) setupPageTables(pagingBase uint64, giB int) error {
 			phys := (uint64(g) << 30) | (uint64(i) << 21)
 			put64(pd+uint64(i)*8, phys|p|rw|us|ps)
 		}
+	}
+	return nil
+}
+
+func (v *VM) setupFreeBSDPageTables(pagingBase uint64, giB int) error {
+	if pagingBase+0x3000 > uint64(len(v.mem)) {
+		return fmt.Errorf("paging structures do not fit")
+	}
+	put64 := func(addr, value uint64) {
+		binary.LittleEndian.PutUint64(v.mem[addr:addr+8], value)
+	}
+	pml4 := pagingBase
+	pdpt := pagingBase + 0x1000
+	pd := pagingBase + 0x2000
+	const (
+		p  = 1 << 0
+		rw = 1 << 1
+		us = 1 << 2
+		ps = 1 << 7
+	)
+	for i := 0; i < 512; i++ {
+		put64(pml4+uint64(i)*8, pdpt|p|rw|us)
+		put64(pdpt+uint64(i)*8, pd|p|rw|us)
+		phys := uint64(i) << 21
+		put64(pd+uint64(i)*8, phys|p|rw|us|ps)
 	}
 	return nil
 }

--- a/internal/imagefs/imagefs_test.go
+++ b/internal/imagefs/imagefs_test.go
@@ -144,6 +144,44 @@ func TestTarFSKeepsImplicitDirectoryChildrenWhenDirectoryHeaderAppearsLater(t *t
 	}
 }
 
+func TestSeekableTarFSReadsPayloadsFromTarFile(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	mustWriteTarFile(t, tw, "bin/tool", "tool payload")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "bin/tool-hardlink",
+		Typeflag: tar.TypeLink,
+		Mode:     0o644,
+		Linkname: "bin/tool",
+	}); err != nil {
+		t.Fatalf("write hardlink header: %v", err)
+	}
+	mustWriteTarFile(t, tw, "etc/config", "config payload")
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	tarPath := filepath.Join(t.TempDir(), "root.tar")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tar: %v", err)
+	}
+
+	tfs, err := NewSeekableTarFS(context.Background(), tarPath)
+	if err != nil {
+		t.Fatalf("read seekable tarfs: %v", err)
+	}
+	defer tfs.Close()
+	root := tfs.Root()
+	if got := readFile(t, root, "/bin/tool"); got != "tool payload" {
+		t.Fatalf("tool = %q", got)
+	}
+	if got := readFile(t, root, "/bin/tool-hardlink"); got != "tool payload" {
+		t.Fatalf("hardlink = %q", got)
+	}
+	if got := readFile(t, root, "/etc/config"); got != "config payload" {
+		t.Fatalf("config = %q", got)
+	}
+}
+
 func direntNames(entries []DirEnt) string {
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {

--- a/internal/imagefs/tarfs.go
+++ b/internal/imagefs/tarfs.go
@@ -18,6 +18,7 @@ import (
 type TarFS struct {
 	root    *tarDir
 	backing *os.File
+	close   func() error
 	tmpDir  string
 	closed  bool
 }
@@ -52,7 +53,42 @@ func NewTarFSWithOptions(ctx context.Context, r io.Reader, opts TarFSOptions) (*
 		backing: backing,
 		tmpDir:  tmpDir,
 	}
+	tfs.close = func() error {
+		err := backing.Close()
+		if removeErr := os.RemoveAll(tmpDir); err == nil {
+			err = removeErr
+		}
+		return err
+	}
 	if err := tfs.read(ctx, r, opts); err != nil {
+		_ = tfs.Close()
+		return nil, err
+	}
+	return tfs, nil
+}
+
+func NewSeekableTarFS(ctx context.Context, filename string) (*TarFS, error) {
+	return NewSeekableTarFSWithOptions(ctx, filename, TarFSOptions{})
+}
+
+func NewSeekableTarFSWithOptions(ctx context.Context, filename string, opts TarFSOptions) (*TarFS, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("open tarfs backing file: %w", err)
+	}
+	tfs := &TarFS{
+		root: &tarDir{
+			node: tarNode{
+				name:    "",
+				mode:    fs.ModeDir | 0o755,
+				modTime: time.Unix(0, 0),
+			},
+			children: map[string]tarEntry{},
+		},
+		backing: f,
+		close:   f.Close,
+	}
+	if err := tfs.readSeekable(ctx, f, opts); err != nil {
 		_ = tfs.Close()
 		return nil, err
 	}
@@ -71,11 +107,10 @@ func (t *TarFS) Close() error {
 		return nil
 	}
 	t.closed = true
-	err := t.backing.Close()
-	if removeErr := os.RemoveAll(t.tmpDir); err == nil {
-		err = removeErr
+	if t.close != nil {
+		return t.close()
 	}
-	return err
+	return nil
 }
 
 func (t *TarFS) read(ctx context.Context, r io.Reader, opts TarFSOptions) error {
@@ -104,6 +139,58 @@ func (t *TarFS) read(ctx context.Context, r io.Reader, opts TarFSOptions) error 
 			return err
 		}
 		entry, err := t.entryFromHeader(hdr, tr, clean, byPath)
+		if err != nil {
+			return err
+		}
+		parent.children[name] = entry
+		byPath[clean] = entry
+	}
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.n += int64(n)
+	return n, err
+}
+
+func (t *TarFS) readSeekable(ctx context.Context, r io.Reader, opts TarFSOptions) error {
+	byPath := map[string]tarEntry{"/": {Dir: t.root}}
+	cr := &countingReader{r: r}
+	tr := tar.NewReader(cr)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		clean := cleanTarPath(hdr.Name)
+		if clean == "/" {
+			continue
+		}
+		included := opts.Include == nil || opts.Include(clean, hdr)
+		if !included {
+			if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
+				if _, err := io.CopyN(io.Discard, tr, hdr.Size); err != nil {
+					return fmt.Errorf("skip %s payload: %w", clean, err)
+				}
+			}
+			continue
+		}
+		parent, name, err := t.ensureParent(clean, hdr.ModTime, byPath)
+		if err != nil {
+			return err
+		}
+		entry, err := t.entryFromSeekableHeader(hdr, tr, clean, cr.n, byPath)
 		if err != nil {
 			return err
 		}
@@ -152,6 +239,53 @@ func (t *TarFS) entryFromHeader(hdr *tar.Header, tr *tar.Reader, clean string, b
 			node:    node,
 			backing: t.backing,
 			offset:  offset,
+			size:    uint64(hdr.Size),
+			key:     clean,
+		}
+		return tarEntry{File: file}, nil
+	case tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
+		return tarEntry{File: &tarFile{node: node, key: clean}}, nil
+	default:
+		return tarEntry{}, fmt.Errorf("%s has unsupported tar entry type %q", clean, hdr.Typeflag)
+	}
+}
+
+func (t *TarFS) entryFromSeekableHeader(hdr *tar.Header, tr *tar.Reader, clean string, dataOffset int64, byPath map[string]tarEntry) (tarEntry, error) {
+	mode := linuxModeToGo(fsmeta.LinuxModeFromTarHeader(hdr))
+	node := tarNode{
+		name:    path.Base(clean),
+		mode:    mode,
+		uid:     uint32(hdr.Uid),
+		gid:     uint32(hdr.Gid),
+		rdev:    tarRDev(hdr),
+		modTime: hdr.ModTime,
+	}
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		dir := &tarDir{node: node, children: map[string]tarEntry{}}
+		if existing, ok := byPath[clean]; ok && existing.Dir != nil {
+			existing.Dir.node = node
+			return existing, nil
+		}
+		return tarEntry{Dir: dir}, nil
+	case tar.TypeSymlink:
+		return tarEntry{Symlink: &tarSymlink{node: node, target: fsmeta.NormalizeSymlinkTarget(hdr.Linkname)}}, nil
+	case tar.TypeLink:
+		target := cleanTarPath(hdr.Linkname)
+		entry, ok := byPath[target]
+		if !ok || entry.File == nil {
+			return tarEntry{}, fmt.Errorf("%s hardlink target %s not found", clean, target)
+		}
+		entry.File.addLink(clean)
+		return tarEntry{File: entry.File}, nil
+	case tar.TypeReg, tar.TypeRegA:
+		if _, err := io.CopyN(io.Discard, tr, hdr.Size); err != nil {
+			return tarEntry{}, fmt.Errorf("skip %s payload: %w", clean, err)
+		}
+		file := &tarFile{
+			node:    node,
+			backing: t.backing,
+			offset:  dataOffset,
 			size:    uint64(hdr.Size),
 			key:     clean,
 		}

--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -587,7 +587,7 @@ func (ns *NetStack) AttachNetworkInterface() (*NetworkInterface, error) {
 	if _, err := cryptoRand.Read(hostMAC); err != nil {
 		return nil, fmt.Errorf("generate host mac: %w", err)
 	}
-	hostMAC[0] |= 2 // Locally administered bit
+	hostMAC[0] = (hostMAC[0] | 2) &^ 1 // Locally administered unicast.
 	value, _ := macToUint64(hostMAC)
 	ns.hostMAC.Store(uint64(value))
 

--- a/internal/netstack/netstack_test.go
+++ b/internal/netstack/netstack_test.go
@@ -1,0 +1,27 @@
+package netstack
+
+import (
+	"net"
+	"testing"
+)
+
+func TestAttachNetworkInterfaceGeneratesUnicastHostMAC(t *testing.T) {
+	ns := New(nil)
+	if err := ns.SetGuestMAC(net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ns.AttachNetworkInterface(); err != nil {
+		t.Fatal(err)
+	}
+
+	host := macFromUint64(macAddr(ns.hostMAC.Load()))
+	if len(host) != 6 {
+		t.Fatalf("host mac length = %d", len(host))
+	}
+	if host[0]&1 != 0 {
+		t.Fatalf("host mac is multicast: %s", host.String())
+	}
+	if host[0]&2 == 0 {
+		t.Fatalf("host mac is not locally administered: %s", host.String())
+	}
+}

--- a/internal/virtio/block.go
+++ b/internal/virtio/block.go
@@ -107,7 +107,7 @@ func (b *Block) Read(addr uint64, size int) (uint64, error) {
 	case regVendorID:
 		return truncateValue(mmioVendorID, size), nil
 	case regDeviceFeatures:
-		features := featureVersion1 | blockFeatureSizeMax | blockFeatureSegMax | blockFeatureFlush
+		features := featureVersion1 | blockFeatureSegMax | blockFeatureFlush
 		if b.deviceFeatureSel == 0 {
 			return truncateValue(features, size), nil
 		}
@@ -491,7 +491,7 @@ func (b *Block) configBytesLocked() []byte {
 }
 
 func (b *Block) legacyFeaturesLocked() uint64 {
-	return blockFeatureSizeMax | blockFeatureSegMax | blockFeatureFlush
+	return blockFeatureSegMax | blockFeatureFlush
 }
 
 func (b *Block) updateIRQLocked() error {

--- a/internal/virtio/net.go
+++ b/internal/virtio/net.go
@@ -23,7 +23,8 @@ const (
 	netHdrFlagNeedsChecksum = 1
 
 	netStatusLinkUp      = 1
-	netHeaderLen         = 12
+	netHeaderLen         = 10
+	netHeaderLenMergeRX  = 12
 	maxNetPacketPoolSize = 256 * 1024
 )
 
@@ -49,6 +50,7 @@ type Net struct {
 	IRQ  uint32
 	MAC  net.HardwareAddr
 
+	DisableMergeRX   bool
 	mu               sync.Mutex
 	mem              GuestMemory
 	irq              IRQController
@@ -124,7 +126,7 @@ func (n *Net) Read(addr uint64, size int) (uint64, error) {
 	case regVendorID:
 		return truncateValue(mmioVendorID, size), nil
 	case regDeviceFeatures:
-		features := featureVersion1 | netFeatureMAC | netFeatureStatus | netFeatureMergeRX
+		features := n.deviceFeaturesLocked()
 		if n.deviceFeatureSel == 0 {
 			return truncateValue(features, size), nil
 		}
@@ -415,13 +417,14 @@ func (n *Net) processTXLocked(packets []netTXPacket) ([]netTXPacket, error) {
 			return nil, err
 		}
 		releaseData := data
-		if len(data) >= netHeaderLen {
-			if err := fixTXChecksum(data); err != nil {
+		headerLen := n.netHeaderLenLocked()
+		if len(data) >= headerLen {
+			if err := fixTXChecksum(data, headerLen); err != nil {
 				releaseNetPacketBuffer(releaseData)
 				releaseNetTXPackets(packets)
 				return nil, err
 			}
-			packet := data[netHeaderLen:]
+			packet := data[headerLen:]
 			if n.backend != nil {
 				if len(packets) == cap(packets) {
 					releaseNetPacketBuffer(releaseData)
@@ -543,9 +546,12 @@ func (n *Net) readChainLocked(q *queue, head uint16, writable bool) ([]byte, err
 }
 
 func (n *Net) writeRXPacketLocked(q *queue, head uint16, packet []byte) (uint32, error) {
-	var hdr [netHeaderLen]byte
-	binary.LittleEndian.PutUint16(hdr[10:12], 1)
-	totalLen := netHeaderLen + len(packet)
+	headerLen := n.netHeaderLenLocked()
+	var hdr [netHeaderLenMergeRX]byte
+	if headerLen == netHeaderLenMergeRX {
+		binary.LittleEndian.PutUint16(hdr[10:12], 1)
+	}
+	totalLen := headerLen + len(packet)
 	offset := 0
 	index := head
 	for i := uint16(0); i < q.size; i++ {
@@ -554,7 +560,7 @@ func (n *Net) writeRXPacketLocked(q *queue, head uint16, packet []byte) (uint32,
 			return uint32(offset), err
 		}
 		if desc.flags&descFWrite != 0 && desc.length > 0 && offset < totalLen {
-			written, err := n.writeRXChunk(desc.addr, int(desc.length), hdr[:], packet, offset)
+			written, err := n.writeRXChunk(desc.addr, int(desc.length), hdr[:headerLen], packet, offset)
 			if err != nil {
 				return uint32(offset), err
 			}
@@ -683,7 +689,22 @@ func (n *Net) configBytesLocked() []byte {
 }
 
 func (n *Net) legacyFeaturesLocked() uint64 {
-	return netFeatureMAC | netFeatureStatus | netFeatureMergeRX
+	return n.deviceFeaturesLocked() &^ featureVersion1
+}
+
+func (n *Net) deviceFeaturesLocked() uint64 {
+	features := featureVersion1 | netFeatureMAC | netFeatureStatus
+	if !n.DisableMergeRX {
+		features |= netFeatureMergeRX
+	}
+	return features
+}
+
+func (n *Net) netHeaderLenLocked() int {
+	if n.driverFeatures&netFeatureMergeRX != 0 {
+		return netHeaderLenMergeRX
+	}
+	return netHeaderLen
 }
 
 func (n *Net) resetLocked() {
@@ -700,8 +721,8 @@ func (n *Net) resetLocked() {
 	n.pendingRx = nil
 }
 
-func fixTXChecksum(frame []byte) error {
-	if len(frame) < netHeaderLen {
+func fixTXChecksum(frame []byte, headerLen int) error {
+	if len(frame) < headerLen {
 		return nil
 	}
 	flags := frame[0]
@@ -710,7 +731,7 @@ func fixTXChecksum(frame []byte) error {
 	}
 	csumStart := int(binary.LittleEndian.Uint16(frame[6:8]))
 	csumOffset := int(binary.LittleEndian.Uint16(frame[8:10]))
-	packet := frame[netHeaderLen:]
+	packet := frame[headerLen:]
 	if csumStart < 0 || csumStart >= len(packet) || csumStart+csumOffset+2 > len(packet) {
 		return fmt.Errorf("virtio-net checksum range out of packet: start=%d offset=%d len=%d", csumStart, csumOffset, len(packet))
 	}

--- a/internal/virtio/net_test.go
+++ b/internal/virtio/net_test.go
@@ -1,0 +1,113 @@
+package virtio
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+type testNetBackend struct {
+	packets [][]byte
+}
+
+func (b *testNetBackend) HandleTxPacket(packet []byte) error {
+	b.packets = append(b.packets, append([]byte(nil), packet...))
+	return nil
+}
+
+func TestNetLegacyFeaturesAdvertiseMergeRXByDefault(t *testing.T) {
+	dev := NewNet(0, 0x1000, 11, nil, nil)
+
+	features, err := dev.ReadLegacy(0, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features&netFeatureMergeRX == 0 {
+		t.Fatalf("legacy features are missing mergeable RX: %#x", features)
+	}
+	if features&netFeatureMAC == 0 || features&netFeatureStatus == 0 {
+		t.Fatalf("legacy features missing base net features: %#x", features)
+	}
+}
+
+func TestNetLegacyFeaturesCanDisableMergeRX(t *testing.T) {
+	dev := NewNet(0, 0x1000, 11, nil, nil)
+	dev.DisableMergeRX = true
+
+	features, err := dev.ReadLegacy(0, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features&netFeatureMergeRX != 0 {
+		t.Fatalf("legacy features include mergeable RX after disabling it: %#x", features)
+	}
+	if features&netFeatureMAC == 0 || features&netFeatureStatus == 0 {
+		t.Fatalf("legacy features missing base net features: %#x", features)
+	}
+}
+
+func TestNetLegacyTXStripsTenByteHeader(t *testing.T) {
+	mem := make(testGuestMemory, 0x20000)
+	backend := &testNetBackend{}
+	irq := &testIRQ{}
+	dev := NewNet(0, 0x1000, 11, net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}, backend)
+	dev.DisableMergeRX = true
+	dev.Attach(mem, irq)
+
+	if err := dev.WriteLegacy(14, 2, netQueueTX); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.WriteLegacy(8, 4, 0x10); err != nil {
+		t.Fatal(err)
+	}
+	packet := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02, 0x08, 0x06}
+	copy(mem[0x2000+netHeaderLen:], packet)
+	writeDesc(mem, 0x10000, 0x2000, uint32(netHeaderLen+len(packet)), 0, 0)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+2:], 1)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+4:], 0)
+
+	if err := dev.WriteLegacy(16, 2, netQueueTX); err != nil {
+		t.Fatal(err)
+	}
+	if len(backend.packets) != 1 {
+		t.Fatalf("packets = %d", len(backend.packets))
+	}
+	if !bytes.Equal(backend.packets[0], packet) {
+		t.Fatalf("packet = %x, want %x", backend.packets[0], packet)
+	}
+}
+
+func TestNetLegacyRXWritesTenByteHeader(t *testing.T) {
+	mem := make(testGuestMemory, 0x20000)
+	irq := &testIRQ{}
+	dev := NewNet(0, 0x1000, 11, nil, nil)
+	dev.DisableMergeRX = true
+	dev.Attach(mem, irq)
+
+	if err := dev.WriteLegacy(14, 2, netQueueRX); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.WriteLegacy(8, 4, 0x10); err != nil {
+		t.Fatal(err)
+	}
+	writeDesc(mem, 0x10000, 0x3000, 2048, descFWrite, 0)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+2:], 1)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+4:], 0)
+
+	packet := []byte{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x08, 0x00}
+	if err := dev.EnqueueRxPacket(packet); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := binary.LittleEndian.Uint16(mem[0x10000+16*netQueueSize+4096+4:]); got != 0 {
+		t.Fatalf("used element id = %d", got)
+	}
+	usedLen := binary.LittleEndian.Uint32(mem[0x10000+16*netQueueSize+4096+8:])
+	if usedLen != uint32(netHeaderLen+len(packet)) {
+		t.Fatalf("used len = %d, want %d", usedLen, netHeaderLen+len(packet))
+	}
+	if !bytes.Equal(mem[0x3000+netHeaderLen:0x3000+netHeaderLen+uint64(len(packet))], packet) {
+		t.Fatalf("packet payload was not written after ten-byte header")
+	}
+}

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -16,6 +16,7 @@ import (
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/amd64vm"
+	freebsdrootfs "j5.nz/cc/internal/freebsd/rootfs"
 	"j5.nz/cc/internal/fsimage"
 	"j5.nz/cc/internal/guestinit"
 	"j5.nz/cc/internal/hv/kvm"
@@ -46,6 +47,9 @@ func (b *runtimeBackend) Start(ctx context.Context, req client.CreateInstanceReq
 func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
 	if openbsdrootfs.IsBuiltInImage(req.Image) {
 		return b.startOpenBSDStream(ctx, req, onEvent)
+	}
+	if freebsdrootfs.IsBuiltInImage(req.Image) {
+		return b.startFreeBSDStream(ctx, req, onEvent)
 	}
 	if b == nil || b.kernel == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
@@ -125,6 +129,21 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		return b.startOpenBSDStream(ctx, client.CreateInstanceRequest{
 			ID:             req.ID,
 			Image:          openbsdrootfs.BuiltInImageName,
+			InitSystem:     req.InitSystem,
+			Kernel:         req.Kernel,
+			Network:        req.Network,
+			KernelModules:  append([]string(nil), req.KernelModules...),
+			MemoryMB:       req.MemoryMB,
+			CPUs:           req.CPUs,
+			NestedVirt:     req.NestedVirt,
+			Dmesg:          req.Dmesg,
+			TimeoutSeconds: req.TimeoutSeconds,
+		}, onEvent)
+	}
+	if freebsdrootfs.IsBuiltInImage(req.Image) {
+		return b.startFreeBSDStream(ctx, client.CreateInstanceRequest{
+			ID:             req.ID,
+			Image:          freebsdrootfs.BuiltInImageName,
 			InitSystem:     req.InitSystem,
 			Kernel:         req.Kernel,
 			Network:        req.Network,
@@ -225,6 +244,27 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 		defer inst.Close()
 		if len(req.Command) == 0 {
 			output, _ := inst.(*openbsdInstance).ConsoleHistory(ctx)
+			return client.ExecResponse{ExitCode: 0, Output: output}, nil
+		}
+		return inst.Exec(ctx, runExecRequest(req))
+	}
+	if freebsdrootfs.IsBuiltInImage(req.Image) {
+		inst, err := b.startFreeBSDStream(ctx, client.CreateInstanceRequest{
+			ID:             req.ID,
+			Image:          freebsdrootfs.BuiltInImageName,
+			InitSystem:     req.InitSystem,
+			Network:        req.Network,
+			MemoryMB:       req.MemoryMB,
+			CPUs:           req.CPUs,
+			Dmesg:          req.Dmesg,
+			TimeoutSeconds: req.TimeoutSeconds,
+		}, nil)
+		if err != nil {
+			return client.ExecResponse{}, err
+		}
+		defer inst.Close()
+		if len(req.Command) == 0 {
+			output, _ := inst.(*freebsdInstance).ConsoleHistory(ctx)
 			return client.ExecResponse{ExitCode: 0, Output: output}, nil
 		}
 		return inst.Exec(ctx, runExecRequest(req))
@@ -405,8 +445,8 @@ func (b *runtimeBackend) RunInInstance(ctx context.Context, inst Instance, runni
 			Rows:       req.Rows,
 		})
 	}
-	if openbsdrootfs.IsBuiltInImage(runningImage) || openbsdrootfs.IsBuiltInImage(targetImage) {
-		return client.ExecResponse{}, fmt.Errorf("OpenBSD instances do not support executing commands from alternate images yet")
+	if openbsdrootfs.IsBuiltInImage(runningImage) || openbsdrootfs.IsBuiltInImage(targetImage) || freebsdrootfs.IsBuiltInImage(runningImage) || freebsdrootfs.IsBuiltInImage(targetImage) {
+		return client.ExecResponse{}, fmt.Errorf("BSD instances do not support executing commands from alternate images yet")
 	}
 
 	session, ok := inst.(*linuxInstance)
@@ -469,8 +509,8 @@ func (b *runtimeBackend) RunInInstanceStream(ctx context.Context, inst Instance,
 		}
 		return inst.ExecStream(ctx, runExecRequest(req), inputs, onEvent)
 	}
-	if openbsdrootfs.IsBuiltInImage(runningImage) || openbsdrootfs.IsBuiltInImage(targetImage) {
-		return fmt.Errorf("OpenBSD instances do not support executing commands from alternate images yet")
+	if openbsdrootfs.IsBuiltInImage(runningImage) || openbsdrootfs.IsBuiltInImage(targetImage) || freebsdrootfs.IsBuiltInImage(runningImage) || freebsdrootfs.IsBuiltInImage(targetImage) {
+		return fmt.Errorf("BSD instances do not support executing commands from alternate images yet")
 	}
 
 	session, ok := inst.(*linuxInstance)
@@ -531,8 +571,8 @@ func (b *runtimeBackend) ExecInInstanceStream(ctx context.Context, inst Instance
 	if targetImage == "" || targetImage == runningImage {
 		return inst.ExecStream(ctx, req, inputs, onEvent)
 	}
-	if openbsdrootfs.IsBuiltInImage(runningImage) || openbsdrootfs.IsBuiltInImage(targetImage) {
-		return fmt.Errorf("OpenBSD instances do not support executing commands from alternate images yet")
+	if openbsdrootfs.IsBuiltInImage(runningImage) || openbsdrootfs.IsBuiltInImage(targetImage) || freebsdrootfs.IsBuiltInImage(runningImage) || freebsdrootfs.IsBuiltInImage(targetImage) {
+		return fmt.Errorf("BSD instances do not support executing commands from alternate images yet")
 	}
 	session, ok := inst.(*linuxInstance)
 	if !ok {
@@ -729,6 +769,189 @@ func (i *openbsdInstance) Close() error {
 }
 
 func openBSDEffectiveExecEnv(base, overrides []string, replace bool) []string {
+	defaults := []string{
+		"PATH=/bin:/sbin:/usr/bin:/usr/sbin",
+		"HOME=/root",
+		"TERM=xterm",
+	}
+	if replace {
+		return vmruntime.MergeEnv(defaults, overrides)
+	}
+	return vmruntime.MergeEnv(vmruntime.MergeEnv(defaults, base), overrides)
+}
+
+func (b *runtimeBackend) startFreeBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if b == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	if len(req.Shares) != 0 {
+		return nil, fmt.Errorf("FreeBSD runtime does not support filesystem shares yet")
+	}
+	if req.Network != nil && !req.Network.Enabled {
+		return nil, fmt.Errorf("FreeBSD runtime requires virtio-net for the managed control channel")
+	}
+	if req.CPUs > 1 {
+		return nil, fmt.Errorf("FreeBSD runtime currently supports one vCPU")
+	}
+	if req.NestedVirt {
+		return nil, fmt.Errorf("FreeBSD runtime does not support nested virtualization")
+	}
+	runtime, err := freebsdrootfs.BuildManagedRuntime(ctx, freeBSDRuntimeConfig(b.guestInitCache))
+	if err != nil {
+		return nil, err
+	}
+	session, err := kvm.StartFreeBSDManagedSession(ctx, kvm.FreeBSDManagedConfig{
+		Kernel:   runtime.Kernel,
+		Root:     runtime.Root,
+		MemoryMB: req.MemoryMB,
+		Dmesg:    req.Dmesg,
+	}, onEvent)
+	if err != nil {
+		_ = runtime.Close()
+		return nil, err
+	}
+	return &freebsdInstance{
+		session: session,
+		runtime: runtime,
+		root:    runtime.RootFS,
+		baseEnv: freeBSDEffectiveExecEnv(nil, nil, false),
+		workDir: "/",
+		dmesg:   req.Dmesg,
+	}, nil
+}
+
+func freeBSDRuntimeConfig(guestInitCache string) freebsdrootfs.Config {
+	cacheDir := guestInitCache
+	if cacheDir == "" {
+		cacheDir = filepath.Join(os.TempDir(), "cc-freebsd")
+	} else {
+		cacheDir = filepath.Join(filepath.Dir(cacheDir), "freebsd")
+	}
+	return freebsdrootfs.Config{CacheDir: cacheDir}
+}
+
+type freebsdInstance struct {
+	session *kvm.ManagedSession
+	runtime *freebsdrootfs.Runtime
+	root    imagefs.Directory
+	baseEnv []string
+	workDir string
+	dmesg   bool
+}
+
+func (i *freebsdInstance) Exec(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {
+	if i == nil || i.session == nil {
+		return client.ExecResponse{}, fmt.Errorf("instance is not running")
+	}
+	if req.Kind != "" && req.Kind != "exec" {
+		return i.session.Exec(ctx, req)
+	}
+	execReq, err := i.freeBSDExecRequest(req)
+	if err != nil {
+		return client.ExecResponse{}, err
+	}
+	return i.session.Exec(ctx, execReq)
+}
+
+func (i *freebsdInstance) AddShare(context.Context, client.ShareMount) error {
+	return fmt.Errorf("FreeBSD runtime does not support filesystem shares yet")
+}
+
+func (i *freebsdInstance) AddPortForward(context.Context, client.PortForward) error {
+	return fmt.Errorf("FreeBSD runtime does not support port forwards yet")
+}
+
+func (i *freebsdInstance) ExecStream(ctx context.Context, req client.ExecRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	if i == nil || i.session == nil {
+		return fmt.Errorf("instance is not running")
+	}
+	if req.Kind != "" && req.Kind != "exec" {
+		workDir := req.WorkDir
+		if workDir == "" {
+			workDir = i.workDir
+		}
+		req.WorkDir = workDir
+		return i.session.ExecStream(ctx, req, inputs, onEvent)
+	}
+	execReq, err := i.freeBSDExecRequest(req)
+	if err != nil {
+		return err
+	}
+	return i.session.ExecStream(ctx, execReq, inputs, onEvent)
+}
+
+func (i *freebsdInstance) freeBSDExecRequest(req client.ExecRequest) (client.ExecRequest, error) {
+	env := freeBSDEffectiveExecEnv(i.baseEnv, req.Env, req.ReplaceEnv)
+	command := append([]string(nil), req.Command...)
+	if !req.SkipResolve {
+		if i.root == nil {
+			return client.ExecRequest{}, fmt.Errorf("running FreeBSD instance does not have a root filesystem")
+		}
+		var err error
+		command, err = imagefs.ResolveCommand(i.root, req.Command, env)
+		if err != nil {
+			return client.ExecRequest{}, err
+		}
+	}
+	workDir := req.WorkDir
+	if workDir == "" {
+		workDir = i.workDir
+	}
+	if workDir == "" {
+		workDir = "/"
+	}
+	if !strings.HasPrefix(workDir, "/") {
+		return client.ExecRequest{}, fmt.Errorf("workdir must be absolute")
+	}
+	return client.ExecRequest{
+		Command:     command,
+		Env:         env,
+		RootDir:     req.RootDir,
+		ReplaceEnv:  req.ReplaceEnv,
+		SkipResolve: req.SkipResolve,
+		WorkDir:     workDir,
+		User:        req.User,
+		Stdin:       append([]byte(nil), req.Stdin...),
+		TTY:         req.TTY,
+		ControlFD:   req.ControlFD,
+		Cols:        req.Cols,
+		Rows:        req.Rows,
+	}, nil
+}
+
+func (i *freebsdInstance) Flush(ctx context.Context) error {
+	if i == nil || i.session == nil {
+		return nil
+	}
+	return i.session.Flush(ctx)
+}
+
+func (i *freebsdInstance) ConsoleHistory(ctx context.Context) (string, error) {
+	if i == nil || i.session == nil {
+		return "", nil
+	}
+	return i.session.ConsoleHistory(ctx)
+}
+
+func (i *freebsdInstance) Wait() error {
+	if i == nil || i.session == nil {
+		return nil
+	}
+	return i.session.Wait()
+}
+
+func (i *freebsdInstance) Close() error {
+	if i == nil || i.session == nil {
+		return nil
+	}
+	err := i.session.Close()
+	if closeErr := i.runtime.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func freeBSDEffectiveExecEnv(base, overrides []string, replace bool) []string {
 	defaults := []string{
 		"PATH=/bin:/sbin:/usr/bin:/usr/sbin",
 		"HOME=/root",

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -221,6 +221,72 @@ func TestRuntimeBootsOpenBSDBuiltinImage(t *testing.T) {
 	}
 }
 
+func TestRuntimeBootsFreeBSDBuiltinImage(t *testing.T) {
+	if os.Getenv("CC_TEST_FREEBSD_KVM") == "" {
+		t.Skip("set CC_TEST_FREEBSD_KVM=1 to run FreeBSD runtime boot test")
+	}
+	if err := Supports(); err != nil {
+		t.Skipf("VM runtime unsupported on this host: %v", err)
+	}
+	cacheRoot := runtimeBootCacheRoot(t)
+	backend := NewRuntimeBackend(nil, nil, filepath.Join(cacheRoot, "guestinit"))
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	inst, err := backend.StartStream(ctx, client.CreateInstanceRequest{
+		Image:    "@freebsd",
+		MemoryMB: 1024,
+	}, nil)
+	if err != nil {
+		t.Fatalf("boot FreeBSD runtime: %v", err)
+	}
+	defer inst.Close()
+
+	resp, err := inst.Exec(ctx, client.ExecRequest{
+		Command: []string{"sh", "-c", "printf 'freebsd-runtime:'; printf %s \"$(uname -s)\"; printf ':copy:'; cat"},
+		WorkDir: "/tmp",
+		Stdin:   []byte("stdin-ok"),
+	})
+	if err != nil {
+		t.Fatalf("FreeBSD runtime exec: %v", err)
+	}
+	if resp.ExitCode != 0 || strings.TrimSpace(resp.Output) != "freebsd-runtime:FreeBSD:copy:stdin-ok" {
+		t.Fatalf("FreeBSD exec response = code %d output %q", resp.ExitCode, resp.Output)
+	}
+
+	var controlOutput string
+	var controlExit *int
+	if err := inst.ExecStream(ctx, client.ExecRequest{
+		Command:   []string{"sh", "-c", "printf 'freebsd-control:%s\\n' \"$PWD\" >&3"},
+		WorkDir:   "/tmp",
+		ControlFD: true,
+	}, nil, func(event client.ExecEvent) error {
+		switch event.Kind {
+		case "control":
+			controlOutput += event.Output
+		case "exit":
+			code := event.ExitCode
+			controlExit = &code
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("FreeBSD runtime control fd exec: %v", err)
+	}
+	if controlExit == nil || *controlExit != 0 {
+		t.Fatalf("FreeBSD control fd exit = %v, want 0", controlExit)
+	}
+	if strings.TrimSpace(controlOutput) != "freebsd-control:/tmp" {
+		t.Fatalf("FreeBSD control fd output = %q, want freebsd-control:/tmp", controlOutput)
+	}
+
+	flusher, ok := inst.(instanceFlushProvider)
+	if !ok {
+		t.Fatal("FreeBSD runtime does not expose flush")
+	}
+	if err := flusher.Flush(ctx); err != nil {
+		t.Fatalf("FreeBSD runtime flush: %v", err)
+	}
+}
+
 func TestRuntimeRejectsInvalidRequests(t *testing.T) {
 	env := newRuntimeBootEnv(t)
 	for _, tc := range []struct {


### PR DESCRIPTION
## Summary
- add FreeBSD amd64 direct boot, rootfs construction, and managed runtime support
- support writable generated UFS roots and extra virtio-block devices for managed FreeBSD sessions
- fix FFS/UFS metadata issues found by FreeBSD fsck, including large-image cylinder group offsets and directory depth tracking

## Validation
- `go test ./internal/freebsd/rootfs ./internal/fsimage/ffs ./internal/virtio`
- `CC_TEST_FREEBSD_ROOTFS=1 go test ./internal/hv/kvm -run 'TestFreeBSDManagedSessionExec|TestFreeBSDManagedSessionFsckFFSGeneratedRootOnSecondDisk' -count=1 -v`
- vmsh-side validation was run from the parent repo with the rebuilt ccvm: `VMSH_TEST_FREEBSD=1 ... go test ./internal/shell -run TestVMIntegrationFreeBSDBuiltinRunsCommandsAndCopiesFiles -count=1 -v`