### PR TITLE
Improve distro image support

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -1634,6 +1634,7 @@ func serveRunWebSocket(ws *websocket.Conn, runner func(context.Context, client.E
 	}()
 
 	err := runner(ctx, req, inputs, func(event client.ExecEvent) error {
+		event = sanitizeExecEventForJSON(event)
 		return websocket.JSON.Send(ws, event)
 	})
 	if err != nil {
@@ -1751,7 +1752,14 @@ func writeRunEventStream(w http.ResponseWriter, ctx context.Context, manager *vm
 }
 
 func sanitizeExecEventForJSON(event client.ExecEvent) client.ExecEvent {
-	if len(event.Data) > 0 && !utf8.Valid(event.Data) {
+	if len(event.Data) == 0 {
+		return event
+	}
+	if utf8.Valid(event.Data) {
+		event.Data = nil
+		return event
+	}
+	if event.Output != "" {
 		event.Output = ""
 	}
 	return event

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -109,6 +109,41 @@ func TestMuxBadRequests(t *testing.T) {
 	}
 }
 
+func TestSanitizeExecEventForJSONUsesTextOrBinary(t *testing.T) {
+	text := sanitizeExecEventForJSON(client.ExecEvent{
+		Kind:   "stdout",
+		Output: "hello\n",
+		Data:   []byte("hello\n"),
+	})
+	if text.Output != "hello\n" {
+		t.Fatalf("text output = %q", text.Output)
+	}
+	if len(text.Data) != 0 {
+		t.Fatalf("text data was not cleared: %q", string(text.Data))
+	}
+
+	binary := sanitizeExecEventForJSON(client.ExecEvent{
+		Kind:   "stdout",
+		Output: "\xff\x00",
+		Data:   []byte{0xff, 0x00},
+	})
+	if binary.Output != "" {
+		t.Fatalf("binary output = %q", binary.Output)
+	}
+	if !bytes.Equal(binary.Data, []byte{0xff, 0x00}) {
+		t.Fatalf("binary data = %v", binary.Data)
+	}
+
+	encoded := mustJSON(t, binary)
+	var decoded client.ExecEvent
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode sanitized binary event: %v json=%s", err, string(encoded))
+	}
+	if !bytes.Equal(decoded.Data, []byte{0xff, 0x00}) {
+		t.Fatalf("decoded data = %v", decoded.Data)
+	}
+}
+
 func jsonBody(t *testing.T, value any) *bytes.Reader {
 	t.Helper()
 	return bytes.NewReader(mustJSON(t, value))

--- a/internal/hv/kvm/boot_linux_amd64.go
+++ b/internal/hv/kvm/boot_linux_amd64.go
@@ -125,7 +125,9 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 		extraCmdline = append(extraCmdline, "acpi=off", "pci=conf1")
 	}
 	extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(rng.Base, rng.IRQ))
-	extraCmdline = append(extraCmdline, linuxKVMHostKernelArgs()...)
+	if block == nil {
+		extraCmdline = append(extraCmdline, linuxKVMHostKernelArgs()...)
+	}
 	plan, err := amd64vm.PrepareBoot(mem, kernel, initrd, amd64vm.BootConfig{
 		MemoryMB:     memoryMB,
 		Dmesg:        dmesg,

--- a/internal/hv/kvm/virtio_pci_linux_amd64_test.go
+++ b/internal/hv/kvm/virtio_pci_linux_amd64_test.go
@@ -21,6 +21,9 @@ func TestLinuxBootsWithVirtioPCIBlock(t *testing.T) {
 	if os.Getenv("CC_TEST_LINUX_KVM_PCI") == "" {
 		t.Skip("set CC_TEST_LINUX_KVM_PCI=1 to run Linux virtio-pci block KVM smoke test")
 	}
+	if hostCPUHasFlag("hypervisor") {
+		t.Skip("legacy virtio-pci block smoke test requires bare-metal KVM")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 

--- a/internal/imagefs/imagefs.go
+++ b/internal/imagefs/imagefs.go
@@ -162,24 +162,60 @@ func ResolveCommand(root Directory, command []string, env []string) ([]string, e
 func ResolvePath(root Directory, guestPath string) (string, Entry, error) {
 	clean := path.Clean("/" + strings.TrimPrefix(strings.TrimSpace(guestPath), "/"))
 	for depth := 0; depth < 40; depth++ {
-		entry, err := LookupPath(root, clean)
+		resolved, entry, err := resolvePathOnce(root, clean)
 		if err != nil {
 			return "", Entry{}, err
 		}
 		if entry.Symlink == nil {
-			return clean, entry, nil
+			return resolved, entry, nil
 		}
-		target := fsmeta.NormalizeSymlinkTarget(strings.TrimSpace(entry.Symlink.Target()))
-		if target == "" {
-			return "", Entry{}, fmt.Errorf("%q symlink target is empty", clean)
-		}
-		if strings.HasPrefix(target, "/") {
-			clean = path.Clean(target)
-		} else {
-			clean = path.Clean(path.Join(path.Dir(clean), target))
-		}
+		clean = resolved
 	}
 	return "", Entry{}, fmt.Errorf("%q has too many symlink levels", guestPath)
+}
+
+func resolvePathOnce(root Directory, guestPath string) (string, Entry, error) {
+	if root == nil {
+		return "", Entry{}, fmt.Errorf("root filesystem is nil")
+	}
+	clean := path.Clean("/" + strings.TrimPrefix(strings.TrimSpace(guestPath), "/"))
+	if clean == "/" {
+		return clean, Entry{Dir: root}, nil
+	}
+	current := root
+	parts := strings.Split(strings.TrimPrefix(clean, "/"), "/")
+	for i, part := range parts {
+		entry, err := current.Lookup(part)
+		if err != nil {
+			return "", Entry{}, err
+		}
+		currentPath := "/" + strings.Join(parts[:i+1], "/")
+		if entry.Symlink != nil {
+			target := fsmeta.NormalizeSymlinkTarget(strings.TrimSpace(entry.Symlink.Target()))
+			if target == "" {
+				return "", Entry{}, fmt.Errorf("%q symlink target is empty", currentPath)
+			}
+			remainder := path.Join(parts[i+1:]...)
+			var next string
+			if strings.HasPrefix(target, "/") {
+				next = target
+			} else {
+				next = path.Join(path.Dir(currentPath), target)
+			}
+			if remainder != "" && remainder != "." {
+				next = path.Join(next, remainder)
+			}
+			return path.Clean(next), entry, nil
+		}
+		if i == len(parts)-1 {
+			return currentPath, entry, nil
+		}
+		if entry.Dir == nil {
+			return "", Entry{}, fmt.Errorf("%q is not a directory", currentPath)
+		}
+		current = entry.Dir
+	}
+	return "", Entry{}, fmt.Errorf("empty path")
 }
 
 type hostFile struct {

--- a/internal/imagefs/imagefs_test.go
+++ b/internal/imagefs/imagefs_test.go
@@ -99,6 +99,41 @@ func TestResolvePathFollowsSymlinks(t *testing.T) {
 	}
 }
 
+func TestResolvePathFollowsIntermediateSymlinkDirectories(t *testing.T) {
+	overlay := NewOverlay(nil)
+	if err := overlay.AddDir("/usr/bin", fs.ModeDir|0o755); err != nil {
+		t.Fatalf("add usr bin: %v", err)
+	}
+	if err := overlay.AddSymlink("/bin", "usr/bin"); err != nil {
+		t.Fatalf("add bin symlink: %v", err)
+	}
+	if err := overlay.AddFile("/usr/bin/bash", 0o755, []byte("bash")); err != nil {
+		t.Fatalf("add bash: %v", err)
+	}
+	if err := overlay.AddSymlink("/usr/bin/sh", "bash"); err != nil {
+		t.Fatalf("add sh symlink: %v", err)
+	}
+
+	resolved, entry, err := ResolvePath(overlay.Root(), "/bin/sh")
+	if err != nil {
+		t.Fatalf("resolve intermediate symlink: %v", err)
+	}
+	if resolved != "/usr/bin/bash" {
+		t.Fatalf("resolved path = %q, want /usr/bin/bash", resolved)
+	}
+	if entry.File == nil {
+		t.Fatalf("resolved intermediate symlink did not yield a file")
+	}
+
+	cmd, err := ResolveCommand(overlay.Root(), []string{"sh", "-c", "true"}, []string{"PATH=/bin"})
+	if err != nil {
+		t.Fatalf("resolve command through intermediate symlink: %v", err)
+	}
+	if strings.Join(cmd, " ") != "/bin/sh -c true" {
+		t.Fatalf("resolved command = %#v", cmd)
+	}
+}
+
 func TestLookupPathCleansInputAndReportsNonDirectory(t *testing.T) {
 	rootDir := t.TempDir()
 	mustWriteFile(t, filepath.Join(rootDir, "file"), "contents")

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -1335,10 +1335,19 @@ func (reg *registryContext) authorize(ctx context.Context, header string) error 
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		fmt.Sprintf("%s?service=%s&scope=%s", params["realm"], params["service"], params["scope"]),
-		nil,
-	)
+	tokenURL, err := url.Parse(params["realm"])
+	if err != nil {
+		return fmt.Errorf("parse token realm: %w", err)
+	}
+	query := tokenURL.Query()
+	if service := params["service"]; service != "" {
+		query.Set("service", service)
+	}
+	if scope := params["scope"]; scope != "" {
+		query.Set("scope", scope)
+	}
+	tokenURL.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -172,6 +172,32 @@ func TestResolvedOCISourceUsesImmutableDigest(t *testing.T) {
 	}
 }
 
+func TestRegistryAuthorizeEncodesChallengeParams(t *testing.T) {
+	var gotService, gotScope string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotService = r.URL.Query().Get("service")
+		gotScope = r.URL.Query().Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"ok"}`))
+	}))
+	defer server.Close()
+
+	reg := &registryContext{client: server.Client()}
+	header := `Bearer realm="` + server.URL + `/token",service="SUSE Linux Docker Registry",scope="repository:bci/bci-base:pull"`
+	if err := reg.authorize(context.Background(), header); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if gotService != "SUSE Linux Docker Registry" {
+		t.Fatalf("service query = %q", gotService)
+	}
+	if gotScope != "repository:bci/bci-base:pull" {
+		t.Fatalf("scope query = %q", gotScope)
+	}
+	if reg.token != "ok" {
+		t.Fatalf("token = %q", reg.token)
+	}
+}
+
 func alpineFixture(t *testing.T) string {
 	t.Helper()
 	_, file, _, ok := runtime.Caller(0)

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -2898,7 +2898,7 @@ func cleanChildName(name string) (string, bool) {
 	if name == "" {
 		return "", false
 	}
-	if !strings.Contains(name, "/") && name != "." && name != ".." {
+	if strings.IndexByte(name, '/') < 0 && name != "." && name != ".." {
 		return name, true
 	}
 	clean := path.Clean("/" + name)
@@ -2952,7 +2952,7 @@ type imageFS struct {
 	nextNodeID uint64
 	nextHandle uint64
 	nodes      map[uint64]*imageNode
-	handles    map[uint64]*imageHandle
+	handles    map[uint64]imageHandle
 	dirHandles map[uint64][]dirEntry
 }
 
@@ -2973,6 +2973,7 @@ type imageNode struct {
 	gid           uint32
 	rdev          uint32
 	size          uint64
+	nlink         uint32
 	data          []byte
 	symlinkTarget string
 	entries       map[string]uint64
@@ -3034,7 +3035,7 @@ func newImageFS(root imagefs.Directory, statfsPath string, uid, gid uint32, mapO
 		nextNodeID: 2,
 		nextHandle: 1,
 		nodes:      map[uint64]*imageNode{},
-		handles:    map[uint64]*imageHandle{},
+		handles:    map[uint64]imageHandle{},
 		dirHandles: map[uint64][]dirEntry{},
 	}
 	if root == nil {
@@ -3815,6 +3816,9 @@ func (p *imageFS) debugfLocked(format string, args ...any) {
 }
 
 func (p *imageFS) debugNodefLocked(op string, nodeID uint64, format string, args ...any) {
+	if len(p.debugPaths) == 0 || p.debugLog == nil {
+		return
+	}
 	guestPath := p.pathForNode(nodeID)
 	if !p.debugPathMatchLocked(guestPath) {
 		return
@@ -3827,8 +3831,15 @@ func (p *imageFS) debugNodefLocked(op string, nodeID uint64, format string, args
 }
 
 func (p *imageFS) debugChildfLocked(op string, parent uint64, name string, format string, args ...any) {
+	if len(p.debugPaths) == 0 || p.debugLog == nil {
+		return
+	}
 	parentPath := p.pathForNode(parent)
-	childPath := path.Join(parentPath, path.Base(path.Clean("/"+name)))
+	childName, ok := cleanChildName(name)
+	if !ok {
+		childName = name
+	}
+	childPath := path.Join(parentPath, childName)
 	if !p.debugPathMatchLocked(childPath) && !p.debugPathMatchLocked(parentPath) {
 		return
 	}
@@ -3860,7 +3871,12 @@ func (p *imageFS) Lookup(parent uint64, name string) (uint64, FuseAttr, int32) {
 		p.mu.Unlock()
 		return 0, FuseAttr{}, -linuxENOENT
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		p.mu.Unlock()
+		return 0, FuseAttr{}, -linuxEINVAL
+	}
 	if name == "." {
 		attr := p.attr(parentNode)
 		p.mu.Unlock()
@@ -3969,7 +3985,7 @@ func (p *imageFS) OpenForCaller(nodeID uint64, flags uint32, uid uint32, gid uin
 	}
 	fh := p.nextHandle
 	p.nextHandle++
-	handle := &imageHandle{nodeID: nodeID}
+	handle := imageHandle{nodeID: nodeID}
 	if openable, ok := node.abstractFile.(imagefs.OpenReaderFile); ok {
 		reader, closer, err := openable.OpenReader()
 		if err != nil {
@@ -3984,10 +4000,10 @@ func (p *imageFS) OpenForCaller(nodeID uint64, flags uint32, uid uint32, gid uin
 
 func (p *imageFS) Release(_ uint64, fh uint64) {
 	p.mu.Lock()
-	handle := p.handles[fh]
+	handle, ok := p.handles[fh]
 	delete(p.handles, fh)
 	p.mu.Unlock()
-	if handle != nil && handle.closer != nil {
+	if ok && handle.closer != nil {
 		_ = handle.closer.Close()
 	}
 }
@@ -4009,7 +4025,7 @@ func (p *imageFS) Read(nodeID uint64, fh uint64, off uint64, size uint32) ([]byt
 	handle, ok := p.handles[fh]
 	node := p.nodes[nodeID]
 	p.mu.Unlock()
-	if !ok || handle == nil || handle.nodeID != nodeID || node == nil {
+	if !ok || handle.nodeID != nodeID || node == nil {
 		return nil, -linuxEBADF
 	}
 	if node.abstractFile == nil {
@@ -4045,7 +4061,7 @@ func (p *imageFS) Lseek(nodeID uint64, fh uint64, offset uint64, whence uint32) 
 	handle, ok := p.handles[fh]
 	node := p.nodes[nodeID]
 	p.mu.Unlock()
-	if !ok || handle == nil || handle.nodeID != nodeID || node == nil {
+	if !ok || handle.nodeID != nodeID || node == nil {
 		return 0, -linuxEBADF
 	}
 	switch whence {
@@ -4230,7 +4246,11 @@ func (p *imageFS) Mkdir(parent uint64, name string, mode uint32, uid uint32, gid
 	if errno := p.checkParentMutationLocked(parentNode, uid, gid); errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return 0, FuseAttr{}, -linuxEINVAL
+	}
 	p.debugChildfLocked("mkdir", parent, name, "mode=%#o uid=%d gid=%d", mode, uid, gid)
 	if _, exists := parentNode.entries[name]; exists {
 		p.debugChildfLocked("mkdir-exists", parent, name, "errno=%d", -linuxEEXIST)
@@ -4247,6 +4267,7 @@ func (p *imageFS) Mkdir(parent uint64, name string, mode uint32, uid uint32, gid
 	}
 	p.nextNodeID++
 	p.nodes[node.id] = node
+	p.registerImageNodeLinkLocked(node)
 	parentNode.entries[name] = node.id
 	return node.id, p.attr(node), 0
 }
@@ -4261,7 +4282,11 @@ func (p *imageFS) Mknod(parent uint64, name string, mode uint32, rdev uint32, ui
 	if errno := p.checkParentMutationLocked(parentNode, uid, gid); errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return 0, FuseAttr{}, -linuxEINVAL
+	}
 	fileType := mode & linuxSIFMT
 	p.debugChildfLocked("mknod", parent, name, "mode=%#o type=%#o rdev=%d uid=%d gid=%d", mode, fileType, rdev, uid, gid)
 	switch fileType {
@@ -4295,6 +4320,7 @@ func (p *imageFS) Mknod(parent uint64, name string, mode uint32, rdev uint32, ui
 	}
 	p.nextNodeID++
 	p.nodes[node.id] = node
+	p.registerImageNodeLinkLocked(node)
 	parentNode.entries[name] = node.id
 	return node.id, p.attr(node), 0
 }
@@ -4309,7 +4335,11 @@ func (p *imageFS) Symlink(parent uint64, name string, target string, uid uint32,
 	if errno := p.checkParentMutationLocked(parentNode, uid, gid); errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return 0, FuseAttr{}, -linuxEINVAL
+	}
 	p.debugChildfLocked("symlink", parent, name, "target=%q uid=%d gid=%d", target, uid, gid)
 	if _, exists := parentNode.entries[name]; exists {
 		p.debugChildfLocked("symlink-exists", parent, name, "errno=%d", -linuxEEXIST)
@@ -4350,7 +4380,10 @@ func (p *imageFS) LinkForCaller(nodeID uint64, newParent uint64, newName string,
 	if node.isDir() {
 		return 0, FuseAttr{}, -linuxEPERM
 	}
-	name := path.Base(path.Clean("/" + newName))
+	name, ok := cleanChildName(newName)
+	if !ok {
+		return 0, FuseAttr{}, -linuxEINVAL
+	}
 	p.debugChildfLocked("link", newParent, name, "old_path=%q old_node=%d", p.pathForNode(nodeID), nodeID)
 	if _, exists := parentNode.entries[name]; exists {
 		p.debugChildfLocked("link-exists", newParent, name, "errno=%d", -linuxEEXIST)
@@ -4384,6 +4417,8 @@ func (p *imageFS) LinkForCaller(nodeID uint64, newParent uint64, newName string,
 	}
 	p.nextNodeID++
 	p.nodes[linked.id] = linked
+	p.registerImageNodeLinkLocked(linked)
+	p.refreshImageNodeLinksLocked(linked)
 	parentNode.entries[name] = linked.id
 	return linked.id, p.attr(linked), 0
 }
@@ -4402,7 +4437,11 @@ func (p *imageFS) RmDirForCaller(parent uint64, name string, uid uint32, gid uin
 	if errno := p.checkParentMutationLocked(parentNode, uid, gid); errno != 0 {
 		return errno
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return -linuxEINVAL
+	}
 	p.debugChildfLocked("rmdir", parent, name, "")
 	childID, ok := parentNode.entries[name]
 	if !ok {
@@ -4439,7 +4478,11 @@ func (p *imageFS) CreateForCaller(parent uint64, name string, flags uint32, mode
 	if parentNode == nil {
 		return 0, 0, FuseAttr{}, -linuxENOENT
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return 0, 0, FuseAttr{}, -linuxEINVAL
+	}
 	p.debugChildfLocked("create", parent, name, "flags=%#x mode=%#o uid=%d gid=%d", flags, mode, uid, gid)
 	if existingID, exists := parentNode.entries[name]; exists {
 		if flags&linuxOEXCL != 0 {
@@ -4473,7 +4516,7 @@ func (p *imageFS) CreateForCaller(parent uint64, name string, flags uint32, mode
 		}
 		fh := p.nextHandle
 		p.nextHandle++
-		p.handles[fh] = &imageHandle{nodeID: node.id}
+		p.handles[fh] = imageHandle{nodeID: node.id}
 		return node.id, fh, p.attr(node), 0
 	}
 	if errno := p.checkParentMutationLocked(parentNode, uid, gid); errno != 0 {
@@ -4493,10 +4536,11 @@ func (p *imageFS) CreateForCaller(parent uint64, name string, flags uint32, mode
 	}
 	p.nextNodeID++
 	p.nodes[node.id] = node
+	p.registerImageNodeLinkLocked(node)
 	parentNode.entries[name] = node.id
 	fh := p.nextHandle
 	p.nextHandle++
-	p.handles[fh] = &imageHandle{nodeID: node.id}
+	p.handles[fh] = imageHandle{nodeID: node.id}
 	return node.id, fh, p.attr(node), 0
 }
 
@@ -4507,9 +4551,9 @@ func (p *imageFS) Write(nodeID uint64, fh uint64, off uint64, data []byte, _ uin
 func (p *imageFS) WriteForCaller(nodeID uint64, fh uint64, off uint64, data []byte, flags uint32, uid uint32, gid uint32) (uint32, int32) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	handle := p.handles[fh]
+	handle, ok := p.handles[fh]
 	node := p.nodes[nodeID]
-	if handle == nil || handle.nodeID != nodeID || node == nil {
+	if !ok || handle.nodeID != nodeID || node == nil {
 		return 0, -linuxEBADF
 	}
 	if errno := p.checkNodeAccessLocked(node, uid, gid, imageAccessWrite); errno != 0 {
@@ -4547,7 +4591,7 @@ func growImageNodeData(node *imageNode, size uint64) int32 {
 	}
 	newCap := cap(node.data)
 	if newCap < 4096 {
-		newCap = 4096
+		newCap = wantLen
 	}
 	for newCap < wantLen {
 		if newCap > int(^uint(0)>>1)/2 {
@@ -4626,7 +4670,11 @@ func (p *imageFS) UnlinkForCaller(parent uint64, name string, uid uint32, gid ui
 	if errno := p.checkParentMutationLocked(parentNode, uid, gid); errno != 0 {
 		return errno
 	}
-	name = path.Base(path.Clean("/" + name))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return -linuxEINVAL
+	}
 	childID, ok := parentNode.entries[name]
 	if !ok {
 		p.debugChildfLocked("unlink-miss", parent, name, "errno=%d", -linuxENOENT)
@@ -4650,6 +4698,7 @@ func (p *imageFS) UnlinkForCaller(parent uint64, name string, uid uint32, gid ui
 		parentNode.whiteouts[name] = true
 	}
 	delete(p.nodes, childID)
+	p.unregisterImageNodeLinkLocked(child)
 	return 0
 }
 
@@ -4673,8 +4722,15 @@ func (p *imageFS) RenameForCaller(parent uint64, name string, newParent uint64, 
 			return errno
 		}
 	}
-	name = path.Base(path.Clean("/" + name))
-	newName = path.Base(path.Clean("/" + newName))
+	var ok bool
+	name, ok = cleanChildName(name)
+	if !ok {
+		return -linuxEINVAL
+	}
+	newName, ok = cleanChildName(newName)
+	if !ok {
+		return -linuxEINVAL
+	}
 	p.debugChildfLocked("rename-old", parent, name, "new_parent=%q new_name=%q flags=%#x", p.pathForNode(newParent), newName, flags)
 	p.debugChildfLocked("rename-new", newParent, newName, "old_parent=%q old_name=%q flags=%#x", p.pathForNode(parent), name, flags)
 	childID, ok := parentNode.entries[name]
@@ -4699,6 +4755,7 @@ func (p *imageFS) RenameForCaller(parent uint64, name string, newParent uint64, 
 		}
 		p.debugChildfLocked("rename-replace-target", newParent, newName, "existing=%d", existingID)
 		delete(p.nodes, existingID)
+		p.unregisterImageNodeLinkLocked(existing)
 	}
 	delete(parentNode.entries, name)
 	if parentNode.abstractDir != nil {
@@ -4756,10 +4813,12 @@ func (p *imageFS) attr(node *imageNode) FuseAttr {
 			modTime = mt
 		}
 	}
+	isDir := node.isDir()
+	isSymlink := node.isSymlink()
 	switch {
-	case node.isDir():
+	case isDir:
 		mode = linuxSIFDIR | linuxModeBits(nodeMode)
-	case node.isSymlink():
+	case isSymlink:
 		mode = linuxSIFLNK | linuxModeBits(nodeMode)
 	case node.rawMode != 0:
 		mode = (node.rawMode &^ linuxPermMask) | linuxModeBits(nodeMode)
@@ -4767,40 +4826,80 @@ func (p *imageFS) attr(node *imageNode) FuseAttr {
 		mode = linuxSIFREG | linuxModeBits(nodeMode)
 	}
 	nlink := uint32(1)
-	if node.isDir() {
+	if isDir {
 		nlink = maxU32(2, 2+uint32(len(node.entries)))
 	} else {
-		inode := p.imageNodeInodeLocked(node)
-		nlink = 0
-		for _, candidate := range p.nodes {
-			if candidate != nil && !candidate.isDir() && p.imageNodeInodeLocked(candidate) == inode {
-				nlink++
-			}
-		}
-		if nlink == 0 {
-			nlink = 1
-		}
+		nlink = p.imageNodeLinkCountLocked(node)
 	}
 	attrUID, attrGID := node.uid, node.gid
 	if p.mapOwner {
 		attrUID, attrGID = p.ownerUID, p.ownerGID
 	}
+	sec := uint64(modTime.Unix())
+	nsec := uint32(modTime.Nanosecond())
 	return FuseAttr{
 		Ino:       p.imageNodeInodeLocked(node),
 		Size:      size,
 		Blocks:    uint64((size + 511) / 512),
-		ATimeSec:  uint64(modTime.Unix()),
-		MTimeSec:  uint64(modTime.Unix()),
-		CTimeSec:  uint64(modTime.Unix()),
-		ATimeNsec: uint32(modTime.Nanosecond()),
-		MTimeNsec: uint32(modTime.Nanosecond()),
-		CTimeNsec: uint32(modTime.Nanosecond()),
+		ATimeSec:  sec,
+		MTimeSec:  sec,
+		CTimeSec:  sec,
+		ATimeNsec: nsec,
+		MTimeNsec: nsec,
+		CTimeNsec: nsec,
 		Mode:      mode,
 		NLink:     nlink,
 		UID:       attrUID,
 		GID:       attrGID,
 		RDev:      node.rdev,
 		BlkSize:   4096,
+	}
+}
+
+func (p *imageFS) registerImageNodeLinkLocked(node *imageNode) {
+	if node == nil || node.isDir() {
+		return
+	}
+	if node.nlink == 0 {
+		node.nlink = 1
+	}
+}
+
+func (p *imageFS) unregisterImageNodeLinkLocked(node *imageNode) {
+	if node == nil || node.isDir() {
+		return
+	}
+	p.refreshImageNodeLinksLocked(node)
+}
+
+func (p *imageFS) imageNodeLinkCountLocked(node *imageNode) uint32 {
+	if node == nil || node.isDir() {
+		return 1
+	}
+	if node.nlink != 0 {
+		return node.nlink
+	}
+	return 1
+}
+
+func (p *imageFS) refreshImageNodeLinksLocked(node *imageNode) {
+	if node == nil || node.isDir() {
+		return
+	}
+	inode := p.imageNodeInodeLocked(node)
+	nlink := uint32(0)
+	for _, candidate := range p.nodes {
+		if candidate != nil && !candidate.isDir() && p.imageNodeInodeLocked(candidate) == inode {
+			nlink++
+		}
+	}
+	if nlink == 0 {
+		nlink = 1
+	}
+	for _, candidate := range p.nodes {
+		if candidate != nil && !candidate.isDir() && p.imageNodeInodeLocked(candidate) == inode {
+			candidate.nlink = nlink
+		}
 	}
 }
 
@@ -4873,6 +4972,7 @@ func (p *imageFS) createAbstractNode(parent *imageNode, name string, entry image
 		node.modTime = time.Unix(0, 0)
 	}
 	p.nodes[node.id] = node
+	p.registerImageNodeLinkLocked(node)
 	parent.entries[name] = node.id
 	return node, 0
 }

--- a/internal/virtio/mountfs_test.go
+++ b/internal/virtio/mountfs_test.go
@@ -3,6 +3,7 @@ package virtio
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -228,6 +229,64 @@ func TestImageFSAllowsOwnerAfterRootChown(t *testing.T) {
 
 	if _, errno := fsys.(fsSetAttrCallerBackend).SetAttrForCaller(fileID, fattrUID, 0, 0, 0, 1001, 1000, zeroTime(), zeroTime(), 1000, 1000); errno != -linuxEPERM {
 		t.Fatalf("non-root chown errno = %d, want %d", errno, -linuxEPERM)
+	}
+}
+
+func BenchmarkImageFSGentooLikeTinyFiles(b *testing.B) {
+	const (
+		fileCount = 1024
+		fileSize  = 128
+	)
+	payload := make([]byte, fileSize)
+	names := make([]string, fileCount)
+	for i := range names {
+		names[i] = "repo-file-" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(fileCount * fileSize)
+	b.ReportMetric(fileCount, "files/op")
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		fsys := NewImageFS(imagefs.NewOverlay(nil).Root(), "")
+		create := fsys.(fsCreateCallerBackend)
+		write := fsys.(fsWriteCallerBackend)
+
+		for _, name := range names {
+			nodeID, fh, _, errno := create.CreateForCaller(1, name, linuxOWRONLY|linuxOCREAT|linuxOEXCL, 0o644, 0, 0)
+			if errno != 0 {
+				b.Fatalf("create %s errno = %d", name, errno)
+			}
+			if _, errno := write.WriteForCaller(nodeID, fh, 0, payload, 0, 0, 0); errno != 0 {
+				b.Fatalf("write %s errno = %d", name, errno)
+			}
+			fsys.Release(nodeID, fh)
+		}
+	}
+}
+
+func BenchmarkImageFSSameBytesSingleFile(b *testing.B) {
+	const (
+		fileCount = 1024
+		fileSize  = 128
+	)
+	payload := make([]byte, fileCount*fileSize)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ReportMetric(1, "files/op")
+
+	for n := 0; n < b.N; n++ {
+		fsys := NewImageFS(imagefs.NewOverlay(nil).Root(), "")
+		nodeID, fh, _, errno := fsys.(fsCreateCallerBackend).CreateForCaller(1, "repo-pack", linuxOWRONLY|linuxOCREAT|linuxOEXCL, 0o644, 0, 0)
+		if errno != 0 {
+			b.Fatalf("create repo-pack errno = %d", errno)
+		}
+		if _, errno := fsys.(fsWriteCallerBackend).WriteForCaller(nodeID, fh, 0, payload, 0, 0, 0); errno != 0 {
+			b.Fatalf("write repo-pack errno = %d", errno)
+		}
+		fsys.Release(nodeID, fh)
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve intermediate imagefs symlinks for command lookup
- escape OCI bearer token query params and sanitize exec websocket JSON events
- add imageFS tiny-file benchmarks and optimize metadata-heavy create/write paths

## Tests
- `go test ./internal/virtio ./internal/imagefs ./internal/oci ./internal/ccvmd`
- `go test ./internal/virtio -run '^$' -bench 'BenchmarkImageFS(GentooLikeTinyFiles|SameBytesSingleFile)$' -benchtime=1s -count=5`