### PR TITLE
[codex] Start built-in BSD guests in sidecar workers

### DIFF
--- a/internal/vm/sidecar_builtin_bsd.go
+++ b/internal/vm/sidecar_builtin_bsd.go
@@ -1,0 +1,63 @@
+//go:build (darwin && arm64) || (linux && amd64) || (linux && arm64)
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"j5.nz/cc/client"
+	managedguest "j5.nz/cc/internal/managed/guest"
+	"j5.nz/cc/internal/vm/builtin"
+)
+
+func (h *sidecarVMHost) startBuiltinGuestStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return nil, false, nil
+	}
+	req.Image = profile.Canonical
+	req.ID = DefaultInstanceID
+	sidecar, err := h.launch(ctx, nil)
+	if err != nil {
+		return nil, true, err
+	}
+	if _, err := sidecar.Worker().Start(ctx, req, onEvent); err != nil {
+		_ = sidecar.Close()
+		return nil, true, err
+	}
+	return newSidecarInstance(DefaultInstanceID, sidecar, req.Image, builtinSidecarResources(profile)), true, nil
+}
+
+func (h *sidecarVMHost) startBuiltinGuestBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return nil, false, nil
+	}
+	req.Image = profile.Canonical
+	req.ID = DefaultInstanceID
+	sidecar, err := h.launch(ctx, nil)
+	if err != nil {
+		return nil, true, err
+	}
+	if _, err := sidecar.Worker().StartBlank(ctx, req, onEvent); err != nil {
+		_ = sidecar.Close()
+		return nil, true, err
+	}
+	return newSidecarInstance(DefaultInstanceID, sidecar, req.Image, builtinSidecarResources(profile)), true, nil
+}
+
+func builtinSidecarResources(profile managedguest.Profile) sidecarStartResources {
+	return sidecarStartResources{
+		osName:       profile.Name,
+		capabilities: profile.Caps,
+		execEnv:      builtin.EffectiveExecEnv,
+	}
+}
+
+func (h *sidecarVMHost) rejectBuiltinGuestAlternateImage(image string) error {
+	if isBuiltinGuestImage(image) {
+		return fmt.Errorf("managed guest image %q cannot be mounted as an alternate Linux root", image)
+	}
+	return nil
+}

--- a/internal/vm/sidecar_builtin_bsd_darwin_arm64_test.go
+++ b/internal/vm/sidecar_builtin_bsd_darwin_arm64_test.go
@@ -1,0 +1,93 @@
+//go:build darwin && arm64
+
+package vm
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/imagefs"
+	"j5.nz/cc/internal/virtio"
+)
+
+func TestBuiltinBSDSidecarResourcesUseGuestProfile(t *testing.T) {
+	profile, ok := builtinGuestForImage("@openbsd")
+	if !ok {
+		t.Fatal("OpenBSD built-in profile was not resolved")
+	}
+	resources := builtinSidecarResources(profile)
+	if resources.osName != "OpenBSD" {
+		t.Fatalf("sidecar built-in OS name = %q, want OpenBSD", resources.osName)
+	}
+	if !reflect.DeepEqual(resources.capabilities, profile.Caps) {
+		t.Fatalf("sidecar built-in capabilities = %+v, want %+v", resources.capabilities, profile.Caps)
+	}
+	if resources.execEnv == nil {
+		t.Fatal("sidecar built-in exec env was not configured")
+	}
+}
+
+func TestSidecarResourcePrepRejectsBuiltinBSDBeforeImageStore(t *testing.T) {
+	host := &sidecarVMHost{}
+	_, err := prepareSidecarCreateResources(host, context.Background(), client.CreateInstanceRequest{Image: "@netbsd"})
+	if err == nil {
+		t.Fatal("prepareSidecarCreateResources unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
+		t.Fatalf("built-in NetBSD create prep went through OCI image store path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "managed guest runtime") {
+		t.Fatalf("prepareSidecarCreateResources error = %v, want managed guest runtime guard", err)
+	}
+
+	_, err = prepareSidecarBlankResources(host, context.Background(), client.StartInstanceRequest{Image: "@openbsd"})
+	if err == nil {
+		t.Fatal("prepareSidecarBlankResources unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
+		t.Fatalf("built-in OpenBSD blank prep went through OCI image store path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "managed guest runtime") {
+		t.Fatalf("prepareSidecarBlankResources error = %v, want managed guest runtime guard", err)
+	}
+}
+
+func TestSidecarAlternateImageRejectsBuiltinBSDBeforeImageStore(t *testing.T) {
+	host := &sidecarVMHost{}
+	rootFS, ok := virtio.NewMountedFS(virtio.NewImageFS(imagefs.NewHostFS(t.TempDir(), nil), ""), nil).(sidecarRootFS)
+	if !ok {
+		t.Fatal("test rootfs does not implement sidecarRootFS")
+	}
+	inst := &sidecarInstance{rootFS: rootFS}
+
+	_, err := host.prepareRunInInstanceExec(context.Background(), inst, "alpine", client.RunRequest{
+		Image:   "@openbsd",
+		Command: []string{"uname"},
+	})
+	if err == nil {
+		t.Fatal("prepareRunInInstanceExec unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
+		t.Fatalf("built-in OpenBSD run-in-instance went through OCI image store path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot be mounted as an alternate Linux root") {
+		t.Fatalf("prepareRunInInstanceExec error = %v, want alternate root guard", err)
+	}
+
+	_, err = host.prepareExecInInstance(context.Background(), inst, "alpine", client.ExecRequest{
+		Image:   "@netbsd",
+		Command: []string{"uname"},
+	})
+	if err == nil {
+		t.Fatal("prepareExecInInstance unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
+		t.Fatalf("built-in NetBSD exec-in-instance went through OCI image store path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot be mounted as an alternate Linux root") {
+		t.Fatalf("prepareExecInInstance error = %v, want alternate root guard", err)
+	}
+}

--- a/internal/vm/sidecar_builtin_bsd_unsupported.go
+++ b/internal/vm/sidecar_builtin_bsd_unsupported.go
@@ -1,0 +1,21 @@
+//go:build !(darwin && arm64) && !(linux && amd64) && !(linux && arm64)
+
+package vm
+
+import (
+	"context"
+
+	"j5.nz/cc/client"
+)
+
+func (h *sidecarVMHost) startBuiltinGuestStream(context.Context, client.CreateInstanceRequest, func(client.BootEvent) error) (Instance, bool, error) {
+	return nil, false, nil
+}
+
+func (h *sidecarVMHost) startBuiltinGuestBlankStream(context.Context, client.StartInstanceRequest, func(client.BootEvent) error) (Instance, bool, error) {
+	return nil, false, nil
+}
+
+func (h *sidecarVMHost) rejectBuiltinGuestAlternateImage(string) error {
+	return nil
+}

--- a/internal/vm/sidecar_host.go
+++ b/internal/vm/sidecar_host.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -98,6 +99,9 @@ func (h *sidecarVMHost) Start(ctx context.Context, req client.CreateInstanceRequ
 }
 
 func (h *sidecarVMHost) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if inst, ok, err := h.startBuiltinGuestStream(ctx, req, onEvent); ok || err != nil {
+		return inst, err
+	}
 	resources, err := h.prepareCreateResources(ctx, req)
 	if err != nil {
 		return nil, err
@@ -121,6 +125,9 @@ func (h *sidecarVMHost) StartBlank(ctx context.Context, req client.StartInstance
 }
 
 func (h *sidecarVMHost) StartBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if inst, ok, err := h.startBuiltinGuestBlankStream(ctx, req, onEvent); ok || err != nil {
+		return inst, err
+	}
 	resources, err := h.prepareBlankResources(ctx, req)
 	if err != nil {
 		return nil, err
@@ -202,6 +209,9 @@ func (h *sidecarVMHost) prepareExecInInstance(ctx context.Context, inst *sidecar
 	if err := execplan.CheckAlternateImageExec(inst); err != nil {
 		return client.ExecRequest{}, err
 	}
+	if err := h.rejectBuiltinGuestAlternateImage(targetImage); err != nil {
+		return client.ExecRequest{}, err
+	}
 	if h.images == nil {
 		return client.ExecRequest{}, fmt.Errorf("sidecar image store is not configured")
 	}
@@ -237,6 +247,9 @@ func (h *sidecarVMHost) prepareRunInInstanceExec(ctx context.Context, inst *side
 	if err := execplan.CheckAlternateImageExec(inst); err != nil {
 		return client.ExecRequest{}, err
 	}
+	if err := h.rejectBuiltinGuestAlternateImage(targetImage); err != nil {
+		return client.ExecRequest{}, err
+	}
 	if h.images == nil {
 		return client.ExecRequest{}, fmt.Errorf("sidecar image store is not configured")
 	}
@@ -258,13 +271,16 @@ func (h *sidecarVMHost) prepareRunInInstanceExec(ctx context.Context, inst *side
 }
 
 type sidecarStartResources struct {
-	env         []string
-	close       func()
-	remote      bool
-	rootFS      sidecarRootFS
-	resolver    *sidecarCommandResolver
-	networkIPv4 string
-	network     *networkRuntime
+	env          []string
+	close        func()
+	remote       bool
+	rootFS       sidecarRootFS
+	resolver     *sidecarCommandResolver
+	networkIPv4  string
+	network      *networkRuntime
+	osName       string
+	capabilities guestCapabilities
+	execEnv      func(base, overrides []string, replace bool) []string
 }
 
 type sidecarBootBundle struct {
@@ -303,11 +319,24 @@ func combineSidecarResources(resources ...sidecarStartResources) sidecarStartRes
 		if combined.network == nil && resource.network != nil {
 			combined.network = resource.network
 		}
+		if combined.osName == "" && resource.osName != "" {
+			combined.osName = resource.osName
+		}
+		if isZeroGuestCapabilities(combined.capabilities) && !isZeroGuestCapabilities(resource.capabilities) {
+			combined.capabilities = resource.capabilities
+		}
+		if combined.execEnv == nil && resource.execEnv != nil {
+			combined.execEnv = resource.execEnv
+		}
 		if resource.close != nil {
 			combined.close = appendSidecarClose(combined.close, resource.close)
 		}
 	}
 	return combined
+}
+
+func isZeroGuestCapabilities(caps guestCapabilities) bool {
+	return reflect.DeepEqual(caps, guestCapabilities{})
 }
 
 func appendSidecarClose(existing, next func()) func() {
@@ -469,22 +498,34 @@ func newSidecarInstance(id string, sidecar *sidecarpkg.Daemon, imageName string,
 		network:      resources.network,
 		hasImageRoot: resources.resolver != nil,
 	}
-	inst.managedInstanceCore = newSidecarManagedCore(inst.managedSession(), resources.resolver)
+	inst.managedInstanceCore = newSidecarManagedCore(inst.managedSession(), resources)
 	return inst
 }
 
-func newSidecarManagedCore(session *sidecarpkg.ManagedSession, resolver *sidecarCommandResolver) *managedInstanceCore {
+func newSidecarManagedCore(session *sidecarpkg.ManagedSession, resources sidecarStartResources) *managedInstanceCore {
+	osName := resources.osName
+	if osName == "" {
+		osName = "sidecar"
+	}
+	caps := resources.capabilities
+	if isZeroGuestCapabilities(caps) {
+		caps = managedguest.LinuxProfile.Caps
+	}
+	env := resources.execEnv
+	if env == nil {
+		env = sidecarEffectiveExecEnv
+	}
 	cfg := hostmanaged.Config{
-		OSName:       "sidecar",
+		OSName:       osName,
 		Session:      session,
-		Capabilities: managedguest.LinuxProfile.Caps,
-		Env:          sidecarEffectiveExecEnv,
+		Capabilities: caps,
+		Env:          env,
 		MarkResolved: true,
 	}
-	if resolver != nil {
-		cfg.Root = resolver.root
-		cfg.BaseEnv = resolver.baseEnv
-		cfg.WorkDir = resolver.workDir
+	if resources.resolver != nil {
+		cfg.Root = resources.resolver.root
+		cfg.BaseEnv = resources.resolver.baseEnv
+		cfg.WorkDir = resources.resolver.workDir
 	}
 	return hostmanaged.NewCore(cfg)
 }
@@ -611,7 +652,7 @@ func (i *sidecarInstance) managedCore() *managedInstanceCore {
 	if i.managedInstanceCore != nil {
 		return i.managedInstanceCore
 	}
-	return newSidecarManagedCore(i.managedSession(), i.resolver)
+	return newSidecarManagedCore(i.managedSession(), sidecarStartResources{resolver: i.resolver})
 }
 
 func sidecarShouldPassthroughToWorker(hasImageRoot bool, core *managedInstanceCore, req client.ExecRequest) bool {

--- a/internal/vm/sidecar_host_test.go
+++ b/internal/vm/sidecar_host_test.go
@@ -72,7 +72,7 @@ func TestSidecarCommandResolverSkipsResolvedRequests(t *testing.T) {
 }
 
 func TestSidecarBlankRootPassthroughDecision(t *testing.T) {
-	blankCore := newSidecarManagedCore(sidecarpkg.NewManagedSession(nil, ""), nil)
+	blankCore := newSidecarManagedCore(sidecarpkg.NewManagedSession(nil, ""), sidecarStartResources{})
 	if !sidecarShouldPassthroughToWorker(false, blankCore, client.ExecRequest{Command: []string{"echo"}}) {
 		t.Fatalf("blank unresolved exec should pass through to worker")
 	}
@@ -82,9 +82,11 @@ func TestSidecarBlankRootPassthroughDecision(t *testing.T) {
 	if sidecarShouldPassthroughToWorker(false, blankCore, client.ExecRequest{Command: []string{"/bin/echo"}, SkipResolve: true}) {
 		t.Fatalf("already-resolved request should use managed core")
 	}
-	imageCore := newSidecarManagedCore(sidecarpkg.NewManagedSession(nil, ""), &sidecarCommandResolver{
-		root:    sidecarResolverRoot(t),
-		baseEnv: []string{"PATH=/bin"},
+	imageCore := newSidecarManagedCore(sidecarpkg.NewManagedSession(nil, ""), sidecarStartResources{
+		resolver: &sidecarCommandResolver{
+			root:    sidecarResolverRoot(t),
+			baseEnv: []string{"PATH=/bin"},
+		},
 	})
 	if sidecarShouldPassthroughToWorker(true, imageCore, client.ExecRequest{Command: []string{"tool"}}) {
 		t.Fatalf("image-backed exec should use managed core")

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -52,6 +52,9 @@ type sidecarBootBundleMetadata struct {
 
 func prepareSidecarCreateResources(h *sidecarVMHost, ctx context.Context, req client.CreateInstanceRequest) (sidecarStartResources, error) {
 	_ = ctx
+	if isBuiltinGuestImage(req.Image) {
+		return sidecarStartResources{}, fmt.Errorf("built-in guest image %q must be started by the managed guest runtime, not sidecar OCI resources", req.Image)
+	}
 	if h.images == nil {
 		return sidecarStartResources{}, fmt.Errorf("sidecar image store is not configured")
 	}
@@ -93,6 +96,9 @@ func prepareSidecarBlankResources(h *sidecarVMHost, ctx context.Context, req cli
 	var resolver *sidecarCommandResolver
 	var image *oci.Image
 	if imageName := strings.TrimSpace(req.Image); imageName != "" {
+		if isBuiltinGuestImage(imageName) {
+			return sidecarStartResources{}, fmt.Errorf("built-in guest image %q must be started by the managed guest runtime, not sidecar OCI resources", imageName)
+		}
 		if h.images == nil {
 			return sidecarStartResources{}, fmt.Errorf("sidecar image store is not configured")
 		}


### PR DESCRIPTION
## Summary

This fixes built-in BSD starts on macOS sidecar placement by launching OpenBSD, FreeBSD, and NetBSD inside the selected sidecar worker process instead of starting them in the parent ccvm process.

## Root Cause

macOS HVF creation is guarded by a process-local VM lifecycle lock. The previous built-in BSD sidecar shortcut bypassed OCI resource prep, but it also started the BSD runtime directly in the parent ccvm. If another BSD VM was already running there, the next BSD start blocked behind that HVF lock before the guest could boot.

## Changes

- Route sidecar-hosted built-in BSD starts through worker launch and worker Start/StartBlank calls.
- Preserve BSD guest names, capabilities, and BSD exec environment for sidecar-backed BSD instances.
- Keep guards that prevent built-in BSD images from falling through to sidecar OCI image handling or alternate Linux-root mounts.
- Update sidecar tests for built-in BSD resource identity and guard behavior.

## Validation

- `go test ./internal/vm ./internal/vm/host -count=1 -timeout 4m`
- Manual isolated daemon check: started `@openbsd`, left it running, then started `@netbsd`; both reached `running`, with NetBSD in a sidecar worker.