### PR TITLE
[codex] fix windows amd64 guest support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
           CC_TEST_FREEBSD_ROOTFS: "1"
           CC_TEST_FREEBSD_KVM: "1"
           CC_TEST_NETBSD_ROOTFS: "1"
+          CC_TEST_NETBSD_KVM: "1"
         run: |
           set -euo pipefail
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -o internal/guestinit/guest-init-linux-arm64 ./internal/cmd/init

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -567,6 +567,17 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server) error {
 				continue
 			}
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "flushed"})
+		case vm.WorkerFrameAddShare:
+			var req vm.WorkerAddShareRequest
+			if err := frame.DecodePayload(&req); err != nil {
+				_ = sendWorkerError(codec, frame.ID, err)
+				continue
+			}
+			if err := srvState.vms.AddShareTo(context.Background(), req.ID, req.Share); err != nil {
+				_ = sendWorkerError(codec, frame.ID, err)
+				continue
+			}
+			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "mounted"})
 		case vm.WorkerFrameConsole:
 			var req vm.WorkerConsoleRequest
 			_ = frame.DecodePayload(&req)
@@ -1277,20 +1288,37 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func()) *ht
 			}
 		}
 		if wantsBootEventStream(r) {
-			writeBootEvent(w, client.BootEvent{Kind: "status", Message: "starting VM"})
-			state, err := srvState.vms.StartBlankStream(bootCtx, req, func(event client.BootEvent) error {
+			var streamMu sync.Mutex
+			streamOpen := true
+			writeStreamEvent := func(event client.BootEvent) error {
+				streamMu.Lock()
+				defer streamMu.Unlock()
+				if !streamOpen {
+					return nil
+				}
 				return writeBootEvent(w, event)
+			}
+			closeStream := func() {
+				streamMu.Lock()
+				streamOpen = false
+				streamMu.Unlock()
+			}
+			defer closeStream()
+
+			writeStreamEvent(client.BootEvent{Kind: "status", Message: "starting VM"})
+			state, err := srvState.vms.StartBlankStream(bootCtx, req, func(event client.BootEvent) error {
+				return writeStreamEvent(event)
 			})
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) || errors.Is(bootCtx.Err(), context.DeadlineExceeded) {
-					_ = writeBootEvent(w, client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
+					_ = writeStreamEvent(client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
 					return
 				}
-				_ = writeBootEvent(w, client.BootEvent{Kind: "error", Error: err.Error()})
+				_ = writeStreamEvent(client.BootEvent{Kind: "error", Error: err.Error()})
 				return
 			}
 			timingLog("POST /vm/start vms.StartBlankStream took=%s", time.Since(start))
-			_ = writeBootEvent(w, client.BootEvent{Kind: "ready", State: state})
+			_ = writeStreamEvent(client.BootEvent{Kind: "ready", State: state})
 			timingLog("POST /vm/start total=%s", time.Since(start))
 			return
 		}

--- a/internal/freebsd/rootfs/rootfs_test.go
+++ b/internal/freebsd/rootfs/rootfs_test.go
@@ -42,10 +42,11 @@ func TestBuildManagedRootFromFreeBSDBaseSet(t *testing.T) {
 		{name: "etc", mode: 0o755, dir: true},
 		{name: "dev", mode: 0o755, dir: true},
 	})
-	root, err := BuildManagedRoot(context.Background(), baseTXZ, []byte("#!/bin/sh\necho test init\n"))
+	root, closeRoot, err := buildManagedRoot(context.Background(), baseTXZ, []byte("#!/bin/sh\necho test init\n"), machine.NetworkSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer closeRoot()
 	baseTar := strings.TrimSuffix(baseTXZ, filepath.Ext(baseTXZ)) + ".tar"
 	if st, err := os.Stat(baseTar); err != nil || st.Size() == 0 {
 		t.Fatalf("decompressed base tar was not cached: stat=%v err=%v", st, err)

--- a/internal/fsimage/ffs/build_test.go
+++ b/internal/fsimage/ffs/build_test.go
@@ -32,6 +32,7 @@ func TestBuildFFSWritesOpenBSDRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	meta := map[string]fsmeta.Entry{
+		"/sbin/init":   {Mode: fsmeta.LinuxModeFromFileMode(0o755)},
 		"/dev/console": {Mode: fsmeta.LinuxModeFromFileMode(fs.ModeDevice | fs.ModeCharDevice | 0o600), RDev: 0},
 	}
 	img, err := Build(context.Background(), imagefs.NewHostFS(root, meta), Options{
@@ -83,7 +84,10 @@ func TestBuildFFSRawLayoutStartsAtBlockDeviceRoot(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, "sbin"))
 	mustWriteMode(t, filepath.Join(root, "sbin", "init"), "hello freebsd\n", 0o755)
-	img, err := Build(context.Background(), imagefs.NewHostFS(root, nil), Options{
+	meta := map[string]fsmeta.Entry{
+		"/sbin/init": {Mode: fsmeta.LinuxModeFromFileMode(0o755)},
+	}
+	img, err := Build(context.Background(), imagefs.NewHostFS(root, meta), Options{
 		SizeBytes:         16 << 20,
 		DeterministicTime: time.Unix(1234, 0),
 		Layout:            LayoutRaw,
@@ -113,7 +117,10 @@ func TestBuildFFSRawLayoutLargeCylinderGroupsAtFreeBSDOffsets(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, "sbin"))
 	mustWriteMode(t, filepath.Join(root, "sbin", "init"), "hello freebsd\n", 0o755)
-	img, err := Build(context.Background(), imagefs.NewHostFS(root, nil), Options{
+	meta := map[string]fsmeta.Entry{
+		"/sbin/init": {Mode: fsmeta.LinuxModeFromFileMode(0o755)},
+	}
+	img, err := Build(context.Background(), imagefs.NewHostFS(root, meta), Options{
 		SizeBytes:         5 << 30,
 		DeterministicTime: time.Unix(1234, 0),
 		Layout:            LayoutRaw,
@@ -180,7 +187,10 @@ func TestBuildFFSDynamicInodeTableKeepsDirectoriesReadable(t *testing.T) {
 	for i := 0; i < 900; i++ {
 		mustMkdir(t, filepath.Join(root, "usr", "share", "dir"+strconv.Itoa(i)))
 	}
-	img, err := Build(context.Background(), imagefs.NewHostFS(root, nil), Options{
+	meta := map[string]fsmeta.Entry{
+		"/sbin/init": {Mode: fsmeta.LinuxModeFromFileMode(0o755)},
+	}
+	img, err := Build(context.Background(), imagefs.NewHostFS(root, meta), Options{
 		SizeBytes:         32 << 20,
 		DeterministicTime: time.Unix(1234, 0),
 	})

--- a/internal/fsimage/vm/vm_test.go
+++ b/internal/fsimage/vm/vm_test.go
@@ -129,6 +129,7 @@ func TestVirtualMemoryRandomReadWriteConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create backing file: %v", err)
 	}
+	defer backing.Close()
 	if _, err := backing.WriteAt(oracle, 0); err != nil {
 		t.Fatalf("write backing file: %v", err)
 	}
@@ -172,11 +173,15 @@ func TestVirtualMemoryRandomReadWriteConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create sparse output: %v", err)
 	}
+	defer out.Close()
 	if err := out.Truncate(size); err != nil {
 		t.Fatalf("truncate sparse output: %v", err)
 	}
 	if _, err := vm.WriteSparseTo(out); err != nil {
 		t.Fatalf("write sparse output: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close sparse output: %v", err)
 	}
 	got, err := os.ReadFile(out.Name())
 	if err != nil {

--- a/internal/hv/kvm/bsd_pc_session_linux_amd64.go
+++ b/internal/hv/kvm/bsd_pc_session_linux_amd64.go
@@ -232,7 +232,6 @@ func attachBSDPCDevices(vm *VM, root virtio.BlockBackend, extraBlocks []virtio.B
 		extraBlock.Attach(vm, vm)
 		pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(dev, ioBase, irq, extraBlock))
 	}
-	netdev.Attach(vm, vm)
 	netIndex := len(pciDevices) + 1
 	if netPCIDev == 0 {
 		netPCIDev = uint8(netIndex)
@@ -243,6 +242,8 @@ func attachBSDPCDevices(vm *VM, root virtio.BlockBackend, extraBlocks []virtio.B
 	if netIRQ == 0 {
 		netIRQ = uint8(10 + netIndex)
 	}
+	netdev.IRQ = uint32(netIRQ)
+	netdev.Attach(vm, vm)
 	pciDevices = append(pciDevices, NewVirtioNetPCIDevice(netPCIDev, netIOBase, netIRQ, netdev))
 	return NewPCIBus(pciDevices...)
 }

--- a/internal/hv/kvm/netbsd_session_linux_amd64.go
+++ b/internal/hv/kvm/netbsd_session_linux_amd64.go
@@ -193,6 +193,9 @@ func newNetBSDManagedNet(guestIPv4 net.IP, mac net.HardwareAddr) (*virtio.Net, *
 	stack := netstack.New(slog.Default())
 	_ = stack.SetGuestMAC(mac)
 	_ = stack.SetGuestIPv4(guestIPv4)
+	if hostMAC, err := net.ParseMAC("02:42:0a:2a:00:01"); err == nil {
+		_ = stack.SetHostMAC(hostMAC)
+	}
 	iface, _ := stack.AttachNetworkInterface()
 	dev := virtio.NewNet(0, 0x1000, 11, mac, netBSDManagedNetBackend{iface: iface})
 	dev.DisableMergeRX = true

--- a/internal/hv/whp/bindings_windows_amd64.go
+++ b/internal/hv/whp/bindings_windows_amd64.go
@@ -64,9 +64,11 @@ const capabilityCodeHypervisorPresent capabilityCode = 0
 
 type partitionPropertyCode uint32
 
-const partitionPropertyCodeProcessorCount partitionPropertyCode = 0x00001fff
-
-const partitionPropertyCodeLocalAPICEmulationMode partitionPropertyCode = 0x00001005
+const (
+	partitionPropertyCodeExtendedVMExits        partitionPropertyCode = 0x00000001
+	partitionPropertyCodeLocalAPICEmulationMode partitionPropertyCode = 0x00001005
+	partitionPropertyCodeProcessorCount         partitionPropertyCode = 0x00001fff
+)
 
 type localAPICEmulationMode uint32
 
@@ -285,6 +287,10 @@ func (c *runVPExitContext) memoryAccess() *memoryAccessContext {
 	return (*memoryAccessContext)(unsafe.Pointer(&c.Payload[0]))
 }
 
+func (c *runVPExitContext) instructionLength() uint8 {
+	return uint8(c.VpContext.InstructionLengthCr8 & 0xf)
+}
+
 type x64IOPortAccessInfo struct {
 	AsUint32 uint32
 }
@@ -314,6 +320,25 @@ type x64IOPortAccessContext struct {
 
 func (c *runVPExitContext) ioPortAccess() *x64IOPortAccessContext {
 	return (*x64IOPortAccessContext)(unsafe.Pointer(&c.Payload[0]))
+}
+
+type x64MSRAccessInfo struct {
+	AsUint32 uint32
+}
+
+func (i x64MSRAccessInfo) isWrite() bool {
+	return i.AsUint32&0x1 != 0
+}
+
+type x64MSRAccessContext struct {
+	AccessInfo x64MSRAccessInfo
+	MSRNumber  uint32
+	Rax        uint64
+	Rdx        uint64
+}
+
+func (c *runVPExitContext) msrAccess() *x64MSRAccessContext {
+	return (*x64MSRAccessContext)(unsafe.Pointer(&c.Payload[0]))
 }
 
 type x64ApicEoiContext struct {

--- a/internal/hv/whp/boot_status_windows_amd64.go
+++ b/internal/hv/whp/boot_status_windows_amd64.go
@@ -1,0 +1,12 @@
+//go:build windows && amd64
+
+package whp
+
+import "j5.nz/cc/client"
+
+func emitManagedBootStatus(onEvent func(client.BootEvent) error, message string) error {
+	if onEvent == nil {
+		return nil
+	}
+	return onEvent(client.BootEvent{Kind: "status", Message: message})
+}

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -557,7 +557,7 @@ func (p *bootPlatform) WriteIO(port uint16, data []byte) error {
 	}
 	if p.pic.Write(port, data) {
 		p.pic.Resample()
-		p.deliverPICOutput(false)
+		p.deliverPICOutput()
 		return nil
 	}
 	if p.pit.Write(port, data) {
@@ -683,7 +683,7 @@ func (p *bootPlatform) SetIRQ(irq uint32, level bool) error {
 	}
 	if level {
 		p.pic.SetIRQ(line, true)
-		p.deliverPICOutput(true)
+		p.deliverPICOutput()
 	} else {
 		p.pic.SetIRQ(line, false)
 	}
@@ -730,7 +730,7 @@ func (p *bootPlatform) raiseIRQ(line uint8) {
 		}
 	}
 	p.pic.SetIRQ(line, true)
-	p.deliverPICOutput(false)
+	p.deliverPICOutput()
 	p.pic.SetIRQ(line, false)
 }
 
@@ -799,7 +799,7 @@ func (p *bootPlatform) resampleDeviceIRQs() {
 	}
 }
 
-func (p *bootPlatform) deliverPICOutput(kick bool) bool {
+func (p *bootPlatform) deliverPICOutput() bool {
 	if vector, line, ok := p.pic.AcknowledgePending(); ok {
 		trigger := interruptTriggerEdge
 		if p.pic.LevelTriggered(line) {
@@ -810,10 +810,9 @@ func (p *bootPlatform) deliverPICOutput(kick bool) bool {
 			vector: vector,
 			level:  p.pic.LevelTriggered(line),
 		}, trigger)
+		_ = p.vm.NotifyInterruptWindow()
 		_ = p.vm.kickOutOfHLT()
-		if kick {
-			p.vm.kickIfRunning()
-		}
+		p.vm.kickIfRunning()
 		return true
 	}
 	return false

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -277,6 +277,10 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 			}
 		case runVPExitReasonX64ApicEoi:
 			platform.HandleEOI(raw.apicEoi().InterruptVector)
+		case runVPExitReasonX64MsrAccess:
+			if err := handleMSRAccess(vm, exit, &raw); err != nil {
+				return out.String(), fmt.Errorf("handle msr at rip=%#x: %w", exit.RIP, err)
+			}
 		case runVPExitReasonX64InterruptWindow:
 		case runVPExitReasonCanceled:
 		default:
@@ -313,6 +317,10 @@ type bootPlatform struct {
 	vsock         *virtio.Vsock
 	rng           *virtio.RNG
 	netdev        *virtio.Net
+	pci           *PCIBus
+	i8042         *I8042
+	rtc           *CMOSRTC
+	acpiPM        *ACPIPM
 	start         time.Time
 	irqAttempts   uint64
 	irqDelivered  uint64
@@ -320,6 +328,7 @@ type bootPlatform struct {
 	irqSuppressed uint64
 	irqLine       [16]uint64
 	deviceIRQLine [ioapicRedirEntries]bool
+	deferredIRQ   [ioapicRedirEntries]bool
 	pendingMu     sync.Mutex
 	pendingIRQ    [256]bool
 	pendingIRQs   []pendingIRQ
@@ -330,6 +339,7 @@ type bootPlatform struct {
 type pendingIRQ struct {
 	route   bootIOAPICRoute
 	trigger interruptTriggerMode
+	device  bool
 }
 
 type bootPlatformExitSnapshot struct {
@@ -465,6 +475,24 @@ func (p *bootPlatform) AttachNet(netdev *virtio.Net) {
 	netdev.Attach(p.vm, p)
 }
 
+func (p *bootPlatform) AttachPCI(pci *PCIBus) {
+	p.pci = pci
+	if pci == nil {
+		return
+	}
+	for _, dev := range pci.devices {
+		if dev != nil && dev.IRQLine < ioapicRedirEntries {
+			p.deviceIRQLine[dev.IRQLine] = true
+		}
+	}
+}
+
+func (p *bootPlatform) AttachPCDevices(i8042 *I8042, rtc *CMOSRTC, acpiPM *ACPIPM) {
+	p.i8042 = i8042
+	p.rtc = rtc
+	p.acpiPM = acpiPM
+}
+
 func (p *bootPlatform) markDeviceIRQ(irq uint32) {
 	if irq < ioapicRedirEntries {
 		p.deviceIRQLine[irq] = true
@@ -495,6 +523,18 @@ func (p *bootPlatform) ReadIO(port uint16, data []byte) error {
 	if p.pit.Read(port, data) {
 		return nil
 	}
+	if handled, err := p.pci.ReadIO(port, data); handled || err != nil {
+		return err
+	}
+	if handled, err := p.i8042.ReadIO(port, data); handled || err != nil {
+		return err
+	}
+	if handled, err := p.rtc.ReadIO(port, data); handled || err != nil {
+		return err
+	}
+	if handled, err := p.acpiPM.ReadIO(port, data); handled || err != nil {
+		return err
+	}
 	for i := range data {
 		data[i] = defaultIOReadByte(port + uint16(i))
 	}
@@ -518,6 +558,18 @@ func (p *bootPlatform) WriteIO(port uint16, data []byte) error {
 	}
 	if p.pit.Write(port, data) {
 		return nil
+	}
+	if handled, err := p.pci.WriteIO(port, data); handled || err != nil {
+		return err
+	}
+	if handled, err := p.i8042.WriteIO(port, data); handled || err != nil {
+		return err
+	}
+	if handled, err := p.rtc.WriteIO(port, data); handled || err != nil {
+		return err
+	}
+	if handled, err := p.acpiPM.WriteIO(port, data); handled || err != nil {
+		return err
 	}
 	return nil
 }
@@ -589,6 +641,7 @@ func (p *bootPlatform) WriteMMIO(addr uint64, data []byte) error {
 		if pending {
 			p.injectIOAPIC(route, p.isDeviceIRQ(route.line))
 		}
+		p.deliverDeferredDeviceIRQs()
 		return nil
 	}
 	if off, ok := hpetOffset(addr, len(data)); ok {
@@ -606,13 +659,17 @@ func (p *bootPlatform) SetIRQ(irq uint32, level bool) error {
 	if level {
 		p.recordIRQAttempt(line)
 	} else {
-		p.clearPendingIRQForLine(line)
+		p.clearPendingIRQForLine(line, true)
+		p.pic.Clear(line)
 	}
 	if int(line) < ioapicRedirEntries {
 		ioapicEnabled := p.ioapic.enabled(line)
 		if route, pending := p.ioapic.assert(line, level); pending {
 			p.injectIOAPIC(route, true)
 			return nil
+		}
+		if level && p.isDeviceIRQ(line) {
+			p.markDeferredDeviceIRQ(line)
 		}
 		if !level || ioapicEnabled {
 			if level {
@@ -633,14 +690,30 @@ func (p *bootPlatform) raiseTimerIRQ() {
 		atomic.AddUint64(&p.irqSuppressed, 1)
 		return
 	}
-	if p.reassertDeviceIRQ() {
-		return
-	}
+	p.reassertLegacyPICDeviceIRQ()
 	if p.ioapic.enabled(2) {
 		p.raiseIRQ(2)
 		return
 	}
 	p.raiseIRQ(0)
+}
+
+func (p *bootPlatform) reassertLegacyPICDeviceIRQ() {
+	for line, isDevice := range p.deviceIRQLine {
+		if !isDevice {
+			continue
+		}
+		if _, ok := p.ioapic.routeForLine(uint8(line)); ok {
+			continue
+		}
+		if _, ok := p.ioapic.deviceHighRoute(uint8(line)); ok {
+			continue
+		}
+		if p.injectPIC(uint8(line), false) {
+			p.recordIRQAttempt(uint8(line))
+			return
+		}
+	}
 }
 
 func (p *bootPlatform) raiseIRQ(line uint8) {
@@ -672,22 +745,6 @@ func (p *bootPlatform) raiseIRQ(line uint8) {
 	p.injectPIC(line, false)
 }
 
-func (p *bootPlatform) reassertDeviceIRQ() bool {
-	for line, isDevice := range p.deviceIRQLine {
-		if !isDevice {
-			continue
-		}
-		route, ok := p.ioapic.deviceHighRoute(uint8(line))
-		if !ok {
-			continue
-		}
-		p.recordIRQAttempt(uint8(line))
-		p.injectIOAPIC(route, true)
-		return true
-	}
-	return false
-}
-
 func (p *bootPlatform) recordIRQAttempt(line uint8) {
 	atomic.AddUint64(&p.irqAttempts, 1)
 	if int(line) < len(p.irqLine) {
@@ -698,6 +755,9 @@ func (p *bootPlatform) recordIRQAttempt(line uint8) {
 func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 	if route.vector < 0x10 {
 		atomic.AddUint64(&p.irqSuppressed, 1)
+		if deviceIRQ {
+			p.markDeferredDeviceIRQ(route.line)
+		}
 		p.ioapic.cancel(route)
 		return
 	}
@@ -706,7 +766,8 @@ func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 		trigger = interruptTriggerLevel
 	}
 	if deviceIRQ {
-		p.queuePendingIRQ(route, trigger)
+		p.clearDeferredDeviceIRQ(route.line)
+		p.queuePendingIRQ(route, trigger, true)
 		_ = p.vm.kickOutOfHLT()
 		p.vm.kickIfRunning()
 		return
@@ -727,33 +788,45 @@ func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 }
 
 func (p *bootPlatform) armPendingIRQWindow() error {
+	p.deliverDeferredDeviceIRQs()
 	if !p.hasPendingIRQ() {
 		return nil
 	}
 	return p.vm.NotifyInterruptWindow()
 }
 
-func (p *bootPlatform) injectPIC(line uint8, kick bool) {
+func (p *bootPlatform) injectPIC(line uint8, kick bool) bool {
 	if vector, ok := p.pic.Acknowledge(line); ok {
-		if err := p.vm.RequestInterrupt(uint32(vector)); err != nil {
+		var err error
+		if p.pic.LevelTriggered(line) {
+			err = p.vm.RequestInterruptWithTrigger(uint32(vector), interruptTriggerLevel)
+		} else {
+			err = p.vm.RequestInterrupt(uint32(vector))
+		}
+		if err != nil {
 			atomic.AddUint64(&p.irqFailed, 1)
 		} else {
 			atomic.AddUint64(&p.irqDelivered, 1)
 			if kick {
 				p.vm.kickIfRunning()
 			}
+			return true
 		}
 	}
+	return false
 }
 
 func (p *bootPlatform) HandleEOI(vector uint32) {
 	if route, pending := p.ioapic.handleEOI(vector); pending {
+		if p.isDeviceIRQ(route.line) {
+			return
+		}
 		atomic.AddUint64(&p.irqAttempts, 1)
 		p.injectIOAPIC(route, p.isDeviceIRQ(route.line))
 	}
 }
 
-func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptTriggerMode) {
+func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptTriggerMode, device bool) {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
 	if p.pendingIRQ[route.vector] {
@@ -763,15 +836,63 @@ func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptT
 	p.pendingIRQs = append(p.pendingIRQs, pendingIRQ{
 		route:   route,
 		trigger: trigger,
+		device:  device,
 	})
 }
 
-func (p *bootPlatform) clearPendingIRQForLine(line uint8) {
+func (p *bootPlatform) markDeferredDeviceIRQ(line uint8) {
+	if int(line) >= len(p.deferredIRQ) {
+		return
+	}
+	p.pendingMu.Lock()
+	p.deferredIRQ[line] = true
+	p.pendingMu.Unlock()
+}
+
+func (p *bootPlatform) clearDeferredDeviceIRQ(line uint8) {
+	if int(line) >= len(p.deferredIRQ) {
+		return
+	}
+	p.pendingMu.Lock()
+	p.deferredIRQ[line] = false
+	p.pendingMu.Unlock()
+}
+
+func (p *bootPlatform) deliverDeferredDeviceIRQs() {
+	var routes []bootIOAPICRoute
+	p.pendingMu.Lock()
+	for line, deferred := range p.deferredIRQ {
+		if !deferred || !p.deviceIRQLine[line] {
+			continue
+		}
+		route, ok := p.ioapic.routeForLine(uint8(line))
+		if !ok {
+			p.pendingMu.Unlock()
+			if p.injectPIC(uint8(line), true) {
+				p.clearDeferredDeviceIRQ(uint8(line))
+			}
+			p.pendingMu.Lock()
+			continue
+		}
+		p.deferredIRQ[line] = false
+		routes = append(routes, route)
+	}
+	p.pendingMu.Unlock()
+	for _, route := range routes {
+		p.injectIOAPIC(route, true)
+	}
+}
+
+func (p *bootPlatform) clearPendingIRQForLine(line uint8, keepUndeliveredDevice bool) {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
 	for i := 0; i < len(p.pendingIRQs); {
 		pending := p.pendingIRQs[i]
 		if pending.route.line != line {
+			i++
+			continue
+		}
+		if keepUndeliveredDevice && pending.device {
 			i++
 			continue
 		}
@@ -797,25 +918,47 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
-	if pending.route.level {
-		if _, ok := p.ioapic.deviceHighRoute(pending.route.line); !ok {
-			copy(p.pendingIRQs, p.pendingIRQs[1:])
-			p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
-			p.pendingIRQ[pending.route.vector] = false
-			p.pendingMu.Unlock()
-			return false, nil
+	if pending.device && !windowExit {
+		p.pendingMu.Unlock()
+		return false, nil
+	}
+	route := pending.route
+	trigger := pending.trigger
+	if route.level {
+		if _, ok := p.ioapic.deviceHighRoute(route.line); !ok {
+			if pending.device {
+				// Virtio legacy devices can deassert when the guest polls ISR status
+				// before WHP has accepted the queued interrupt. Keep the completion
+				// edge deliverable once so guests waiting on an interrupt still wake.
+				route.level = false
+				trigger = interruptTriggerEdge
+			} else {
+				copy(p.pendingIRQs, p.pendingIRQs[1:])
+				p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
+				p.pendingIRQ[route.vector] = false
+				p.pendingMu.Unlock()
+				return false, nil
+			}
 		}
 	}
 	if !windowExit {
+		copy(p.pendingIRQs, p.pendingIRQs[1:])
+		p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
+		p.pendingIRQ[route.vector] = false
 		p.pendingMu.Unlock()
 		var err error
-		if p.usePendingInterruptionFallback(pending.route.line) {
-			err = p.vm.SetPendingInterruption(pending.route.vector)
+		if p.usePendingInterruptionFallback(route.line) {
+			err = p.vm.SetPendingInterruption(route.vector)
 		} else {
-			err = p.vm.RequestInterruptWithTrigger(uint32(pending.route.vector), pending.trigger)
+			if route.level && !p.ioapic.beginInterrupt(route.vector) {
+				atomic.AddUint64(&p.irqSuppressed, 1)
+				return false, nil
+			}
+			err = p.vm.RequestInterruptWithTrigger(uint32(route.vector), trigger)
 		}
 		if err != nil {
 			atomic.AddUint64(&p.irqFailed, 1)
+			p.ioapic.cancel(route)
 			return false, err
 		}
 		atomic.AddUint64(&p.irqDelivered, 1)
@@ -823,17 +966,17 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 	}
 	copy(p.pendingIRQs, p.pendingIRQs[1:])
 	p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
-	p.pendingIRQ[pending.route.vector] = false
+	p.pendingIRQ[route.vector] = false
 	p.pendingMu.Unlock()
 
 	_ = p.vm.kickOutOfHLT()
-	if pending.route.level && !p.ioapic.beginInterrupt(pending.route.vector) {
+	if route.level && !p.ioapic.beginInterrupt(route.vector) {
 		atomic.AddUint64(&p.irqSuppressed, 1)
 		return false, nil
 	}
-	if err := p.vm.RequestInterruptWithTrigger(uint32(pending.route.vector), pending.trigger); err != nil {
+	if err := p.vm.RequestInterruptWithTrigger(uint32(route.vector), trigger); err != nil {
 		atomic.AddUint64(&p.irqFailed, 1)
-		p.ioapic.cancel(pending.route)
+		p.ioapic.cancel(route)
 		return false, err
 	}
 	atomic.AddUint64(&p.irqDelivered, 1)
@@ -855,13 +998,27 @@ func (p *bootPlatform) usePendingInterruptionFallback(line uint8) bool {
 func (p *bootPlatform) hasPendingIRQ() bool {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
-	return len(p.pendingIRQs) != 0
+	if len(p.pendingIRQs) != 0 {
+		return true
+	}
+	for _, pending := range p.deferredIRQ {
+		if pending {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *bootPlatform) pendingIRQCount() int {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
-	return len(p.pendingIRQs)
+	count := len(p.pendingIRQs)
+	for _, pending := range p.deferredIRQ {
+		if pending {
+			count++
+		}
+	}
+	return count
 }
 
 func canAcceptInterrupt(ctx *runVPExitContext, vector uint8) bool {

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -340,6 +340,8 @@ type pendingIRQ struct {
 	route   bootIOAPICRoute
 	trigger interruptTriggerMode
 	device  bool
+	sticky  bool
+	pic     bool
 }
 
 type bootPlatformExitSnapshot struct {
@@ -554,6 +556,8 @@ func (p *bootPlatform) WriteIO(port uint16, data []byte) error {
 		return nil
 	}
 	if p.pic.Write(port, data) {
+		p.pic.Resample()
+		p.deliverPICOutput(false)
 		return nil
 	}
 	if p.pit.Write(port, data) {
@@ -659,8 +663,7 @@ func (p *bootPlatform) SetIRQ(irq uint32, level bool) error {
 	if level {
 		p.recordIRQAttempt(line)
 	} else {
-		p.clearPendingIRQForLine(line, true)
-		p.pic.Clear(line)
+		p.clearPendingIRQForLine(line, p.keepUndeliveredDeviceIRQ(line))
 	}
 	if int(line) < ioapicRedirEntries {
 		ioapicEnabled := p.ioapic.enabled(line)
@@ -679,7 +682,10 @@ func (p *bootPlatform) SetIRQ(irq uint32, level bool) error {
 		}
 	}
 	if level {
-		p.injectPIC(line, true)
+		p.pic.SetIRQ(line, true)
+		p.deliverPICOutput(true)
+	} else {
+		p.pic.SetIRQ(line, false)
 	}
 	return nil
 }
@@ -690,30 +696,11 @@ func (p *bootPlatform) raiseTimerIRQ() {
 		atomic.AddUint64(&p.irqSuppressed, 1)
 		return
 	}
-	p.reassertLegacyPICDeviceIRQ()
 	if p.ioapic.enabled(2) {
 		p.raiseIRQ(2)
 		return
 	}
 	p.raiseIRQ(0)
-}
-
-func (p *bootPlatform) reassertLegacyPICDeviceIRQ() {
-	for line, isDevice := range p.deviceIRQLine {
-		if !isDevice {
-			continue
-		}
-		if _, ok := p.ioapic.routeForLine(uint8(line)); ok {
-			continue
-		}
-		if _, ok := p.ioapic.deviceHighRoute(uint8(line)); ok {
-			continue
-		}
-		if p.injectPIC(uint8(line), false) {
-			p.recordIRQAttempt(uint8(line))
-			return
-		}
-	}
 }
 
 func (p *bootPlatform) raiseIRQ(line uint8) {
@@ -742,7 +729,9 @@ func (p *bootPlatform) raiseIRQ(line uint8) {
 			return
 		}
 	}
-	p.injectPIC(line, false)
+	p.pic.SetIRQ(line, true)
+	p.deliverPICOutput(false)
+	p.pic.SetIRQ(line, false)
 }
 
 func (p *bootPlatform) recordIRQAttempt(line uint8) {
@@ -767,7 +756,7 @@ func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 	}
 	if deviceIRQ {
 		p.clearDeferredDeviceIRQ(route.line)
-		p.queuePendingIRQ(route, trigger, true)
+		p.queuePendingIRQ(route, trigger, true, p.keepUndeliveredDeviceIRQ(route.line))
 		_ = p.vm.kickOutOfHLT()
 		p.vm.kickIfRunning()
 		return
@@ -788,30 +777,44 @@ func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 }
 
 func (p *bootPlatform) armPendingIRQWindow() error {
+	p.resampleDeviceIRQs()
 	p.deliverDeferredDeviceIRQs()
 	if !p.hasPendingIRQ() {
+		return nil
+	}
+	if delivered, err := p.flushHaltedPICIRQ(); err != nil {
+		return err
+	} else if delivered {
 		return nil
 	}
 	return p.vm.NotifyInterruptWindow()
 }
 
-func (p *bootPlatform) injectPIC(line uint8, kick bool) bool {
-	if vector, ok := p.pic.Acknowledge(line); ok {
-		var err error
+func (p *bootPlatform) resampleDeviceIRQs() {
+	if p.netdev != nil && p.netdev.IRQAsserted() {
+		line := uint8(p.netdev.IRQ)
+		if route, pending := p.ioapic.assert(line, true); pending {
+			p.injectIOAPIC(route, true)
+		}
+	}
+}
+
+func (p *bootPlatform) deliverPICOutput(kick bool) bool {
+	if vector, line, ok := p.pic.AcknowledgePending(); ok {
+		trigger := interruptTriggerEdge
 		if p.pic.LevelTriggered(line) {
-			err = p.vm.RequestInterruptWithTrigger(uint32(vector), interruptTriggerLevel)
-		} else {
-			err = p.vm.RequestInterrupt(uint32(vector))
+			trigger = interruptTriggerLevel
 		}
-		if err != nil {
-			atomic.AddUint64(&p.irqFailed, 1)
-		} else {
-			atomic.AddUint64(&p.irqDelivered, 1)
-			if kick {
-				p.vm.kickIfRunning()
-			}
-			return true
+		p.queuePendingPICIRQ(bootIOAPICRoute{
+			line:   line,
+			vector: vector,
+			level:  p.pic.LevelTriggered(line),
+		}, trigger)
+		_ = p.vm.kickOutOfHLT()
+		if kick {
+			p.vm.kickIfRunning()
 		}
+		return true
 	}
 	return false
 }
@@ -826,7 +829,7 @@ func (p *bootPlatform) HandleEOI(vector uint32) {
 	}
 }
 
-func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptTriggerMode, device bool) {
+func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptTriggerMode, device bool, sticky bool) {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
 	if p.pendingIRQ[route.vector] {
@@ -837,7 +840,60 @@ func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptT
 		route:   route,
 		trigger: trigger,
 		device:  device,
+		sticky:  sticky,
 	})
+}
+
+func (p *bootPlatform) queuePendingPICIRQ(route bootIOAPICRoute, trigger interruptTriggerMode) {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	if p.pendingIRQ[route.vector] {
+		return
+	}
+	p.pendingIRQ[route.vector] = true
+	p.pendingIRQs = append(p.pendingIRQs, pendingIRQ{
+		route:   route,
+		trigger: trigger,
+		pic:     true,
+	})
+}
+
+func (p *bootPlatform) flushHaltedPICIRQ() (bool, error) {
+	p.pendingMu.Lock()
+	if len(p.pendingIRQs) == 0 {
+		p.pendingMu.Unlock()
+		return false, nil
+	}
+	pending := p.pendingIRQs[0]
+	if !pending.pic {
+		p.pendingMu.Unlock()
+		return false, nil
+	}
+	route := pending.route
+	p.pendingMu.Unlock()
+
+	ready, err := p.vm.haltedAndInterruptible(route.vector)
+	if err != nil || !ready {
+		return false, err
+	}
+
+	p.pendingMu.Lock()
+	if len(p.pendingIRQs) == 0 || !p.pendingIRQs[0].pic || p.pendingIRQs[0].route.vector != route.vector {
+		p.pendingMu.Unlock()
+		return false, nil
+	}
+	copy(p.pendingIRQs, p.pendingIRQs[1:])
+	p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
+	p.pendingIRQ[route.vector] = false
+	p.pendingMu.Unlock()
+
+	if err := p.vm.SetPendingInterruption(route.vector); err != nil {
+		atomic.AddUint64(&p.irqFailed, 1)
+		return false, err
+	}
+	_ = p.vm.kickOutOfHLT()
+	atomic.AddUint64(&p.irqDelivered, 1)
+	return true, nil
 }
 
 func (p *bootPlatform) markDeferredDeviceIRQ(line uint8) {
@@ -865,13 +921,15 @@ func (p *bootPlatform) deliverDeferredDeviceIRQs() {
 		if !deferred || !p.deviceIRQLine[line] {
 			continue
 		}
-		route, ok := p.ioapic.routeForLine(uint8(line))
-		if !ok {
-			p.pendingMu.Unlock()
-			if p.injectPIC(uint8(line), true) {
-				p.clearDeferredDeviceIRQ(uint8(line))
-			}
-			p.pendingMu.Lock()
+		var route bootIOAPICRoute
+		var pending bool
+		if p.keepUndeliveredDeviceIRQ(uint8(line)) {
+			route, pending = p.ioapic.routeForLine(uint8(line))
+		} else {
+			route, pending = p.ioapic.assert(uint8(line), true)
+		}
+		if !pending {
+			p.deferredIRQ[line] = false
 			continue
 		}
 		p.deferredIRQ[line] = false
@@ -883,7 +941,7 @@ func (p *bootPlatform) deliverDeferredDeviceIRQs() {
 	}
 }
 
-func (p *bootPlatform) clearPendingIRQForLine(line uint8, keepUndeliveredDevice bool) {
+func (p *bootPlatform) clearPendingIRQForLine(line uint8, keepSticky bool) {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
 	for i := 0; i < len(p.pendingIRQs); {
@@ -892,7 +950,7 @@ func (p *bootPlatform) clearPendingIRQForLine(line uint8, keepUndeliveredDevice 
 			i++
 			continue
 		}
-		if keepUndeliveredDevice && pending.device {
+		if keepSticky && pending.sticky {
 			i++
 			continue
 		}
@@ -900,6 +958,10 @@ func (p *bootPlatform) clearPendingIRQForLine(line uint8, keepUndeliveredDevice 
 		copy(p.pendingIRQs[i:], p.pendingIRQs[i+1:])
 		p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
 	}
+}
+
+func (p *bootPlatform) keepUndeliveredDeviceIRQ(line uint8) bool {
+	return p.netdev == nil || p.netdev.IRQ != uint32(line)
 }
 
 func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
@@ -918,18 +980,14 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
-	if pending.device && !windowExit {
-		p.pendingMu.Unlock()
-		return false, nil
-	}
 	route := pending.route
 	trigger := pending.trigger
 	if route.level {
-		if _, ok := p.ioapic.deviceHighRoute(route.line); !ok {
-			if pending.device {
-				// Virtio legacy devices can deassert when the guest polls ISR status
-				// before WHP has accepted the queued interrupt. Keep the completion
-				// edge deliverable once so guests waiting on an interrupt still wake.
+		if pending.pic {
+			// The PIC has already latched this interrupt. Further level resampling
+			// happens when the guest EOIs and the current line state is sampled.
+		} else if _, ok := p.ioapic.deviceHighRoute(route.line); !ok {
+			if pending.sticky {
 				route.level = false
 				trigger = interruptTriggerEdge
 			} else {
@@ -947,7 +1005,7 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 		p.pendingIRQ[route.vector] = false
 		p.pendingMu.Unlock()
 		var err error
-		if p.usePendingInterruptionFallback(route.line) {
+		if pending.pic || p.usePendingInterruptionFallback(route.line) {
 			err = p.vm.SetPendingInterruption(route.vector)
 		} else {
 			if route.level && !p.ioapic.beginInterrupt(route.vector) {
@@ -970,6 +1028,14 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 	p.pendingMu.Unlock()
 
 	_ = p.vm.kickOutOfHLT()
+	if pending.pic {
+		if err := p.vm.SetPendingInterruption(route.vector); err != nil {
+			atomic.AddUint64(&p.irqFailed, 1)
+			return false, err
+		}
+		atomic.AddUint64(&p.irqDelivered, 1)
+		return true, nil
+	}
 	if route.level && !p.ioapic.beginInterrupt(route.vector) {
 		atomic.AddUint64(&p.irqSuppressed, 1)
 		return false, nil
@@ -1021,6 +1087,25 @@ func (p *bootPlatform) pendingIRQCount() int {
 	return count
 }
 
+func (p *bootPlatform) pendingIRQSummary() string {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	var parts []string
+	for _, pending := range p.pendingIRQs {
+		source := "ioapic"
+		if pending.pic {
+			source = "pic"
+		}
+		parts = append(parts, fmt.Sprintf("%s:%d->%#x", source, pending.route.line, pending.route.vector))
+	}
+	for line, pending := range p.deferredIRQ {
+		if pending {
+			parts = append(parts, fmt.Sprintf("deferred:%d", line))
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
 func canAcceptInterrupt(ctx *runVPExitContext, vector uint8) bool {
 	if ctx == nil {
 		return true
@@ -1047,7 +1132,7 @@ func (p *bootPlatform) Summary() string {
 		p.ioapic.summaryForLines(p.activeIRQLines()),
 	)
 	if pending := p.pendingIRQCount(); pending != 0 {
-		summary += fmt.Sprintf(" irq_pending=%d", pending)
+		summary += fmt.Sprintf(" irq_pending=%d[%s]", pending, p.pendingIRQSummary())
 	}
 	if lastExit := p.lastExitSummary(); lastExit != "" {
 		summary += " " + lastExit
@@ -1057,6 +1142,9 @@ func (p *bootPlatform) Summary() string {
 	}
 	if p.vsock != nil {
 		summary += " " + p.vsock.Summary()
+	}
+	if p.netdev != nil {
+		summary += " " + p.netdev.Summary()
 	}
 	for _, fsdev := range p.fsdevs {
 		if fsdev != nil {

--- a/internal/hv/whp/bsd_session_windows_amd64.go
+++ b/internal/hv/whp/bsd_session_windows_amd64.go
@@ -404,7 +404,6 @@ func attachBSDPCDevices(platform *bootPlatform, root virtio.BlockBackend, extraB
 		extraBlock.Attach(platform.vm, platform)
 		pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(dev, ioBase, irq, extraBlock))
 	}
-	netdev.Attach(platform.vm, platform)
 	netIndex := len(pciDevices) + 1
 	if netPCIDev == 0 {
 		netPCIDev = uint8(netIndex)
@@ -415,6 +414,8 @@ func attachBSDPCDevices(platform *bootPlatform, root virtio.BlockBackend, extraB
 	if netIRQ == 0 {
 		netIRQ = uint8(10 + netIndex)
 	}
+	netdev.IRQ = uint32(netIRQ)
+	platform.AttachNet(netdev)
 	pciDevices = append(pciDevices, NewVirtioNetPCIDevice(netPCIDev, netIOBase, netIRQ, netdev))
 	return NewPCIBus(pciDevices...)
 }

--- a/internal/hv/whp/bsd_session_windows_amd64.go
+++ b/internal/hv/whp/bsd_session_windows_amd64.go
@@ -1,0 +1,604 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/amd64vm"
+	freebsdamd64 "j5.nz/cc/internal/freebsd/boot/amd64"
+	"j5.nz/cc/internal/managed/machine"
+	netbsdamd64 "j5.nz/cc/internal/netbsd/boot/amd64"
+	"j5.nz/cc/internal/netstack"
+	openbsdamd64 "j5.nz/cc/internal/openbsd/boot/amd64"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const bsdControlPort = 10777
+
+var processStart = time.Now()
+
+type OpenBSDManagedConfig struct {
+	Kernel    []byte
+	Root      virtio.BlockBackend
+	MemoryMB  uint64
+	Dmesg     bool
+	GuestIPv4 net.IP
+	GuestMAC  net.HardwareAddr
+	NetDevice *virtio.Net
+	NetStack  *netstack.NetStack
+}
+
+type FreeBSDManagedConfig struct {
+	Kernel      []byte
+	Root        virtio.BlockBackend
+	ExtraBlocks []virtio.BlockBackend
+	MemoryMB    uint64
+	Dmesg       bool
+	GuestIPv4   net.IP
+	GuestMAC    net.HardwareAddr
+	NetDevice   *virtio.Net
+	NetStack    *netstack.NetStack
+}
+
+type NetBSDManagedConfig = FreeBSDManagedConfig
+
+type bsdPCSessionConfig struct {
+	Spec        machine.Spec
+	GuestName   string
+	Kernel      []byte
+	Root        virtio.BlockBackend
+	ExtraBlocks []virtio.BlockBackend
+	MemoryMB    uint64
+	Dmesg       bool
+	NetDevice   *virtio.Net
+	NetStack    *netstack.NetStack
+	NetPCIDev   uint8
+	NetIOBase   uint16
+	NetIRQ      uint8
+	BlockQuirks bsdPCBlockQuirks
+	Prepare     func(vm *VM, mem []byte) error
+	Input       func(context.Context, *serial.UART8250, *vmruntime.SerialTranscript)
+}
+
+type bsdPCBlockQuirks struct {
+	DisableSizeMax bool
+}
+
+func StartOpenBSDManagedSession(ctx context.Context, cfg OpenBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if len(cfg.Kernel) == 0 {
+		return nil, fmt.Errorf("OpenBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return nil, fmt.Errorf("OpenBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 768
+	}
+	return startBSDPCManagedSession(ctx, bsdPCSessionConfig{
+		Spec: machine.Spec{
+			Guest:    "OpenBSD",
+			Arch:     "amd64",
+			MemoryMB: cfg.MemoryMB,
+			Dmesg:    cfg.Dmesg,
+			Control:  machine.ControlSpec{Kind: "tcp", Port: bsdControlPort},
+			Boot:     machine.BootSpec{Kind: "openbsd"},
+			Network:  &machine.NetworkSpec{GuestIPv4: cfg.GuestIPv4.String(), MAC: cfg.GuestMAC.String()},
+			Devices: []machine.DeviceSpec{
+				{Kind: "virtio-block", Name: "root", Bus: "pci", Slot: 1, IOBase: 0x1000, IRQ: 10},
+				{Kind: "virtio-net", Name: "net0", Bus: "pci", Slot: 2, IOBase: 0x1100, IRQ: 11},
+			},
+		},
+		GuestName: "OpenBSD",
+		Kernel:    cfg.Kernel,
+		Root:      cfg.Root,
+		MemoryMB:  cfg.MemoryMB,
+		Dmesg:     cfg.Dmesg,
+		NetDevice: cfg.NetDevice,
+		NetStack:  cfg.NetStack,
+		Prepare: func(vm *VM, mem []byte) error {
+			plan, err := openbsdamd64.PrepareBoot(mem, cfg.Kernel, openbsdamd64.BootOptions{
+				MemorySize: amd64vm.MemorySizeBytes(cfg.MemoryMB),
+				BootDev:    openbsdamd64.SCSIBootDev(0, 0),
+			})
+			if err != nil {
+				return fmt.Errorf("prepare OpenBSD boot: %w", err)
+			}
+			return vm.SetProtectedMode32(plan.EntryGPA, plan.StackGPA)
+		},
+		Input: answerOpenBSDPrompts,
+	}, onEvent)
+}
+
+func StartFreeBSDManagedSession(ctx context.Context, cfg FreeBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if len(cfg.Kernel) == 0 {
+		return nil, fmt.Errorf("FreeBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return nil, fmt.Errorf("FreeBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 1024
+	}
+	return startBSDPCManagedSession(ctx, freeNetBSDSessionConfig("FreeBSD", "freebsd", cfg, bsdPCBlockQuirks{DisableSizeMax: true}, func(vm *VM, mem []byte) error {
+		plan, err := freebsdamd64.PrepareBoot(mem, cfg.Kernel, freebsdamd64.BootOptions{
+			MemorySize: amd64vm.MemorySizeBytes(cfg.MemoryMB),
+		})
+		if err != nil {
+			return fmt.Errorf("prepare FreeBSD boot: %w", err)
+		}
+		return vm.SetFreeBSDLongMode(plan.EntryGVA, plan.StackGPA, plan.PagingGPA)
+	}), onEvent)
+}
+
+func StartNetBSDManagedSession(ctx context.Context, cfg NetBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if len(cfg.Kernel) == 0 {
+		return nil, fmt.Errorf("NetBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return nil, fmt.Errorf("NetBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 1024
+	}
+	return startBSDPCManagedSession(ctx, freeNetBSDSessionConfig("NetBSD", "netbsd", cfg, bsdPCBlockQuirks{}, func(vm *VM, mem []byte) error {
+		plan, err := netbsdamd64.PrepareBoot(mem, cfg.Kernel, netbsdamd64.BootOptions{
+			MemorySize: amd64vm.MemorySizeBytes(cfg.MemoryMB),
+		})
+		if err != nil {
+			return fmt.Errorf("prepare NetBSD boot: %w", err)
+		}
+		return vm.SetProtectedMode32(plan.EntryGPA, plan.StackGPA)
+	}), onEvent)
+}
+
+func freeNetBSDSessionConfig(name, boot string, cfg FreeBSDManagedConfig, quirks bsdPCBlockQuirks, prepare func(*VM, []byte) error) bsdPCSessionConfig {
+	devices := []machine.DeviceSpec{{Kind: "virtio-block", Name: "root", Bus: "pci", Slot: 1, IOBase: 0x1000, IRQ: 10}}
+	for idx := range cfg.ExtraBlocks {
+		devices = append(devices, machine.DeviceSpec{
+			Kind:   "virtio-block",
+			Name:   fmt.Sprintf("extra%d", idx),
+			Bus:    "pci",
+			Slot:   uint8(2 + idx),
+			IOBase: uint16(0x1100 + idx*0x100),
+			IRQ:    uint8(11 + idx),
+		})
+	}
+	netIndex := len(devices) + 1
+	devices = append(devices, machine.DeviceSpec{
+		Kind:   "virtio-net",
+		Name:   "net0",
+		Bus:    "pci",
+		Slot:   uint8(netIndex),
+		IOBase: uint16(0x1000 + netIndex*0x100),
+		IRQ:    uint8(10 + netIndex),
+	})
+	return bsdPCSessionConfig{
+		Spec: machine.Spec{
+			Guest:    name,
+			Arch:     "amd64",
+			MemoryMB: cfg.MemoryMB,
+			Dmesg:    cfg.Dmesg,
+			Control:  machine.ControlSpec{Kind: "tcp", Port: bsdControlPort},
+			Boot:     machine.BootSpec{Kind: boot},
+			Network:  &machine.NetworkSpec{GuestIPv4: cfg.GuestIPv4.String(), MAC: cfg.GuestMAC.String()},
+			Devices:  devices,
+		},
+		GuestName:   name,
+		Kernel:      cfg.Kernel,
+		Root:        cfg.Root,
+		ExtraBlocks: cfg.ExtraBlocks,
+		MemoryMB:    cfg.MemoryMB,
+		Dmesg:       cfg.Dmesg,
+		NetDevice:   cfg.NetDevice,
+		NetStack:    cfg.NetStack,
+		BlockQuirks: quirks,
+		Prepare:     prepare,
+	}
+}
+
+func startBSDPCManagedSession(ctx context.Context, cfg bsdPCSessionConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	cfg = normalizeBSDPCSessionConfig(cfg)
+	if cfg.NetDevice == nil || cfg.NetStack == nil {
+		return nil, fmt.Errorf("%s network device and stack are required", cfg.GuestName)
+	}
+	if cfg.Prepare == nil {
+		return nil, fmt.Errorf("%s boot prepare hook is required", cfg.GuestName)
+	}
+	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
+		return nil, err
+	}
+	ln, err := cfg.NetStack.ListenInternal("tcp", fmt.Sprintf(":%d", bsdSessionControlPort(cfg)))
+	if err != nil {
+		return nil, fmt.Errorf("listen %s control tcp: %w", cfg.GuestName, err)
+	}
+
+	connCh := make(chan net.Conn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+
+	vm, err := newBootVM(amd64vm.MemorySizeBytes(cfg.MemoryMB))
+	if err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	var bootWriter *vmruntime.BootEventWriter
+	serialOut := vmruntime.NewSerialTranscript()
+	var serialWriter io.Writer = serialOut
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = io.MultiWriter(serialOut, bootWriter)
+	}
+	uart := serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter)
+	platform := newBootPlatform(vm, uart)
+	platform.AttachPCDevices(NewI8042(), NewCMOSRTC(nil), NewACPIPM())
+	pci := attachBSDPCDevices(platform, cfg.Root, cfg.ExtraBlocks, cfg.NetDevice, cfg.NetPCIDev, cfg.NetIOBase, cfg.NetIRQ, cfg.BlockQuirks)
+	platform.AttachPCI(pci)
+	if err := cfg.Prepare(vm, vm.Memory()); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+	if err := vm.EnableEmulation(platform); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, fmt.Errorf("enable emulation: %w", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error, 1)
+	if cfg.Input != nil {
+		go cfg.Input(runCtx, uart, serialOut)
+	}
+	go func() {
+		defer vm.Close()
+		defer platform.Close()
+		doneCh <- runBSDManagedVM(runCtx, cfg.GuestName, vm, platform, serialOut)
+	}()
+
+	var control net.Conn
+	select {
+	case err := <-acceptErrCh:
+		cancel()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, bsdStartupError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+	case err := <-doneCh:
+		cancel()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, bsdStartupError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		cancel()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, bsdStartupError(fmt.Errorf("%s guest did not connect to control TCP port %d before startup deadline: %w (%s)", cfg.GuestName, bsdSessionControlPort(cfg), ctx.Err(), platform.Summary()), serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, bsdStartupError(fmt.Errorf("%s control connection did not report ready marker %q: %w", cfg.GuestName, vmruntime.InstanceReadyMarker, err), serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		cancel()
+		_ = control.Close()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, bsdStartupError(fmt.Errorf("%s guest reported boot failure", cfg.GuestName), serialOut.String(), controlTranscript.String())
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	return &ManagedSession{
+		cancel:     cancel,
+		doneCh:     doneCh,
+		control:    control,
+		listener:   ln,
+		bootWriter: bootWriter,
+		transcript: controlTranscript,
+		serialOut:  serialOut,
+		platform:   platform,
+		dmesg:      cfg.Dmesg,
+	}, nil
+}
+
+func normalizeBSDPCSessionConfig(cfg bsdPCSessionConfig) bsdPCSessionConfig {
+	if cfg.GuestName == "" {
+		cfg.GuestName = cfg.Spec.Guest
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = cfg.Spec.MemoryMB
+	}
+	if !cfg.Dmesg {
+		cfg.Dmesg = cfg.Spec.Dmesg
+	}
+	for _, dev := range cfg.Spec.Devices {
+		if dev.Kind != "virtio-net" && dev.Name != "net0" {
+			continue
+		}
+		if cfg.NetPCIDev == 0 {
+			cfg.NetPCIDev = dev.Slot
+		}
+		if cfg.NetIOBase == 0 {
+			cfg.NetIOBase = dev.IOBase
+		}
+		if cfg.NetIRQ == 0 {
+			cfg.NetIRQ = dev.IRQ
+		}
+	}
+	return cfg
+}
+
+func bsdSessionControlPort(cfg bsdPCSessionConfig) int {
+	if cfg.Spec.Control.Port > 0 {
+		return cfg.Spec.Control.Port
+	}
+	return bsdControlPort
+}
+
+func attachBSDPCDevices(platform *bootPlatform, root virtio.BlockBackend, extraBlocks []virtio.BlockBackend, netdev *virtio.Net, netPCIDev uint8, netIOBase uint16, netIRQ uint8, blockQuirks bsdPCBlockQuirks) *PCIBus {
+	var pciDevices []*PCIDevice
+	block := virtio.NewBlock(0, 0x1000, 10, root)
+	block.DisableSizeMax = blockQuirks.DisableSizeMax
+	block.Attach(platform.vm, platform)
+	pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(1, 0x1000, 10, block))
+	for i, backend := range extraBlocks {
+		if backend == nil {
+			continue
+		}
+		dev := uint8(2 + i)
+		ioBase := uint16(0x1100 + i*0x100)
+		irq := uint8(11 + i)
+		extraBlock := virtio.NewBlock(0, 0x1000, uint32(irq), backend)
+		extraBlock.DisableSizeMax = blockQuirks.DisableSizeMax
+		extraBlock.Attach(platform.vm, platform)
+		pciDevices = append(pciDevices, NewVirtioBlockPCIDevice(dev, ioBase, irq, extraBlock))
+	}
+	netdev.Attach(platform.vm, platform)
+	netIndex := len(pciDevices) + 1
+	if netPCIDev == 0 {
+		netPCIDev = uint8(netIndex)
+	}
+	if netIOBase == 0 {
+		netIOBase = uint16(0x1000 + netIndex*0x100)
+	}
+	if netIRQ == 0 {
+		netIRQ = uint8(10 + netIndex)
+	}
+	pciDevices = append(pciDevices, NewVirtioNetPCIDevice(netPCIDev, netIOBase, netIRQ, netdev))
+	return NewPCIBus(pciDevices...)
+}
+
+func answerOpenBSDPrompts(ctx context.Context, uart *serial.UART8250, serialOut *vmruntime.SerialTranscript) {
+	var answeredRoot atomic.Bool
+	var answeredSwap atomic.Bool
+	var fallbackDeadline time.Time
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			serial := serialOut.String()
+			if fallbackDeadline.IsZero() && strings.Contains(serial, "sd0: ") {
+				fallbackDeadline = time.Now().Add(time.Second)
+			}
+			if !answeredRoot.Load() && strings.Contains(serial, "root device:") {
+				answeredRoot.Store(true)
+				_ = uart.InjectRXBytes([]byte("sd0a\n"))
+			}
+			if answeredRoot.Load() && !answeredSwap.Load() && strings.Contains(serial, "swap device") {
+				answeredSwap.Store(true)
+				_ = uart.InjectRXBytes([]byte("\n"))
+			}
+			if !fallbackDeadline.IsZero() && time.Now().After(fallbackDeadline) && !answeredRoot.Load() {
+				answeredRoot.Store(true)
+				answeredSwap.Store(true)
+				_ = uart.InjectRXBytes([]byte("sd0a\n\n"))
+			}
+		}
+	}
+}
+
+func runBSDManagedVM(ctx context.Context, guestName string, vm *VM, platform *bootPlatform, serialOut *vmruntime.SerialTranscript) error {
+	for step := 0; ; step++ {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%w (%s)", err, platform.Summary())
+		}
+		if err := platform.armPendingIRQWindow(); err != nil {
+			return fmt.Errorf("arm pending irq window: %w", err)
+		}
+		var raw runVPExitContext
+		exit, err := vm.runWithCancel(ctx, &raw)
+		if err != nil {
+			if ctx.Err() != nil {
+				return fmt.Errorf("%w (%s)", ctx.Err(), platform.Summary())
+			}
+			return fmt.Errorf("run step %d: %w", step, err)
+		}
+		platform.recordExit(exit, &raw)
+		switch exit.Reason {
+		case runVPExitReasonX64IoPortAccess:
+			if err := vm.emulateIO(&raw); err != nil {
+				io := raw.ioPortAccess()
+				return fmt.Errorf("emulate io at rip=%#x port=%#x: %w\nserial:\n%s", exit.RIP, io.Port, err, serialOut.String())
+			}
+		case runVPExitReasonMemoryAccess:
+			if err := vm.emulateMMIO(&raw); err != nil {
+				if handled, skipErr := skipNoopMMIOCacheFlush(vm, exit, raw.memoryAccess()); handled {
+					if skipErr != nil {
+						return skipErr
+					}
+					break
+				}
+				mem := raw.memoryAccess()
+				return fmt.Errorf("emulate mmio at rip=%#x gpa=%#x gva=%#x access=%d insn_len=%d insn=% x: %w\nserial:\n%s", exit.RIP, uint64(mem.GPA), mem.GVA, mem.AccessInfo.accessType(), mem.InstructionByteCount, mem.InstructionBytes[:mem.InstructionByteCount], err, serialOut.String())
+			}
+		case runVPExitReasonX64Halt:
+			if !platform.hasPendingIRQ() {
+				return fmt.Errorf("%s guest halted\nserial:\n%s\n%s", guestName, serialOut.String(), platform.Summary())
+			}
+		case runVPExitReasonX64ApicEoi:
+			platform.HandleEOI(raw.apicEoi().InterruptVector)
+		case runVPExitReasonX64MsrAccess:
+			if err := handleMSRAccess(vm, exit, &raw); err != nil {
+				return fmt.Errorf("handle msr at rip=%#x: %w\nserial:\n%s", exit.RIP, err, serialOut.String())
+			}
+		case runVPExitReasonX64InterruptWindow:
+		case runVPExitReasonCanceled:
+		default:
+			return fmt.Errorf("unexpected exit %s at rip=%#x\nserial:\n%s\n%s", exit.Reason, exit.RIP, serialOut.String(), platform.Summary())
+		}
+		if flushed, err := platform.flushPendingIRQ(&raw); err != nil {
+			return fmt.Errorf("flush pending irq after %s at rip=%#x: %w", exit.Reason, exit.RIP, err)
+		} else if exit.Reason == runVPExitReasonX64Halt && !flushed {
+			return fmt.Errorf("%s guest halted with pending irq blocked\nserial:\n%s\n%s", guestName, serialOut.String(), platform.Summary())
+		}
+	}
+}
+
+func handleMSRAccess(vm *VM, exit Exit, raw *runVPExitContext) error {
+	msr := raw.msrAccess()
+	nextRIP := exit.RIP + uint64(raw.instructionLength())
+	if raw.instructionLength() == 0 {
+		nextRIP = exit.RIP + 2
+	}
+	if msr.AccessInfo.isWrite() {
+		return vm.SetRIP(nextRIP)
+	}
+	value := readMSR(msr.MSRNumber)
+	return vm.SetRegisters(map[registerName]uint64{
+		registerRax: value & 0xffffffff,
+		registerRdx: value >> 32,
+		registerRip: nextRIP,
+	})
+}
+
+func readMSR(msr uint32) uint64 {
+	switch msr {
+	case 0x10:
+		return uint64(time.Since(processStart).Nanoseconds())
+	case 0xce:
+		return 0
+	case 0xe7, 0xe8:
+		return 0
+	case 0x1a0:
+		return 0
+	default:
+		return 0
+	}
+}
+
+func skipNoopMMIOCacheFlush(vm *VM, exit Exit, mem *memoryAccessContext) (bool, error) {
+	if mem == nil || mem.InstructionByteCount < 3 {
+		return false, nil
+	}
+	insn := mem.InstructionBytes[:mem.InstructionByteCount]
+	i := 0
+	for i < len(insn) {
+		switch insn[i] {
+		case 0x66, 0xf2, 0xf3:
+			i++
+		case 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f:
+			i++
+		default:
+			goto prefixesDone
+		}
+	}
+prefixesDone:
+	if i+2 > len(insn) || insn[i] != 0x0f || insn[i+1] != 0xae {
+		return false, nil
+	}
+	if i+2 >= len(insn) {
+		return false, nil
+	}
+	modrm := insn[i+2]
+	reg := (modrm >> 3) & 0x7
+	if reg != 7 {
+		return false, nil
+	}
+	length := i + 3
+	mod := modrm >> 6
+	rm := modrm & 0x7
+	if mod != 3 && rm == 4 {
+		if length >= len(insn) {
+			return false, nil
+		}
+		sib := insn[length]
+		length++
+		base := sib & 0x7
+		if mod == 0 && base == 5 {
+			length += 4
+		}
+	} else if mod == 0 && rm == 5 {
+		length += 4
+	}
+	switch mod {
+	case 1:
+		length++
+	case 2:
+		length += 4
+	}
+	if length <= 0 || length > int(mem.InstructionByteCount) {
+		return false, nil
+	}
+	if err := vm.SetRIP(exit.RIP + uint64(length)); err != nil {
+		return true, fmt.Errorf("skip MMIO cache flush at rip=%#x: %w", exit.RIP, err)
+	}
+	return true, nil
+}
+
+func bsdStartupError(err error, serialText, controlText string) error {
+	return transcriptError(err, serialText, controlText)
+}

--- a/internal/hv/whp/bsd_session_windows_amd64.go
+++ b/internal/hv/whp/bsd_session_windows_amd64.go
@@ -423,7 +423,6 @@ func attachBSDPCDevices(platform *bootPlatform, root virtio.BlockBackend, extraB
 func answerOpenBSDPrompts(ctx context.Context, uart *serial.UART8250, serialOut *vmruntime.SerialTranscript) {
 	var answeredRoot atomic.Bool
 	var answeredSwap atomic.Bool
-	var fallbackDeadline time.Time
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -432,9 +431,6 @@ func answerOpenBSDPrompts(ctx context.Context, uart *serial.UART8250, serialOut 
 			return
 		case <-ticker.C:
 			serial := serialOut.String()
-			if fallbackDeadline.IsZero() && strings.Contains(serial, "sd0: ") {
-				fallbackDeadline = time.Now().Add(time.Second)
-			}
 			if !answeredRoot.Load() && strings.Contains(serial, "root device:") {
 				answeredRoot.Store(true)
 				_ = uart.InjectRXBytes([]byte("sd0a\n"))
@@ -442,11 +438,6 @@ func answerOpenBSDPrompts(ctx context.Context, uart *serial.UART8250, serialOut 
 			if answeredRoot.Load() && !answeredSwap.Load() && strings.Contains(serial, "swap device") {
 				answeredSwap.Store(true)
 				_ = uart.InjectRXBytes([]byte("\n"))
-			}
-			if !fallbackDeadline.IsZero() && time.Now().After(fallbackDeadline) && !answeredRoot.Load() {
-				answeredRoot.Store(true)
-				answeredSwap.Store(true)
-				_ = uart.InjectRXBytes([]byte("sd0a\n\n"))
 			}
 		}
 	}

--- a/internal/hv/whp/exec_windows_amd64.go
+++ b/internal/hv/whp/exec_windows_amd64.go
@@ -251,6 +251,10 @@ func runManagedExecVM(ctx context.Context, vm *VM, platform *bootPlatform, seria
 			}
 		case runVPExitReasonX64ApicEoi:
 			platform.HandleEOI(raw.apicEoi().InterruptVector)
+		case runVPExitReasonX64MsrAccess:
+			if err := handleMSRAccess(vm, exit, &raw); err != nil {
+				return fmt.Errorf("handle msr at rip=%#x: %w", exit.RIP, err)
+			}
 		case runVPExitReasonX64InterruptWindow:
 		case runVPExitReasonCanceled:
 		default:

--- a/internal/hv/whp/host_windows_amd64.go
+++ b/internal/hv/whp/host_windows_amd64.go
@@ -5,12 +5,14 @@ package whp
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"j5.nz/cc/client"
 	managedhost "j5.nz/cc/internal/managed/host"
 	"j5.nz/cc/internal/managed/machine"
 	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/netstack"
 	"j5.nz/cc/internal/virtio"
 )
 
@@ -29,10 +31,70 @@ type LinuxManagedAttachments struct {
 	NetDevice *virtio.Net
 }
 
+type BSDManagedAttachments struct {
+	GuestIPv4 net.IP
+	GuestMAC  net.HardwareAddr
+	NetDevice *virtio.Net
+	NetStack  *netstack.NetStack
+}
+
 func (Host) Start(ctx context.Context, req managedhost.StartRequest, onEvent func(client.BootEvent) error) (managedsession.Session, error) {
-	if managedGuestKind(req.Spec) != "linux" {
+	switch managedGuestKind(req.Spec) {
+	case "linux":
+		return Host{}.startLinux(ctx, req, onEvent)
+	case "openbsd":
+		attachments, err := bsdManagedAttachments(req.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		return StartOpenBSDManagedSession(ctx, OpenBSDManagedConfig{
+			Kernel:    req.Artifact.Kernel,
+			Root:      req.Artifact.RootBlock,
+			MemoryMB:  req.Spec.MemoryMB,
+			Dmesg:     req.Spec.Dmesg,
+			GuestIPv4: attachments.GuestIPv4,
+			GuestMAC:  attachments.GuestMAC,
+			NetDevice: attachments.NetDevice,
+			NetStack:  attachments.NetStack,
+		}, onEvent)
+	case "freebsd":
+		attachments, err := bsdManagedAttachments(req.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		return StartFreeBSDManagedSession(ctx, FreeBSDManagedConfig{
+			Kernel:      req.Artifact.Kernel,
+			Root:        req.Artifact.RootBlock,
+			ExtraBlocks: req.Artifact.ExtraBlocks,
+			MemoryMB:    req.Spec.MemoryMB,
+			Dmesg:       req.Spec.Dmesg,
+			GuestIPv4:   attachments.GuestIPv4,
+			GuestMAC:    attachments.GuestMAC,
+			NetDevice:   attachments.NetDevice,
+			NetStack:    attachments.NetStack,
+		}, onEvent)
+	case "netbsd":
+		attachments, err := bsdManagedAttachments(req.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		return StartNetBSDManagedSession(ctx, NetBSDManagedConfig{
+			Kernel:      req.Artifact.Kernel,
+			Root:        req.Artifact.RootBlock,
+			ExtraBlocks: req.Artifact.ExtraBlocks,
+			MemoryMB:    req.Spec.MemoryMB,
+			Dmesg:       req.Spec.Dmesg,
+			GuestIPv4:   attachments.GuestIPv4,
+			GuestMAC:    attachments.GuestMAC,
+			NetDevice:   attachments.NetDevice,
+			NetStack:    attachments.NetStack,
+		}, onEvent)
+	default:
 		return nil, fmt.Errorf("whp host does not support managed guest %q boot %q", req.Spec.Guest, req.Spec.Boot.Kind)
 	}
+}
+
+func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEvent func(client.BootEvent) error) (managedsession.Session, error) {
 	var attachments LinuxManagedAttachments
 	switch value := req.Attachments.(type) {
 	case nil:
@@ -84,6 +146,20 @@ func normalizeLinuxManagedMachine(machine LinuxManagedMachine) LinuxManagedMachi
 	return machine
 }
 
+func bsdManagedAttachments(value any) (BSDManagedAttachments, error) {
+	switch attachments := value.(type) {
+	case BSDManagedAttachments:
+		return attachments, nil
+	case *BSDManagedAttachments:
+		if attachments == nil {
+			return BSDManagedAttachments{}, fmt.Errorf("whp bsd managed attachments are nil")
+		}
+		return *attachments, nil
+	default:
+		return BSDManagedAttachments{}, fmt.Errorf("whp bsd managed attachments have type %T", value)
+	}
+}
+
 func managedGuestKind(spec machine.Spec) string {
 	guest := strings.ToLower(strings.TrimSpace(spec.Guest))
 	boot := strings.ToLower(strings.TrimSpace(spec.Boot.Kind))
@@ -98,6 +174,11 @@ func managedGuestKind(spec machine.Spec) string {
 	}
 	if guest == "linux" && boot == "linux" {
 		return "linux"
+	}
+	for _, bsd := range []string{"openbsd", "freebsd", "netbsd"} {
+		if guest == bsd || boot == bsd {
+			return bsd
+		}
 	}
 	return guest
 }

--- a/internal/hv/whp/host_windows_amd64_test.go
+++ b/internal/hv/whp/host_windows_amd64_test.go
@@ -28,12 +28,12 @@ func TestNormalizeLinuxManagedMachineDefaultsSpec(t *testing.T) {
 	}
 }
 
-func TestWHPHostRejectsUnsupportedManagedGuest(t *testing.T) {
+func TestWHPHostDispatchesBSDToAttachmentValidation(t *testing.T) {
 	_, err := (Host{}).Start(context.Background(), managedhost.StartRequest{
 		Spec: machine.Spec{Guest: "FreeBSD", Boot: machine.BootSpec{Kind: "freebsd"}},
 	}, nil)
-	if err == nil || !strings.Contains(err.Error(), "does not support") {
-		t.Fatalf("Start unsupported guest error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "whp bsd managed attachments") {
+		t.Fatalf("Start BSD attachment error = %v", err)
 	}
 }
 

--- a/internal/hv/whp/pc_io_windows_amd64.go
+++ b/internal/hv/whp/pc_io_windows_amd64.go
@@ -1,0 +1,246 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	i8042DataPort   = 0x60
+	i8042StatusPort = 0x64
+
+	i8042StatusOutputFull = 0x01
+
+	i8042CmdSelfTest     = 0xaa
+	i8042CmdTestKeyboard = 0xab
+
+	cmosIndexPort = 0x70
+	cmosDataPort  = 0x71
+
+	cmosRegSeconds  = 0x00
+	cmosRegMinutes  = 0x02
+	cmosRegHours    = 0x04
+	cmosRegWeekday  = 0x06
+	cmosRegMonthDay = 0x07
+	cmosRegMonth    = 0x08
+	cmosRegYear     = 0x09
+	cmosRegStatusA  = 0x0a
+	cmosRegStatusB  = 0x0b
+	cmosRegStatusD  = 0x0d
+	cmosRegCentury  = 0x32
+
+	acpiPM1EventPort   = 0x400
+	acpiPM1ControlPort = 0x404
+)
+
+type I8042 struct {
+	mu    sync.Mutex
+	queue []byte
+}
+
+func NewI8042() *I8042 {
+	return &I8042{}
+}
+
+func (c *I8042) ReadIO(port uint16, data []byte) (bool, error) {
+	if c == nil {
+		return false, nil
+	}
+	if port != i8042DataPort && port != i8042StatusPort {
+		return false, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var value byte
+	switch port {
+	case i8042DataPort:
+		if len(c.queue) != 0 {
+			value = c.queue[0]
+			copy(c.queue, c.queue[1:])
+			c.queue = c.queue[:len(c.queue)-1]
+		}
+	case i8042StatusPort:
+		if len(c.queue) != 0 {
+			value = i8042StatusOutputFull
+		}
+	}
+	for i := range data {
+		data[i] = value
+	}
+	return true, nil
+}
+
+func (c *I8042) WriteIO(port uint16, data []byte) (bool, error) {
+	if c == nil {
+		return false, nil
+	}
+	if port != i8042DataPort && port != i8042StatusPort {
+		return false, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if port == i8042StatusPort && len(data) != 0 {
+		switch data[0] {
+		case i8042CmdSelfTest:
+			c.queue = append(c.queue, 0xfc)
+		case i8042CmdTestKeyboard:
+			c.queue = append(c.queue, 0x00)
+		}
+	}
+	return true, nil
+}
+
+type CMOSRTC struct {
+	mu    sync.Mutex
+	index byte
+	now   func() time.Time
+}
+
+func NewCMOSRTC(now func() time.Time) *CMOSRTC {
+	if now == nil {
+		now = time.Now
+	}
+	return &CMOSRTC{now: now}
+}
+
+func (r *CMOSRTC) ReadIO(port uint16, data []byte) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+	if port != cmosIndexPort && port != cmosDataPort {
+		return false, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	value := r.index
+	if port == cmosDataPort {
+		value = r.readRegisterLocked(r.index)
+	}
+	for i := range data {
+		data[i] = value
+	}
+	return true, nil
+}
+
+func (r *CMOSRTC) WriteIO(port uint16, data []byte) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+	if port != cmosIndexPort && port != cmosDataPort {
+		return false, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if port == cmosIndexPort && len(data) != 0 {
+		r.index = data[0] & 0x7f
+	}
+	return true, nil
+}
+
+func (r *CMOSRTC) readRegisterLocked(reg byte) byte {
+	now := r.now().UTC()
+	switch reg {
+	case cmosRegSeconds:
+		return bcdByte(now.Second())
+	case cmosRegMinutes:
+		return bcdByte(now.Minute())
+	case cmosRegHours:
+		return bcdByte(now.Hour())
+	case cmosRegWeekday:
+		return bcdByte(int(now.Weekday()) + 1)
+	case cmosRegMonthDay:
+		return bcdByte(now.Day())
+	case cmosRegMonth:
+		return bcdByte(int(now.Month()))
+	case cmosRegYear:
+		return bcdByte(now.Year() % 100)
+	case cmosRegStatusA:
+		return 0x26
+	case cmosRegStatusB:
+		return 0x02
+	case cmosRegStatusD:
+		return 0x80
+	case cmosRegCentury:
+		return bcdByte(now.Year() / 100)
+	default:
+		return 0
+	}
+}
+
+func bcdByte(value int) byte {
+	if value < 0 {
+		value = 0
+	}
+	return byte((value/10)<<4 | (value % 10))
+}
+
+type ACPIPM struct {
+	mu      sync.Mutex
+	status  uint16
+	enable  uint16
+	control uint16
+}
+
+func NewACPIPM() *ACPIPM {
+	return &ACPIPM{}
+}
+
+func (p *ACPIPM) ReadIO(port uint16, data []byte) (bool, error) {
+	if p == nil {
+		return false, nil
+	}
+	if port < acpiPM1EventPort || port >= acpiPM1ControlPort+2 {
+		return false, nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	value := uint16(0)
+	switch {
+	case port >= acpiPM1EventPort && port < acpiPM1EventPort+2:
+		value = p.status >> (8 * (port - acpiPM1EventPort))
+	case port >= acpiPM1EventPort+2 && port < acpiPM1EventPort+4:
+		value = p.enable >> (8 * (port - (acpiPM1EventPort + 2)))
+	case port >= acpiPM1ControlPort && port < acpiPM1ControlPort+2:
+		value = p.control >> (8 * (port - acpiPM1ControlPort))
+	}
+	for i := range data {
+		data[i] = byte(value >> (8 * i))
+	}
+	return true, nil
+}
+
+func (p *ACPIPM) WriteIO(port uint16, data []byte) (bool, error) {
+	if p == nil {
+		return false, nil
+	}
+	if port < acpiPM1EventPort || port >= acpiPM1ControlPort+2 {
+		return false, nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var value uint16
+	for i, b := range data {
+		value |= uint16(b) << (8 * i)
+	}
+	mask := uint16(0)
+	for i := range data {
+		mask |= uint16(0xff) << (8 * i)
+	}
+	switch {
+	case port >= acpiPM1EventPort && port < acpiPM1EventPort+2:
+		shift := 8 * (port - acpiPM1EventPort)
+		shiftedMask := mask << shift
+		p.status &^= (value << shift) & shiftedMask
+	case port >= acpiPM1EventPort+2 && port < acpiPM1EventPort+4:
+		shift := 8 * (port - (acpiPM1EventPort + 2))
+		shiftedMask := mask << shift
+		p.enable = (p.enable &^ shiftedMask) | ((value << shift) & shiftedMask)
+	case port >= acpiPM1ControlPort && port < acpiPM1ControlPort+2:
+		shift := 8 * (port - acpiPM1ControlPort)
+		shiftedMask := mask << shift
+		p.control = (p.control &^ shiftedMask) | ((value << shift) & shiftedMask)
+	}
+	return true, nil
+}

--- a/internal/hv/whp/pci_windows_amd64.go
+++ b/internal/hv/whp/pci_windows_amd64.go
@@ -1,0 +1,317 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"encoding/binary"
+
+	"j5.nz/cc/internal/virtio"
+)
+
+const (
+	pciConfigAddressPort = 0xcf8
+	pciConfigDataPort    = 0xcfc
+	pciConfigType2Port   = 0xc000
+	pciConfigType2Size   = 0x1000
+
+	pciVendorQumranet = 0x1af4
+
+	pciVirtioNetDeviceID   = 0x1000
+	pciVirtioBlockDeviceID = 0x1001
+)
+
+type pciIOHandler interface {
+	ReadLegacy(offset uint16, size int) (uint64, error)
+	WriteLegacy(offset uint16, size int, value uint64) error
+}
+
+type PCIBus struct {
+	configAddress      uint32
+	configType2Enable  uint8
+	configType2Forward uint8
+	devices            []*PCIDevice
+}
+
+type PCIDevice struct {
+	Bus           uint8
+	Device        uint8
+	Function      uint8
+	VendorID      uint16
+	DeviceID      uint16
+	SubsystemID   uint16
+	Class         uint8
+	Subclass      uint8
+	ProgIF        uint8
+	Revision      uint8
+	IRQLine       uint8
+	IRQPin        uint8
+	IOBAR         uint32
+	IOSize        uint32
+	Command       uint16
+	legacyIO      pciIOHandler
+	barProbeValue bool
+}
+
+func NewPCIBus(devices ...*PCIDevice) *PCIBus {
+	return &PCIBus{devices: devices}
+}
+
+func NewVirtioBlockPCIDevice(dev uint8, ioBase uint16, irq uint8, block *virtio.Block) *PCIDevice {
+	if block != nil {
+		block.IRQ = uint32(irq)
+	}
+	return &PCIDevice{
+		Device:      dev,
+		VendorID:    pciVendorQumranet,
+		DeviceID:    pciVirtioBlockDeviceID,
+		SubsystemID: 2,
+		Class:       0x01,
+		Subclass:    0x80,
+		IRQLine:     irq,
+		IRQPin:      1,
+		IOBAR:       uint32(ioBase),
+		IOSize:      0x100,
+		legacyIO:    block,
+	}
+}
+
+func NewVirtioNetPCIDevice(dev uint8, ioBase uint16, irq uint8, netdev *virtio.Net) *PCIDevice {
+	if netdev != nil {
+		netdev.IRQ = uint32(irq)
+	}
+	return &PCIDevice{
+		Device:      dev,
+		VendorID:    pciVendorQumranet,
+		DeviceID:    pciVirtioNetDeviceID,
+		SubsystemID: 1,
+		Class:       0x02,
+		Subclass:    0x00,
+		IRQLine:     irq,
+		IRQPin:      1,
+		IOBAR:       uint32(ioBase),
+		IOSize:      0x100,
+		legacyIO:    netdev,
+	}
+}
+
+func (b *PCIBus) ReadIO(port uint16, data []byte) (bool, error) {
+	return b.handleIO(port, data, false)
+}
+
+func (b *PCIBus) WriteIO(port uint16, data []byte) (bool, error) {
+	return b.handleIO(port, data, true)
+}
+
+func (b *PCIBus) handleIO(port uint16, data []byte, write bool) (bool, error) {
+	if b == nil {
+		return false, nil
+	}
+	if port == pciConfigAddressPort+2 && len(data) == 1 {
+		if write {
+			b.configType2Forward = data[0]
+		} else {
+			data[0] = b.configType2Forward
+		}
+		return true, nil
+	}
+	if port >= pciConfigAddressPort && port < pciConfigAddressPort+4 {
+		if port == pciConfigAddressPort && len(data) == 1 {
+			if write {
+				b.configType2Enable = data[0]
+			} else {
+				data[0] = b.configType2Enable
+			}
+			return true, nil
+		}
+		var cfgAddr [4]byte
+		binary.LittleEndian.PutUint32(cfgAddr[:], b.configAddress)
+		if write {
+			writePortBytes(cfgAddr[:], int(port-pciConfigAddressPort), data)
+			b.configAddress = binary.LittleEndian.Uint32(cfgAddr[:])
+		} else {
+			readPortBytes(data, cfgAddr[:], int(port-pciConfigAddressPort))
+		}
+		return true, nil
+	}
+	if port >= pciConfigDataPort && port < pciConfigDataPort+4 {
+		offset := uint8((b.configAddress & 0xfc) + uint32(port-pciConfigDataPort))
+		if write {
+			b.writeConfig(offset, data)
+		} else {
+			b.readConfig(offset, data)
+		}
+		return true, nil
+	}
+	if port >= pciConfigType2Port && port < pciConfigType2Port+pciConfigType2Size {
+		device := uint8((port >> 8) & 0x0f)
+		offset := uint8(port & 0xff)
+		function := uint8((b.configType2Enable >> 1) & 0x07)
+		bus := b.configType2Forward
+		if b.configType2Enable&0xf0 != 0xf0 {
+			for i := range data {
+				data[i] = 0xff
+			}
+			return true, nil
+		}
+		if write {
+			b.writeConfigAt(bus, device, function, offset, data)
+		} else {
+			b.readConfigAt(bus, device, function, offset, data)
+		}
+		return true, nil
+	}
+	for _, dev := range b.devices {
+		if dev == nil || dev.legacyIO == nil || dev.IOSize == 0 {
+			continue
+		}
+		if uint32(port) < dev.IOBAR || uint32(port)+uint32(len(data)) > dev.IOBAR+dev.IOSize {
+			continue
+		}
+		offset := uint16(uint32(port) - dev.IOBAR)
+		if write {
+			value := readLittleValue(data)
+			return true, dev.legacyIO.WriteLegacy(offset, len(data), value)
+		}
+		value, err := dev.legacyIO.ReadLegacy(offset, len(data))
+		if err != nil {
+			return true, err
+		}
+		writeLittleValue(data, value)
+		return true, nil
+	}
+	return false, nil
+}
+
+func (b *PCIBus) readConfig(offset uint8, dst []byte) {
+	b.readDeviceConfig(b.selectedDevice(), offset, dst)
+}
+
+func (b *PCIBus) readConfigAt(bus, device, function, offset uint8, dst []byte) {
+	b.readDeviceConfig(b.deviceAt(bus, device, function), offset, dst)
+}
+
+func (b *PCIBus) readDeviceConfig(dev *PCIDevice, offset uint8, dst []byte) {
+	for i := range dst {
+		dst[i] = 0xff
+	}
+	if dev == nil {
+		return
+	}
+	var cfg [256]byte
+	dev.buildConfig(cfg[:])
+	copy(dst, cfg[offset:])
+}
+
+func (b *PCIBus) writeConfig(offset uint8, src []byte) {
+	b.writeDeviceConfig(b.selectedDevice(), offset, src)
+}
+
+func (b *PCIBus) writeConfigAt(bus, device, function, offset uint8, src []byte) {
+	b.writeDeviceConfig(b.deviceAt(bus, device, function), offset, src)
+}
+
+func (b *PCIBus) writeDeviceConfig(dev *PCIDevice, offset uint8, src []byte) {
+	if dev == nil {
+		return
+	}
+	for i, value := range src {
+		dev.writeConfigByte(uint8(int(offset)+i), value)
+	}
+}
+
+func (b *PCIBus) selectedDevice() *PCIDevice {
+	if b.configAddress&(1<<31) == 0 {
+		return nil
+	}
+	bus := uint8((b.configAddress >> 16) & 0xff)
+	device := uint8((b.configAddress >> 11) & 0x1f)
+	function := uint8((b.configAddress >> 8) & 0x07)
+	return b.deviceAt(bus, device, function)
+}
+
+func (b *PCIBus) deviceAt(bus, device, function uint8) *PCIDevice {
+	for _, dev := range b.devices {
+		if dev != nil && dev.Bus == bus && dev.Device == device && dev.Function == function {
+			return dev
+		}
+	}
+	return nil
+}
+
+func (d *PCIDevice) buildConfig(cfg []byte) {
+	binary.LittleEndian.PutUint16(cfg[0x00:0x02], d.VendorID)
+	binary.LittleEndian.PutUint16(cfg[0x02:0x04], d.DeviceID)
+	binary.LittleEndian.PutUint16(cfg[0x04:0x06], d.Command)
+	cfg[0x08] = d.Revision
+	cfg[0x09] = d.ProgIF
+	cfg[0x0a] = d.Subclass
+	cfg[0x0b] = d.Class
+	cfg[0x0e] = 0
+	if d.barProbeValue {
+		binary.LittleEndian.PutUint32(cfg[0x10:0x14], ^(d.IOSize-1)|0x1)
+	} else {
+		binary.LittleEndian.PutUint32(cfg[0x10:0x14], d.IOBAR|0x1)
+	}
+	binary.LittleEndian.PutUint16(cfg[0x2c:0x2e], d.VendorID)
+	binary.LittleEndian.PutUint16(cfg[0x2e:0x30], d.SubsystemID)
+	cfg[0x3c] = d.IRQLine
+	cfg[0x3d] = d.IRQPin
+}
+
+func (d *PCIDevice) writeConfigByte(offset uint8, value byte) {
+	switch offset {
+	case 0x04:
+		d.Command = (d.Command & 0xff00) | uint16(value)
+	case 0x05:
+		d.Command = (d.Command & 0x00ff) | uint16(value)<<8
+	case 0x10, 0x11, 0x12, 0x13:
+		if value == 0xff {
+			d.barProbeValue = true
+			return
+		}
+		d.barProbeValue = false
+		switch offset {
+		case 0x10:
+			d.IOBAR = (d.IOBAR & 0xffffff00) | uint32(value&0xfc)
+		case 0x11:
+			d.IOBAR = (d.IOBAR & 0xffff00ff) | uint32(value)<<8
+		case 0x12:
+			d.IOBAR = (d.IOBAR & 0xff00ffff) | uint32(value)<<16
+		case 0x13:
+			d.IOBAR = (d.IOBAR & 0x00ffffff) | uint32(value)<<24
+		}
+	case 0x3c:
+		d.IRQLine = value
+	}
+}
+
+func readLittleValue(data []byte) uint64 {
+	var value uint64
+	for i, b := range data {
+		value |= uint64(b) << (8 * i)
+	}
+	return value
+}
+
+func writeLittleValue(data []byte, value uint64) {
+	for i := range data {
+		data[i] = byte(value >> (8 * i))
+	}
+}
+
+func readPortBytes(dst, src []byte, off int) {
+	if off < 0 || off >= len(src) {
+		for i := range dst {
+			dst[i] = 0xff
+		}
+		return
+	}
+	copy(dst, src[off:])
+}
+
+func writePortBytes(dst []byte, off int, src []byte) {
+	if off < 0 || off >= len(dst) {
+		return
+	}
+	copy(dst[off:], src)
+}

--- a/internal/hv/whp/platform_amd64_windows.go
+++ b/internal/hv/whp/platform_amd64_windows.go
@@ -559,11 +559,7 @@ func (a *bootIOAPIC) assert(line uint8, high bool) (bootIOAPICRoute, bool) {
 	if int(line) >= len(a.redir) {
 		return bootIOAPICRoute{}, false
 	}
-	asserted := high
-	if a.redir[line]&(1<<13) != 0 {
-		asserted = !high
-	}
-	if asserted {
+	if high {
 		edge := !a.lineHigh[line]
 		a.lineHigh[line] = true
 		return a.evaluateLocked(line, edge)

--- a/internal/hv/whp/platform_amd64_windows.go
+++ b/internal/hv/whp/platform_amd64_windows.go
@@ -94,15 +94,48 @@ func (p *bootPIC) Acknowledge(line uint8) (uint8, bool) {
 	chip := &p.master
 	irq := line
 	if line >= 8 {
+		if p.master.mask&(1<<2) != 0 {
+			p.slave.irr |= 1 << (line - 8)
+			return 0, false
+		}
 		chip = &p.slave
 		irq = line - 8
 	}
+	chip.irr |= 1 << irq
 	if chip.mask&(1<<irq) != 0 {
 		return 0, false
 	}
-	chip.irr |= 1 << irq
+	chip.irr &^= 1 << irq
 	chip.isr |= 1 << irq
+	if line >= 8 {
+		p.master.irr &^= 1 << 2
+		p.master.isr |= 1 << 2
+	}
 	return chip.vectorBase + irq, true
+}
+
+func (p *bootPIC) Clear(line uint8) {
+	if line >= 16 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	chip := &p.master
+	irq := line
+	if line >= 8 {
+		chip = &p.slave
+		irq = line - 8
+	}
+	chip.irr &^= 1 << irq
+}
+
+func (p *bootPIC) LevelTriggered(line uint8) bool {
+	if line >= 16 {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.elcr[line/8]&(1<<(line%8)) != 0
 }
 
 func (c *bootPICChip) writeCommand(value byte) {
@@ -489,6 +522,19 @@ func (a *bootIOAPIC) deviceHighRoute(line uint8) (bootIOAPICRoute, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if int(line) >= len(a.redir) || !a.lineHigh[line] {
+		return bootIOAPICRoute{}, false
+	}
+	return a.routeForLineLocked(line)
+}
+
+func (a *bootIOAPIC) routeForLine(line uint8) (bootIOAPICRoute, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.routeForLineLocked(line)
+}
+
+func (a *bootIOAPIC) routeForLineLocked(line uint8) (bootIOAPICRoute, bool) {
+	if int(line) >= len(a.redir) {
 		return bootIOAPICRoute{}, false
 	}
 	entry := a.redir[line]

--- a/internal/hv/whp/platform_amd64_windows.go
+++ b/internal/hv/whp/platform_amd64_windows.go
@@ -143,6 +143,7 @@ type bootPIT struct {
 	tickerStop chan struct{}
 	tickerWG   sync.WaitGroup
 	stop       chan struct{}
+	closed     bool
 	channels   [3]bootPITChannel
 	selected   uint8
 	port61     byte
@@ -168,6 +169,7 @@ type bootPITChannel struct {
 
 func (p *bootPIT) Close() {
 	p.mu.Lock()
+	p.closed = true
 	p.stopTickerLocked()
 	select {
 	case <-p.stop:
@@ -300,6 +302,9 @@ func (p *bootPIT) writePort61(value byte) {
 }
 
 func (p *bootPIT) armChannel0Locked() {
+	if p.closed {
+		return
+	}
 	p.stopTickerLocked()
 	reload := p.channels[0].reload
 	if reload == 0 {

--- a/internal/hv/whp/platform_amd64_windows.go
+++ b/internal/hv/whp/platform_amd64_windows.go
@@ -11,10 +11,11 @@ import (
 )
 
 type bootPIC struct {
-	mu     sync.Mutex
-	master bootPICChip
-	slave  bootPICChip
-	elcr   [2]byte
+	mu       sync.Mutex
+	master   bootPICChip
+	slave    bootPICChip
+	elcr     [2]byte
+	lineHigh [16]bool
 }
 
 type bootPICChip struct {
@@ -24,6 +25,7 @@ type bootPICChip struct {
 	ocw3       byte
 	irr        byte
 	isr        byte
+	lastIRR    byte
 }
 
 func (p *bootPIC) Read(port uint16, data []byte) bool {
@@ -85,33 +87,88 @@ func (p *bootPIC) Write(port uint16, data []byte) bool {
 	return true
 }
 
-func (p *bootPIC) Acknowledge(line uint8) (uint8, bool) {
+func (p *bootPIC) SetIRQ(line uint8, level bool) {
 	if line >= 16 {
-		return 0, false
+		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.lineHigh[line] = level
+	p.setLineLocked(line, level)
+}
+
+func (p *bootPIC) setLineLocked(line uint8, level bool) {
 	chip := &p.master
 	irq := line
 	if line >= 8 {
 		if p.master.mask&(1<<2) != 0 {
-			p.slave.irr |= 1 << (line - 8)
-			return 0, false
+			// Keep the slave line state; it will be visible once cascade unmasks.
+			chip = &p.slave
+			irq = line - 8
+		} else {
+			chip = &p.slave
+			irq = line - 8
 		}
-		chip = &p.slave
-		irq = line - 8
 	}
-	chip.irr |= 1 << irq
-	if chip.mask&(1<<irq) != 0 {
-		return 0, false
+	mask := byte(1 << irq)
+	levelTriggered := p.elcr[line/8]&mask != 0
+	if levelTriggered {
+		if level {
+			chip.irr |= mask
+			chip.lastIRR |= mask
+		} else {
+			chip.irr &^= mask
+			chip.lastIRR &^= mask
+		}
+		return
 	}
-	chip.irr &^= 1 << irq
-	chip.isr |= 1 << irq
-	if line >= 8 {
-		p.master.irr &^= 1 << 2
-		p.master.isr |= 1 << 2
+	if level {
+		if chip.lastIRR&mask == 0 {
+			chip.irr |= mask
+		}
+		chip.lastIRR |= mask
+	} else {
+		chip.lastIRR &^= mask
 	}
-	return chip.vectorBase + irq, true
+}
+
+func (p *bootPIC) AcknowledgePending() (uint8, uint8, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.slave.pendingIRQ() >= 0 {
+		p.master.irr |= 1 << 2
+	}
+	masterIRQ := p.master.pendingIRQ()
+	if masterIRQ < 0 {
+		return 0, 0, false
+	}
+	if masterIRQ == 2 {
+		slaveIRQ := p.slave.pendingIRQ()
+		if slaveIRQ >= 0 {
+			p.ackLocked(&p.master, 2, 2)
+			line := uint8(8 + slaveIRQ)
+			return p.ackLocked(&p.slave, uint8(slaveIRQ), line), line, true
+		}
+	}
+	line := uint8(masterIRQ)
+	return p.ackLocked(&p.master, line, line), line, true
+}
+
+func (p *bootPIC) ackLocked(chip *bootPICChip, irq uint8, line uint8) uint8 {
+	mask := byte(1 << irq)
+	chip.isr |= mask
+	if p.elcr[line/8]&mask == 0 {
+		chip.irr &^= mask
+	}
+	return chip.vectorBase + irq
+}
+
+func (p *bootPIC) Resample() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for line, high := range p.lineHigh {
+		p.setLineLocked(uint8(line), high)
+	}
 }
 
 func (p *bootPIC) Clear(line uint8) {
@@ -120,6 +177,7 @@ func (p *bootPIC) Clear(line uint8) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.lineHigh[line] = false
 	chip := &p.master
 	irq := line
 	if line >= 8 {
@@ -138,12 +196,26 @@ func (p *bootPIC) LevelTriggered(line uint8) bool {
 	return p.elcr[line/8]&(1<<(line%8)) != 0
 }
 
+func (c *bootPICChip) pendingIRQ() int {
+	pending := c.irr &^ c.mask
+	if pending == 0 {
+		return -1
+	}
+	for irq := 0; irq < 8; irq++ {
+		if pending&(1<<irq) != 0 {
+			return irq
+		}
+	}
+	return -1
+}
+
 func (c *bootPICChip) writeCommand(value byte) {
 	if value&0x10 != 0 {
 		c.icwStep = 2
 		c.mask = 0xff
 		c.irr = 0
 		c.isr = 0
+		c.lastIRR = 0
 		return
 	}
 	if value&0x20 != 0 {

--- a/internal/hv/whp/platform_amd64_windows_test.go
+++ b/internal/hv/whp/platform_amd64_windows_test.go
@@ -1,0 +1,51 @@
+//go:build windows && amd64
+
+package whp
+
+import "testing"
+
+func TestBootPICLevelLineResamplesUntilDeasserted(t *testing.T) {
+	var pic bootPIC
+	pic.master.vectorBase = 0x20
+	pic.slave.vectorBase = 0x28
+	pic.master.mask = 0xff
+	pic.slave.mask = 0xff
+	pic.master.mask &^= 1 << 2
+	pic.slave.mask &^= 1 << 2
+	pic.elcr[1] = 1 << 2
+
+	pic.SetIRQ(10, true)
+	vector, line, ok := pic.AcknowledgePending()
+	if !ok || vector != 0x2a || line != 10 {
+		t.Fatalf("first ack = vector %#x line %d ok %t, want vector 0x2a line 10", vector, line, ok)
+	}
+	vector, line, ok = pic.AcknowledgePending()
+	if !ok || vector != 0x2a || line != 10 {
+		t.Fatalf("level ack = vector %#x line %d ok %t, want vector 0x2a line 10", vector, line, ok)
+	}
+	pic.SetIRQ(10, false)
+	if vector, line, ok := pic.AcknowledgePending(); ok {
+		t.Fatalf("ack after deassert = vector %#x line %d ok %t, want no pending irq", vector, line, ok)
+	}
+}
+
+func TestBootPICEdgeLineRequiresNewRisingEdge(t *testing.T) {
+	var pic bootPIC
+	pic.master.vectorBase = 0x20
+	pic.master.mask = 0xfe
+
+	pic.SetIRQ(0, true)
+	vector, line, ok := pic.AcknowledgePending()
+	if !ok || vector != 0x20 || line != 0 {
+		t.Fatalf("first ack = vector %#x line %d ok %t, want vector 0x20 line 0", vector, line, ok)
+	}
+	if vector, line, ok := pic.AcknowledgePending(); ok {
+		t.Fatalf("second ack = vector %#x line %d ok %t, want no pending irq", vector, line, ok)
+	}
+	pic.SetIRQ(0, false)
+	pic.SetIRQ(0, true)
+	vector, line, ok = pic.AcknowledgePending()
+	if !ok || vector != 0x20 || line != 0 {
+		t.Fatalf("new edge ack = vector %#x line %d ok %t, want vector 0x20 line 0", vector, line, ok)
+	}
+}

--- a/internal/hv/whp/platform_amd64_windows_test.go
+++ b/internal/hv/whp/platform_amd64_windows_test.go
@@ -49,3 +49,25 @@ func TestBootPICEdgeLineRequiresNewRisingEdge(t *testing.T) {
 		t.Fatalf("new edge ack = vector %#x line %d ok %t, want vector 0x20 line 0", vector, line, ok)
 	}
 }
+
+func TestBootIOAPICActiveLowLevelLineUsesAssertedState(t *testing.T) {
+	var ioapic bootIOAPIC
+	ioapic.init()
+	ioapic.redir[12] = 0x62 | 1<<13 | 1<<15
+
+	route, pending := ioapic.assert(12, true)
+	if !pending {
+		t.Fatalf("assert active-low level line did not produce a pending route")
+	}
+	if route.line != 12 || route.vector != 0x62 || !route.level {
+		t.Fatalf("route = %+v, want line 12 vector 0x62 level", route)
+	}
+	if _, pending := ioapic.deviceHighRoute(12); !pending {
+		t.Fatalf("deviceHighRoute after assert = false, want true")
+	}
+
+	ioapic.assert(12, false)
+	if _, pending := ioapic.deviceHighRoute(12); pending {
+		t.Fatalf("deviceHighRoute after deassert = true, want false")
+	}
+}

--- a/internal/hv/whp/session_windows_amd64.go
+++ b/internal/hv/whp/session_windows_amd64.go
@@ -40,6 +40,9 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 }
 
 func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
+		return nil, err
+	}
 	backend := virtio.NewSimpleVsockBackend()
 	listener, err := backend.Listen(vmruntime.ControlPort)
 	if err != nil {
@@ -138,6 +141,16 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 			_ = bootWriter.Close()
 		}
 		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
 	}
 
 	return &ManagedSession{

--- a/internal/hv/whp/session_windows_amd64.go
+++ b/internal/hv/whp/session_windows_amd64.go
@@ -23,8 +23,8 @@ import (
 type ManagedSession struct {
 	cancel     context.CancelFunc
 	doneCh     chan error
-	control    virtio.VsockConn
-	listener   virtio.VsockListener
+	control    io.ReadWriteCloser
+	listener   io.Closer
 	vsock      *virtio.Vsock
 	bootWriter *vmruntime.BootEventWriter
 	transcript *vmruntime.SerialTranscript

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -33,10 +33,25 @@ type Exit struct {
 func Supports() error {
 	present, err := isHypervisorPresent()
 	if err != nil {
-		return fmt.Errorf("whp unavailable: query hypervisor presence: %w", err)
+		if probeErr := probePartitionSupport(); probeErr == nil {
+			return nil
+		} else {
+			return fmt.Errorf("whp unavailable: query hypervisor presence: %w; partition probe: %w", err, probeErr)
+		}
 	}
 	if !present {
 		return fmt.Errorf("whp unavailable: hypervisor not present")
+	}
+	return nil
+}
+
+func probePartitionSupport() error {
+	part, err := createPartition()
+	if err != nil {
+		return fmt.Errorf("create partition: %w", err)
+	}
+	if err := deletePartition(part); err != nil {
+		return fmt.Errorf("delete partition: %w", err)
 	}
 	return nil
 }

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -77,6 +77,10 @@ func newVM(memorySize uint64, localAPIC bool) (*VM, error) {
 		_ = vm.Close()
 		return nil, fmt.Errorf("set processor count: %w", err)
 	}
+	if err := setPartitionProperty(part, partitionPropertyCodeExtendedVMExits, uint64(1<<1)); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("set extended VM exits: %w", err)
+	}
 	if localAPIC {
 		if err := setPartitionProperty(part, partitionPropertyCodeLocalAPICEmulationMode, localAPICEmulationModeXAPIC); err != nil {
 			_ = vm.Close()
@@ -217,6 +221,54 @@ func (v *VM) SetFlatProtectedMode(entry uint64) error {
 	return nil
 }
 
+func (v *VM) SetProtectedMode32(entry, stack uint64) error {
+	const (
+		cr0PE = 1 << 0
+		cr0MP = 1 << 1
+		cr0ET = 1 << 4
+		cr0NE = 1 << 5
+		cr0PG = 1 << 31
+	)
+	code := x64SegmentRegister{Base: 0, Limit: 0xffffffff, Selector: 0x10, Attributes: segmentAttributes(11, 1, 0, 1, 0, 0, 1, 1)}
+	data := x64SegmentRegister{Base: 0, Limit: 0xffffffff, Selector: 0x18, Attributes: segmentAttributes(3, 1, 0, 1, 0, 0, 1, 1)}
+	names := []registerName{
+		registerCr0,
+		registerCr3,
+		registerCr4,
+		registerEfer,
+		registerCs,
+		registerDs,
+		registerEs,
+		registerFs,
+		registerGs,
+		registerSs,
+		registerRip,
+		registerRsp,
+		registerRflags,
+	}
+	values := make([]registerValue, len(names))
+	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+		return fmt.Errorf("get protected-mode registers: %w", err)
+	}
+	values[0] = uint64RegisterValue((values[0].uint64() | cr0PE | cr0MP | cr0ET | cr0NE) &^ uint64(cr0PG))
+	values[1] = uint64RegisterValue(0)
+	values[2] = uint64RegisterValue(0)
+	values[3] = uint64RegisterValue(0)
+	values[4] = segmentRegisterValue(code)
+	values[5] = segmentRegisterValue(data)
+	values[6] = segmentRegisterValue(data)
+	values[7] = segmentRegisterValue(data)
+	values[8] = segmentRegisterValue(data)
+	values[9] = segmentRegisterValue(data)
+	values[10] = uint64RegisterValue(entry)
+	values[11] = uint64RegisterValue(stack)
+	values[12] = uint64RegisterValue(0x2)
+	if err := setVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+		return fmt.Errorf("set protected-mode registers: %w", err)
+	}
+	return nil
+}
+
 func (v *VM) SetLongMode(entry, zeroPage, stack, pagingBase uint64) error {
 	if err := v.setupPageTables(pagingBase, 4); err != nil {
 		return err
@@ -275,6 +327,62 @@ func (v *VM) SetLongMode(entry, zeroPage, stack, pagingBase uint64) error {
 	return nil
 }
 
+func (v *VM) SetFreeBSDLongMode(entry, stack, pagingBase uint64) error {
+	if err := v.setupFreeBSDPageTables(pagingBase, 4); err != nil {
+		return err
+	}
+	const (
+		cr0PE   = 1 << 0
+		cr0MP   = 1 << 1
+		cr0ET   = 1 << 4
+		cr0NE   = 1 << 5
+		cr0WP   = 1 << 16
+		cr0AM   = 1 << 18
+		cr0PG   = 1 << 31
+		cr4PAE  = 1 << 5
+		eferLME = 1 << 8
+		eferLMA = 1 << 10
+	)
+	code := x64SegmentRegister{Base: 0, Limit: 0xffffffff, Selector: 0x8, Attributes: segmentAttributes(11, 1, 0, 1, 0, 1, 0, 1)}
+	data := x64SegmentRegister{Base: 0, Limit: 0xffffffff, Selector: 0x10, Attributes: segmentAttributes(3, 1, 0, 1, 0, 0, 1, 1)}
+	names := []registerName{
+		registerCr3,
+		registerCr4,
+		registerCr0,
+		registerEfer,
+		registerCs,
+		registerDs,
+		registerEs,
+		registerFs,
+		registerGs,
+		registerSs,
+		registerRip,
+		registerRsp,
+		registerRflags,
+	}
+	values := make([]registerValue, len(names))
+	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+		return fmt.Errorf("get FreeBSD long-mode registers: %w", err)
+	}
+	values[0] = uint64RegisterValue(pagingBase)
+	values[1] = uint64RegisterValue(values[1].uint64() | cr4PAE)
+	values[2] = uint64RegisterValue(values[2].uint64() | cr0PE | cr0MP | cr0ET | cr0NE | cr0WP | cr0AM | cr0PG)
+	values[3] = uint64RegisterValue(values[3].uint64() | eferLME | eferLMA)
+	values[4] = segmentRegisterValue(code)
+	values[5] = segmentRegisterValue(data)
+	values[6] = segmentRegisterValue(data)
+	values[7] = segmentRegisterValue(data)
+	values[8] = segmentRegisterValue(data)
+	values[9] = segmentRegisterValue(data)
+	values[10] = uint64RegisterValue(entry)
+	values[11] = uint64RegisterValue(stack)
+	values[12] = uint64RegisterValue(0x2)
+	if err := setVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+		return fmt.Errorf("set FreeBSD long-mode registers: %w", err)
+	}
+	return nil
+}
+
 func (v *VM) setupPageTables(pagingBase uint64, giB int) error {
 	needed := pagingBase + uint64(0x3000+giB*0x1000)
 	if needed > v.memSize {
@@ -304,6 +412,34 @@ func (v *VM) setupPageTables(pagingBase uint64, giB int) error {
 			phys := (uint64(g) << 30) | (uint64(i) << 21)
 			put64(pd+uint64(i)*8, phys|p|rw|us|ps)
 		}
+	}
+	return nil
+}
+
+func (v *VM) setupFreeBSDPageTables(pagingBase uint64, giB int) error {
+	_ = giB
+	needed := pagingBase + 0x3000
+	if needed > v.memSize {
+		return fmt.Errorf("paging structures require %#x bytes, memory size %#x", needed, v.memSize)
+	}
+	mem := v.Memory()
+	put64 := func(addr, value uint64) {
+		binary.LittleEndian.PutUint64(mem[addr:addr+8], value)
+	}
+	pml4 := pagingBase
+	pdpt := pagingBase + 0x1000
+	pd := pagingBase + 0x2000
+	const (
+		p  = 1 << 0
+		rw = 1 << 1
+		us = 1 << 2
+		ps = 1 << 7
+	)
+	for i := 0; i < 512; i++ {
+		put64(pml4+uint64(i)*8, pdpt|p|rw|us)
+		put64(pdpt+uint64(i)*8, pd|p|rw|us)
+		phys := uint64(i) << 21
+		put64(pd+uint64(i)*8, phys|p|rw|us|ps)
 	}
 	return nil
 }
@@ -352,6 +488,22 @@ func (v *VM) GetRIP() (uint64, error) {
 		return 0, err
 	}
 	return values[0].uint64(), nil
+}
+
+func (v *VM) SetRIP(rip uint64) error {
+	names := []registerName{registerRip}
+	values := []registerValue{uint64RegisterValue(rip)}
+	return setVirtualProcessorRegisters(v.part, 0, names, values)
+}
+
+func (v *VM) SetRegisters(values map[registerName]uint64) error {
+	names := make([]registerName, 0, len(values))
+	regs := make([]registerValue, 0, len(values))
+	for name, value := range values {
+		names = append(names, name)
+		regs = append(regs, uint64RegisterValue(value))
+	}
+	return setVirtualProcessorRegisters(v.part, 0, names, regs)
 }
 
 func (v *VM) RequestInterrupt(vector uint32) error {

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -535,6 +535,36 @@ func (v *VM) SetPendingInterruption(vector uint8) error {
 	return setVirtualProcessorRegisters(v.part, 0, names, values)
 }
 
+func (v *VM) haltedAndInterruptible(vector uint8) (bool, error) {
+	if v == nil || v.part == 0 {
+		return false, nil
+	}
+	names := []registerName{
+		registerRflags,
+		registerPendingInterruption,
+		registerInternalActivityState,
+	}
+	values := make([]registerValue, len(names))
+	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+		return false, err
+	}
+	const (
+		rflagsInterruptEnable = uint64(1 << 9)
+		haltSuspend           = uint64(1 << 1)
+	)
+	if values[0].uint64()&rflagsInterruptEnable == 0 {
+		return false, nil
+	}
+	if values[1].uint64() != 0 {
+		return false, nil
+	}
+	if values[2].uint64()&haltSuspend == 0 {
+		return false, nil
+	}
+	priority := vector >> 4
+	return priority != 0, nil
+}
+
 func (v *VM) kickOutOfHLT() error {
 	if v == nil || v.part == 0 {
 		return nil

--- a/internal/netbsd/guestinit/guestinit_test.go
+++ b/internal/netbsd/guestinit/guestinit_test.go
@@ -12,11 +12,11 @@ func TestBuildFindsModuleFromSourceLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		if err := os.Chdir(wd); err != nil {
 			t.Errorf("restore cwd: %v", err)
 		}
-	})
+	}()
 
 	otherModule := t.TempDir()
 	if err := os.WriteFile(filepath.Join(otherModule, "go.mod"), []byte("module example.invalid/other\n"), 0o644); err != nil {

--- a/internal/netbsd/rootfs/rootfs.go
+++ b/internal/netbsd/rootfs/rootfs.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	BuiltInImageName = managedguest.NetBSDImageName
-	defaultVersion   = "10.1"
-	defaultArch      = "amd64"
-	defaultMirror    = "https://mirror.aarnet.edu.au/pub/netbsd"
+	BuiltInImageName  = managedguest.NetBSDImageName
+	defaultVersion    = "10.1"
+	defaultArch       = "amd64"
+	defaultMirror     = "https://mirror.aarnet.edu.au/pub/netbsd"
+	defaultGatewayMAC = "02:42:0a:2a:00:01"
 )
 
 type Config struct {
@@ -172,7 +173,7 @@ func buildManagedRootFromBase(root imagefs.Directory, closeRoot func() error, in
 	}
 	overlay := imagefs.NewOverlay(root)
 	if err := rootplan.AddFiles(overlay, []rootplan.File{
-		{"/sbin/init", 0o755, []byte(fmt.Sprintf(managedInitScript, network.Interface, network.GuestIPv4, network.GatewayIPv4))},
+		{"/sbin/init", 0o755, []byte(fmt.Sprintf(managedInitScript, network.Interface, network.GuestIPv4, network.GatewayIPv4, network.GatewayMAC, network.GatewayIPv4))},
 		{"/sbin/cc-netbsd-init", 0o755, initBin},
 		{"/etc/fstab", 0o644, []byte(fmt.Sprintf("/dev/%s / ffs rw 1 1\n", rootDevice))},
 		{"/etc/rc.conf", 0o644, []byte(fmt.Sprintf("rc_configured=YES\nhostname=\"%s\"\ndefaultroute=\"%s\"\n", network.Hostname, network.GatewayIPv4))},
@@ -291,6 +292,9 @@ func normalizeNetBSDNetwork(network machine.NetworkSpec) machine.NetworkSpec {
 	}
 	if strings.TrimSpace(network.GatewayIPv4) == "" {
 		network.GatewayIPv4 = "10.42.0.1"
+	}
+	if strings.TrimSpace(network.GatewayMAC) == "" {
+		network.GatewayMAC = defaultGatewayMAC
 	}
 	if strings.TrimSpace(network.DNSIPv4) == "" {
 		network.DNSIPv4 = network.GatewayIPv4
@@ -446,6 +450,7 @@ exec >/dev/console 2>&1
 	echo NETBSD_MANAGED_IFCONFIG_FAILED
 	while :; do /bin/sleep 3600; done
 }
+/usr/sbin/arp -s %s %s >/dev/null 2>&1 || true
 /sbin/route add default %s || true
 exec /sbin/cc-netbsd-init
 `

--- a/internal/netbsd/rootfs/rootfs_test.go
+++ b/internal/netbsd/rootfs/rootfs_test.go
@@ -62,10 +62,11 @@ func TestBuildManagedRootFromNetBSDBaseSet(t *testing.T) {
 		{name: "dev", mode: 0o755, dir: true},
 		{name: "root", mode: 0o700, dir: true},
 	})
-	root, err := BuildManagedRoot(context.Background(), baseTXZ, []byte("#!/bin/sh\necho test init\n"))
+	root, closeRoot, err := buildManagedRoot(context.Background(), baseTXZ, []byte("#!/bin/sh\necho test init\n"), defaultArch, machine.NetworkSpec{}, "ld0a")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer closeRoot()
 	baseTar := strings.TrimSuffix(baseTXZ, filepath.Ext(baseTXZ)) + ".tar"
 	if st, err := os.Stat(baseTar); err != nil || st.Size() == 0 {
 		t.Fatalf("decompressed base tar was not cached: stat=%v err=%v", st, err)

--- a/internal/netbsd/rootfs/rootfs_test.go
+++ b/internal/netbsd/rootfs/rootfs_test.go
@@ -121,6 +121,9 @@ func TestBuildManagedRootFromNetBSDBaseSetUsesNetworkSpec(t *testing.T) {
 	if !strings.Contains(initScript, "route add default 10.42.0.9") {
 		t.Fatalf("init script does not configure gateway: %q", initScript)
 	}
+	if !strings.Contains(initScript, "arp -s 10.42.0.9 02:42:0a:2a:00:01") {
+		t.Fatalf("init script does not configure gateway arp: %q", initScript)
+	}
 	ifconfig := readRootFile(t, root, "/etc/ifconfig.vioif1")
 	if !strings.Contains(ifconfig, "inet 10.42.0.8 netmask 255.255.255.0") {
 		t.Fatalf("ifconfig file does not contain leased IP: %q", ifconfig)

--- a/internal/openbsd/guestinit/guestinit.go
+++ b/internal/openbsd/guestinit/guestinit.go
@@ -27,12 +27,15 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create guest init cache: %w", err)
 	}
+	out := filepath.Join(cacheDir, "guest-init-openbsd-"+arch)
+	if data, err := os.ReadFile(out); err == nil && len(data) != 0 {
+		return data, nil
+	}
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		return nil, fmt.Errorf("locate OpenBSD guest init package")
 	}
 	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
-	out := filepath.Join(cacheDir, "guest-init-openbsd-"+arch)
 	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", out, "./internal/cmd/openbsd-init")
 	cmd.Env = append(os.Environ(), "GOOS=openbsd", "GOARCH="+arch, "CGO_ENABLED=0")
 	cmd.Dir = moduleRoot

--- a/internal/openbsd/rootfs/rootfs_test.go
+++ b/internal/openbsd/rootfs/rootfs_test.go
@@ -42,10 +42,11 @@ func TestBuildManagedRootFromOpenBSDBaseSetCachesSeekableTar(t *testing.T) {
 		{name: "etc", mode: 0o755, dir: true},
 		{name: "dev", mode: 0o755, dir: true},
 	})
-	root, err := BuildManagedRoot(context.Background(), baseTGZ, []byte("#!/bin/sh\necho test init\n"))
+	root, closeRoot, err := buildManagedRoot(context.Background(), baseTGZ, []byte("#!/bin/sh\necho test init\n"), machine.NetworkSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer closeRoot()
 	baseTar := strings.TrimSuffix(baseTGZ, filepath.Ext(baseTGZ)) + ".tar"
 	if st, err := os.Stat(baseTar); err != nil || st.Size() == 0 {
 		t.Fatalf("decompressed base tar was not cached: stat=%v err=%v", st, err)

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -3083,7 +3083,7 @@ func (p *passthroughFS) GetAttr(nodeID uint64) (FuseAttr, int32) {
 	if err != nil {
 		return FuseAttr{}, errnoFromError(err)
 	}
-	return p.fileAttr(nodeID, info), 0
+	return p.fileAttr(nodeID, host, info), 0
 }
 
 func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, int32) {
@@ -3107,7 +3107,7 @@ func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, in
 		p.logf("lookup name=%q guest=%q host=%q", name, guestPath, host)
 	}
 	nodeID := p.ensureNode(guestPath)
-	return nodeID, p.fileAttr(nodeID, info), 0
+	return nodeID, p.fileAttr(nodeID, host, info), 0
 }
 
 func (p *passthroughFS) Mkdir(parent uint64, name string, mode uint32, uid uint32, gid uint32) (uint64, FuseAttr, int32) {
@@ -3141,7 +3141,7 @@ func (p *passthroughFS) Mkdir(parent uint64, name string, mode uint32, uid uint3
 		p.mu.Unlock()
 	}
 	nodeID := p.ensureNode(guestPath)
-	return nodeID, p.fileAttr(nodeID, info), 0
+	return nodeID, p.fileAttr(nodeID, host, info), 0
 }
 
 func (p *passthroughFS) Symlink(parent uint64, name string, target string, uid uint32, gid uint32) (uint64, FuseAttr, int32) {
@@ -3174,7 +3174,7 @@ func (p *passthroughFS) Symlink(parent uint64, name string, target string, uid u
 		p.mu.Unlock()
 	}
 	nodeID := p.ensureNode(guestPath)
-	return nodeID, p.fileAttr(nodeID, info), 0
+	return nodeID, p.fileAttr(nodeID, host, info), 0
 }
 
 func (p *passthroughFS) Link(nodeID uint64, newParent uint64, newName string) (uint64, FuseAttr, int32) {
@@ -3200,7 +3200,7 @@ func (p *passthroughFS) Link(nodeID uint64, newParent uint64, newName string) (u
 	}
 	guestPath := joinGuestChild(guestParent, rel)
 	newNodeID := p.ensureNode(guestPath)
-	return newNodeID, p.fileAttr(newNodeID, info), 0
+	return newNodeID, p.fileAttr(newNodeID, dst, info), 0
 }
 
 func (p *passthroughFS) Create(parent uint64, name string, flags uint32, mode uint32, uid uint32, gid uint32) (uint64, uint64, FuseAttr, int32) {
@@ -3239,7 +3239,7 @@ func (p *passthroughFS) Create(parent uint64, name string, flags uint32, mode ui
 	p.nextHandle++
 	p.handles[handle] = &passthroughHandle{nodeID: nodeID, file: file, append: flags&linuxOAPPEND != 0}
 	p.mu.Unlock()
-	return nodeID, handle, p.fileAttr(nodeID, info), 0
+	return nodeID, handle, p.fileAttr(nodeID, host, info), 0
 }
 
 func (p *passthroughFS) Open(nodeID uint64, flags uint32) (uint64, int32) {
@@ -3575,7 +3575,7 @@ func (p *passthroughFS) SetAttr(nodeID uint64, valid uint32, fh uint64, size uin
 	if err != nil {
 		return FuseAttr{}, errnoFromError(err)
 	}
-	return p.fileAttr(nodeID, info), 0
+	return p.fileAttr(nodeID, host, info), 0
 }
 
 func (p *passthroughFS) StatFS(_ uint64) (uint64, uint64, uint64, uint64, uint64, uint64, uint64, uint64, int32) {
@@ -3692,7 +3692,7 @@ func (p *passthroughFS) renameNodeGuestPath(oldPath, newPath string) {
 	}
 }
 
-func (p *passthroughFS) fileAttr(nodeID uint64, info os.FileInfo) FuseAttr {
+func (p *passthroughFS) fileAttr(nodeID uint64, hostPath string, info os.FileInfo) FuseAttr {
 	mode := goModeToLinux(info.Mode())
 	if mode&os.ModeType == 0 {
 		mode |= 0
@@ -3714,7 +3714,7 @@ func (p *passthroughFS) fileAttr(nodeID uint64, info os.FileInfo) FuseAttr {
 	attr.ATimeNsec = uint32(mod.Nanosecond())
 	attr.MTimeNsec = uint32(mod.Nanosecond())
 	attr.CTimeNsec = uint32(mod.Nanosecond())
-	enrichHostFileAttr(info, &attr)
+	enrichHostFileAttr(hostPath, info, &attr)
 	if p.mapOwner {
 		attr.UID = p.ownerUID
 		attr.GID = p.ownerGID

--- a/internal/virtio/hostfs_darwin.go
+++ b/internal/virtio/hostfs_darwin.go
@@ -18,7 +18,7 @@ func hostStatFS(root string) (uint64, uint64, uint64, uint64, uint64, uint64, ui
 	return st.Blocks, st.Bfree, st.Bavail, st.Files, st.Ffree, bsize, bsize, 255, 0
 }
 
-func enrichHostFileAttr(info os.FileInfo, attr *FuseAttr) {
+func enrichHostFileAttr(_ string, info os.FileInfo, attr *FuseAttr) {
 	st, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return

--- a/internal/virtio/hostfs_linux.go
+++ b/internal/virtio/hostfs_linux.go
@@ -17,7 +17,7 @@ func hostStatFS(root string) (uint64, uint64, uint64, uint64, uint64, uint64, ui
 	return st.Blocks, st.Bfree, st.Bavail, st.Files, st.Ffree, uint64(st.Bsize), uint64(st.Bsize), 255, 0
 }
 
-func enrichHostFileAttr(info os.FileInfo, attr *FuseAttr) {
+func enrichHostFileAttr(_ string, info os.FileInfo, attr *FuseAttr) {
 	st, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return

--- a/internal/virtio/hostfs_windows.go
+++ b/internal/virtio/hostfs_windows.go
@@ -28,7 +28,23 @@ func hostStatFS(root string) (uint64, uint64, uint64, uint64, uint64, uint64, ui
 	return total / blockSize, free / blockSize, freeAvail / blockSize, 0, 0, blockSize, blockSize, 255, 0
 }
 
-func enrichHostFileAttr(_ os.FileInfo, _ *FuseAttr) {
+func enrichHostFileAttr(hostPath string, info os.FileInfo, attr *FuseAttr) {
+	if info == nil || info.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+	file, err := os.Open(hostPath)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	var handleInfo windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &handleInfo); err != nil {
+		return
+	}
+	attr.Ino = uint64(handleInfo.FileIndexHigh)<<32 | uint64(handleInfo.FileIndexLow)
+	if handleInfo.NumberOfLinks != 0 {
+		attr.NLink = handleInfo.NumberOfLinks
+	}
 }
 
 func mapHostError(err error) (int32, bool) {

--- a/internal/virtio/net.go
+++ b/internal/virtio/net.go
@@ -739,6 +739,37 @@ func (n *Net) updateIRQLocked() error {
 	return n.irq.SetIRQ(n.IRQ, level)
 }
 
+func (n *Net) Summary() string {
+	if n == nil {
+		return "virtio-net=<nil>"
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return fmt.Sprintf(
+		"virtio-net status=%#x legacy=%t interrupt_status=%#x irq_high=%t pending_rx=%d q0_ready=%t q0_last=%d q0_used=%d q1_ready=%t q1_last=%d q1_used=%d",
+		n.status,
+		n.legacy,
+		n.interruptStatus,
+		n.irqHigh,
+		len(n.pendingRx),
+		n.queues[netQueueRX].ready,
+		n.queues[netQueueRX].lastAvailIdx,
+		n.queues[netQueueRX].usedIdx,
+		n.queues[netQueueTX].ready,
+		n.queues[netQueueTX].lastAvailIdx,
+		n.queues[netQueueTX].usedIdx,
+	)
+}
+
+func (n *Net) IRQAsserted() bool {
+	if n == nil {
+		return false
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.irqHigh
+}
+
 func (n *Net) configBytesLocked() []byte {
 	var cfg [8]byte
 	copy(cfg[0:6], n.MAC)

--- a/internal/vm/backend_builtin_bsd_windows_amd64.go
+++ b/internal/vm/backend_builtin_bsd_windows_amd64.go
@@ -1,0 +1,81 @@
+//go:build windows && amd64
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"j5.nz/cc/client"
+	managedguest "j5.nz/cc/internal/managed/guest"
+	"j5.nz/cc/internal/vm/builtin"
+)
+
+func builtinGuestForImage(image string) (managedguest.Profile, bool) {
+	return builtin.GuestForImage(image)
+}
+
+func isBuiltinGuestImage(image string) bool {
+	return builtin.IsGuestImage(image)
+}
+
+func (b *runtimeBackend) startBuiltinGuestProfile(context.Context, managedguest.Profile, client.CreateInstanceRequest, func(client.BootEvent) error) (Instance, error) {
+	return nil, fmt.Errorf("WHP managed BSD guests are not implemented on windows/amd64")
+}
+
+func (b *runtimeBackend) startBuiltinGuestStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return nil, false, nil
+	}
+	req.Image = profile.Canonical
+	inst, err := b.startBuiltinGuestProfile(ctx, profile, req, onEvent)
+	return inst, true, err
+}
+
+func (b *runtimeBackend) startBuiltinGuestBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return nil, false, nil
+	}
+	inst, err := b.startBuiltinGuestProfile(ctx, profile, client.CreateInstanceRequest{
+		ID:             req.ID,
+		Image:          profile.Canonical,
+		InitSystem:     req.InitSystem,
+		Kernel:         req.Kernel,
+		Network:        req.Network,
+		KernelModules:  append([]string(nil), req.KernelModules...),
+		MemoryMB:       req.MemoryMB,
+		CPUs:           req.CPUs,
+		NestedVirt:     req.NestedVirt,
+		Dmesg:          req.Dmesg,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}, onEvent)
+	return inst, true, err
+}
+
+func (b *runtimeBackend) runBuiltinGuest(ctx context.Context, req client.RunRequest) (client.ExecResponse, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return client.ExecResponse{}, false, nil
+	}
+	_, err := b.startBuiltinGuestProfile(ctx, profile, client.CreateInstanceRequest{
+		ID:             req.ID,
+		Image:          profile.Canonical,
+		InitSystem:     req.InitSystem,
+		Network:        req.Network,
+		MemoryMB:       req.MemoryMB,
+		CPUs:           req.CPUs,
+		Dmesg:          req.Dmesg,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}, nil)
+	return client.ExecResponse{}, true, err
+}
+
+func builtinGuestCapabilities(image string) guestCapabilities {
+	profile, ok := builtinGuestForImage(image)
+	if !ok {
+		return guestCapabilities{}
+	}
+	return profile.Caps
+}

--- a/internal/vm/backend_builtin_bsd_windows_amd64.go
+++ b/internal/vm/backend_builtin_bsd_windows_amd64.go
@@ -7,8 +7,16 @@ import (
 	"fmt"
 
 	"j5.nz/cc/client"
+	"j5.nz/cc/internal/hv/whp"
+	"j5.nz/cc/internal/imagefs"
 	managedguest "j5.nz/cc/internal/managed/guest"
+	"j5.nz/cc/internal/managed/machine"
+	managedruntime "j5.nz/cc/internal/managed/runtime"
+	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/nfs"
 	"j5.nz/cc/internal/vm/builtin"
+	hostmanaged "j5.nz/cc/internal/vm/host/managed"
+	"j5.nz/cc/internal/vm/netstate"
 )
 
 func builtinGuestForImage(image string) (managedguest.Profile, bool) {
@@ -19,8 +27,17 @@ func isBuiltinGuestImage(image string) bool {
 	return builtin.IsGuestImage(image)
 }
 
-func (b *runtimeBackend) startBuiltinGuestProfile(context.Context, managedguest.Profile, client.CreateInstanceRequest, func(client.BootEvent) error) (Instance, error) {
-	return nil, fmt.Errorf("WHP managed BSD guests are not implemented on windows/amd64")
+func (b *runtimeBackend) startBuiltinGuestProfile(ctx context.Context, profile managedguest.Profile, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	switch profile.Canonical {
+	case managedguest.OpenBSDImageName:
+		return b.startOpenBSDStream(ctx, req, onEvent)
+	case managedguest.FreeBSDImageName:
+		return b.startFreeBSDStream(ctx, req, onEvent)
+	case managedguest.NetBSDImageName:
+		return b.startNetBSDStream(ctx, req, onEvent)
+	default:
+		return nil, fmt.Errorf("managed guest profile %q is not supported on windows/amd64", profile.Canonical)
+	}
 }
 
 func (b *runtimeBackend) startBuiltinGuestStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
@@ -59,7 +76,7 @@ func (b *runtimeBackend) runBuiltinGuest(ctx context.Context, req client.RunRequ
 	if !ok {
 		return client.ExecResponse{}, false, nil
 	}
-	_, err := b.startBuiltinGuestProfile(ctx, profile, client.CreateInstanceRequest{
+	inst, err := b.startBuiltinGuestProfile(ctx, profile, client.CreateInstanceRequest{
 		ID:             req.ID,
 		Image:          profile.Canonical,
 		InitSystem:     req.InitSystem,
@@ -69,7 +86,131 @@ func (b *runtimeBackend) runBuiltinGuest(ctx context.Context, req client.RunRequ
 		Dmesg:          req.Dmesg,
 		TimeoutSeconds: req.TimeoutSeconds,
 	}, nil)
-	return client.ExecResponse{}, true, err
+	if err != nil {
+		return client.ExecResponse{}, true, err
+	}
+	defer inst.Close()
+	if len(req.Command) == 0 {
+		if history, ok := inst.(consoleHistoryProvider); ok {
+			output, _ := history.ConsoleHistory(ctx)
+			return client.ExecResponse{ExitCode: 0, Output: output}, true, nil
+		}
+		return client.ExecResponse{}, true, nil
+	}
+	resp, err := inst.Exec(ctx, runExecRequest(req))
+	return resp, true, err
+}
+
+func (b *runtimeBackend) startOpenBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	return b.startBSDManagedStream(ctx, req, onEvent, builtin.OpenBSDDefinition(b.guestInitCache))
+}
+
+func managedBSDNetworkConfig(cfg *client.NetworkConfig) *client.NetworkConfig {
+	if cfg == nil {
+		return &client.NetworkConfig{Enabled: true, AllowInternet: true}
+	}
+	copyCfg := *cfg
+	return &copyCfg
+}
+
+func (b *runtimeBackend) startFreeBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	return b.startBSDManagedStream(ctx, req, onEvent, builtin.FreeBSDDefinition(b.guestInitCache))
+}
+
+func (b *runtimeBackend) startNetBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	return b.startBSDManagedStream(ctx, req, onEvent, builtin.NetBSDDefinition(b.guestInitCache))
+}
+
+func (b *runtimeBackend) startBSDManagedStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error, def builtin.BSDDefinition) (inst Instance, err error) {
+	if b == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	displayName := def.Profile.Name
+	if displayName == "" {
+		displayName = def.BootKind
+	}
+	if req.Network != nil && !req.Network.Enabled {
+		return nil, fmt.Errorf("%s runtime requires virtio-net for the managed control channel", displayName)
+	}
+	if req.CPUs > 1 {
+		return nil, fmt.Errorf("%s runtime currently supports one vCPU", displayName)
+	}
+	if req.NestedVirt {
+		return nil, fmt.Errorf("%s runtime does not support nested virtualization", displayName)
+	}
+	if def.BuildArtifact == nil {
+		return nil, fmt.Errorf("%s runtime root builder is not configured", displayName)
+	}
+	network, err := newWindowsAMD64NetworkRuntime(managedBSDNetworkConfig(req.Network))
+	if err != nil {
+		return nil, err
+	}
+	if network == nil {
+		return nil, fmt.Errorf("%s runtime requires virtio-net for the managed control channel", displayName)
+	}
+	defer func() {
+		if err != nil {
+			_ = network.Close()
+		}
+	}()
+	networkSpec := machine.NetworkSpec{
+		GuestIPv4:   network.GuestAddress(),
+		GatewayIPv4: "10.42.0.1",
+		GatewayMAC:  defaultGatewayMAC,
+		DNSIPv4:     "10.42.0.1",
+		Hostname:    def.Hostname,
+		Interface:   def.Interface,
+		MAC:         network.mac.String(),
+	}
+	artifact, err := def.BuildArtifact(ctx, def.CacheDir, networkSpec)
+	if err != nil {
+		return nil, err
+	}
+	started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+		Profile: def.Profile,
+		Host:    whp.Host{},
+		Spec: machine.Spec{
+			Guest:    def.Profile.Name,
+			Arch:     "amd64",
+			MemoryMB: req.MemoryMB,
+			Dmesg:    req.Dmesg,
+			Boot:     machine.BootSpec{Kind: def.BootKind},
+			Network:  &networkSpec,
+		},
+		Artifact: artifact,
+		Attachments: whp.BSDManagedAttachments{
+			GuestIPv4: network.ip,
+			GuestMAC:  network.mac,
+			NetDevice: network.Device(),
+			NetStack:  network.stack,
+		},
+	}, onEvent)
+	if err != nil {
+		_ = artifact.Close()
+		return nil, err
+	}
+	nfsServer := nfs.New(network.stack)
+	if err := nfsServer.Start(); err != nil {
+		_ = started.Session.Close()
+		_ = artifact.Close()
+		return nil, err
+	}
+	inst = newWindowsBSDInstance(windowsBSDInstanceConfig{
+		OSName:       displayName,
+		Session:      started.Session,
+		CloseRuntime: artifact.Close,
+		Root:         started.Artifact.RootFS,
+		Network:      network,
+		NFS:          nfsServer,
+		Capabilities: def.Profile.Caps,
+	})
+	for _, share := range req.Shares {
+		if err := inst.AddShare(ctx, share); err != nil {
+			_ = inst.Close()
+			return nil, err
+		}
+	}
+	return inst, nil
 }
 
 func builtinGuestCapabilities(image string) guestCapabilities {
@@ -78,4 +219,91 @@ func builtinGuestCapabilities(image string) guestCapabilities {
 		return guestCapabilities{}
 	}
 	return profile.Caps
+}
+
+type windowsBSDInstanceConfig struct {
+	OSName       string
+	Session      managedsession.Session
+	CloseRuntime func() error
+	Root         imagefs.Directory
+	Network      *windowsNetworkRuntime
+	NFS          *nfs.Server
+	Capabilities guestCapabilities
+}
+
+type windowsBSDInstance struct {
+	*managedInstanceCore
+	session      managedsession.Session
+	closeRuntime func() error
+	network      *windowsNetworkRuntime
+	nfs          *nfs.Server
+	osName       string
+}
+
+func newWindowsBSDInstance(cfg windowsBSDInstanceConfig) *windowsBSDInstance {
+	return &windowsBSDInstance{
+		managedInstanceCore: hostmanaged.NewCore(hostmanaged.Config{
+			OSName:       cfg.OSName,
+			Session:      cfg.Session,
+			Root:         cfg.Root,
+			BaseEnv:      builtin.EffectiveExecEnv(nil, nil, false),
+			WorkDir:      "/",
+			Capabilities: cfg.Capabilities,
+			Env:          builtin.EffectiveExecEnv,
+		}),
+		session:      cfg.Session,
+		closeRuntime: cfg.CloseRuntime,
+		network:      cfg.Network,
+		nfs:          cfg.NFS,
+		osName:       cfg.OSName,
+	}
+}
+
+func (i *windowsBSDInstance) AddShare(ctx context.Context, share client.ShareMount) error {
+	if i == nil || i.nfs == nil {
+		return i.managedInstanceCore.AddShare(ctx, share)
+	}
+	exp, err := i.nfs.AddShare(share)
+	if err != nil {
+		return err
+	}
+	return nfs.MountShare(ctx, i.osName, i.Exec, exp)
+}
+
+func (i *windowsBSDInstance) AddPortForward(ctx context.Context, forward client.PortForward) error {
+	if i == nil || i.network == nil {
+		return netstate.AddManagedNetworkPortForward(ctx, nil, forward)
+	}
+	return netstate.AddManagedNetworkPortForward(ctx, i.network.networkRuntime, forward)
+}
+
+func (i *windowsBSDInstance) AllowServiceProxyPort(ctx context.Context, port int) error {
+	if i == nil || i.network == nil {
+		return netstate.AllowManagedNetworkServiceProxyPort(ctx, nil, port)
+	}
+	return netstate.AllowManagedNetworkServiceProxyPort(ctx, i.network.networkRuntime, port)
+}
+
+func (i *windowsBSDInstance) NetworkIPv4() string {
+	if i == nil || i.network == nil {
+		return ""
+	}
+	return netstate.IPv4(i.network.networkRuntime, "")
+}
+
+func (i *windowsBSDInstance) Close() error {
+	if i == nil {
+		return nil
+	}
+	return hostmanaged.CloseSession(i.session, func() error {
+		if i.nfs != nil {
+			return i.nfs.Close()
+		}
+		return nil
+	}, func() error {
+		if i.network != nil {
+			return i.network.Close()
+		}
+		return nil
+	}, i.closeRuntime)
 }

--- a/internal/vm/backend_builtin_bsd_windows_amd64_test.go
+++ b/internal/vm/backend_builtin_bsd_windows_amd64_test.go
@@ -1,0 +1,54 @@
+//go:build windows && amd64
+
+package vm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"j5.nz/cc/client"
+)
+
+func TestWindowsRuntimeBuiltinBSDDoesNotFallThroughToImageStore(t *testing.T) {
+	backend := NewRuntimeBackend(nil, nil, t.TempDir())
+	for _, tc := range []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{
+			name: "start",
+			run: func(ctx context.Context) error {
+				_, err := backend.StartStream(ctx, client.CreateInstanceRequest{Image: "@freebsd"}, nil)
+				return err
+			},
+		},
+		{
+			name: "start_blank",
+			run: func(ctx context.Context) error {
+				_, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{Image: "@openbsd"}, nil)
+				return err
+			},
+		},
+		{
+			name: "run",
+			run: func(ctx context.Context) error {
+				_, err := backend.Run(ctx, client.RunRequest{Image: "@netbsd"})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run(context.Background())
+			if err == nil {
+				t.Fatal("built-in BSD request unexpectedly succeeded")
+			}
+			if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
+				t.Fatalf("built-in BSD request fell through to image store: %v", err)
+			}
+			if !strings.Contains(err.Error(), "WHP managed BSD guests") {
+				t.Fatalf("built-in BSD request error = %v, want WHP managed BSD blocker", err)
+			}
+		})
+	}
+}

--- a/internal/vm/backend_builtin_bsd_windows_amd64_test.go
+++ b/internal/vm/backend_builtin_bsd_windows_amd64_test.go
@@ -19,21 +19,21 @@ func TestWindowsRuntimeBuiltinBSDDoesNotFallThroughToImageStore(t *testing.T) {
 		{
 			name: "start",
 			run: func(ctx context.Context) error {
-				_, err := backend.StartStream(ctx, client.CreateInstanceRequest{Image: "@freebsd"}, nil)
+				_, err := backend.StartStream(ctx, client.CreateInstanceRequest{Image: "@freebsd", Network: &client.NetworkConfig{Enabled: false}}, nil)
 				return err
 			},
 		},
 		{
 			name: "start_blank",
 			run: func(ctx context.Context) error {
-				_, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{Image: "@openbsd"}, nil)
+				_, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{Image: "@openbsd", Network: &client.NetworkConfig{Enabled: false}}, nil)
 				return err
 			},
 		},
 		{
 			name: "run",
 			run: func(ctx context.Context) error {
-				_, err := backend.Run(ctx, client.RunRequest{Image: "@netbsd"})
+				_, err := backend.Run(ctx, client.RunRequest{Image: "@netbsd", Network: &client.NetworkConfig{Enabled: false}})
 				return err
 			},
 		},
@@ -46,8 +46,8 @@ func TestWindowsRuntimeBuiltinBSDDoesNotFallThroughToImageStore(t *testing.T) {
 			if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
 				t.Fatalf("built-in BSD request fell through to image store: %v", err)
 			}
-			if !strings.Contains(err.Error(), "WHP managed BSD guests") {
-				t.Fatalf("built-in BSD request error = %v, want WHP managed BSD blocker", err)
+			if !strings.Contains(err.Error(), "requires virtio-net") {
+				t.Fatalf("built-in BSD request error = %v, want managed BSD network validation", err)
 			}
 		})
 	}

--- a/internal/vm/backend_windows_amd64.go
+++ b/internal/vm/backend_windows_amd64.go
@@ -47,6 +47,9 @@ func (b *runtimeBackend) Start(ctx context.Context, req client.CreateInstanceReq
 }
 
 func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if inst, ok, err := b.startBuiltinGuestStream(ctx, req, onEvent); ok || err != nil {
+		return inst, err
+	}
 	if b == nil || b.kernel == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
@@ -135,11 +138,29 @@ func (b *runtimeBackend) StartBlank(ctx context.Context, req client.StartInstanc
 }
 
 func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if inst, ok, err := b.startBuiltinGuestBlankStream(ctx, req, onEvent); ok || err != nil {
+		return inst, err
+	}
 	if b == nil || b.kernel == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
 	if req.CPUs > 1 {
 		return nil, fmt.Errorf("windows amd64 runtime currently supports only 1 CPU")
+	}
+	if strings.TrimSpace(req.Image) != "" {
+		return b.StartStream(ctx, client.CreateInstanceRequest{
+			ID:             req.ID,
+			Image:          req.Image,
+			InitSystem:     req.InitSystem,
+			Kernel:         req.Kernel,
+			Network:        req.Network,
+			KernelModules:  append([]string(nil), req.KernelModules...),
+			MemoryMB:       req.MemoryMB,
+			CPUs:           req.CPUs,
+			NestedVirt:     req.NestedVirt,
+			Dmesg:          req.Dmesg,
+			TimeoutSeconds: req.TimeoutSeconds,
+		}, onEvent)
 	}
 	kernel, err := b.kernel.ReadKernel()
 	if err != nil {
@@ -206,6 +227,9 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 }
 
 func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client.ExecResponse, error) {
+	if resp, ok, err := b.runBuiltinGuest(ctx, req); ok || err != nil {
+		return resp, err
+	}
 	if b == nil || b.kernel == nil {
 		return client.ExecResponse{}, fmt.Errorf("runtime backend is not configured")
 	}
@@ -595,7 +619,11 @@ func (i *windowsInstance) Close() error {
 	if core := i.core(); core != nil {
 		session = core.Session()
 	}
-	return hostmanaged.CloseSessionWithNetwork(session, i.network)
+	var network hostmanaged.NetworkCloser
+	if i.network != nil {
+		network = i.network
+	}
+	return hostmanaged.CloseSessionWithNetwork(session, network)
 }
 
 func (i *windowsInstance) NetworkIPv4() string {

--- a/internal/vm/manager_other.go
+++ b/internal/vm/manager_other.go
@@ -5,6 +5,7 @@ package vm
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 
 	"j5.nz/cc/client"
@@ -15,7 +16,8 @@ import (
 
 func NewRuntimeManager(kernel *alpine.Manager, images *oci.Store, guestInitCache string, rootCache string, worker bool) *Manager {
 	backend := NewRuntimeBackend(kernel, images, guestInitCache)
-	if worker || strings.TrimSpace(os.Getenv(sidecarDisableEnv)) != "" || strings.TrimSpace(os.Getenv(sidecarEnableEnv)) == "" {
+	sidecarsEnabled := strings.TrimSpace(os.Getenv(sidecarEnableEnv)) != "" || defaultSidecarsEnabled()
+	if worker || strings.TrimSpace(os.Getenv(sidecarDisableEnv)) != "" || !sidecarsEnabled {
 		return NewManagerWithBackend(backend)
 	}
 	mgr := NewManagerWithHosts(
@@ -31,4 +33,8 @@ func NewRuntimeManager(kernel *alpine.Manager, images *oci.Store, guestInitCache
 		return caps
 	}
 	return mgr
+}
+
+func defaultSidecarsEnabled() bool {
+	return runtime.GOOS == "windows" && runtime.GOARCH == "amd64"
 }

--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -130,6 +130,11 @@ func (c *Client) Flush(ctx context.Context, id string) error {
 	return c.call(ctx, WorkerFrameFlush, WorkerFlushRequest{ID: id}, nil, &resp)
 }
 
+func (c *Client) AddShare(ctx context.Context, id string, share client.ShareMount) error {
+	var resp map[string]string
+	return c.call(ctx, WorkerFrameAddShare, WorkerAddShareRequest{ID: id, Share: share}, nil, &resp)
+}
+
 func (c *Client) ConsoleHistory(ctx context.Context, id string) (string, error) {
 	var resp WorkerConsoleResponse
 	err := c.call(ctx, WorkerFrameConsole, WorkerConsoleRequest{ID: id}, nil, &resp)

--- a/internal/vm/sidecar/daemon_test.go
+++ b/internal/vm/sidecar/daemon_test.go
@@ -1,6 +1,7 @@
 package sidecar
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -26,17 +27,17 @@ func TestDaemonCloseRunsCleanupsOnceInReverseOrder(t *testing.T) {
 }
 
 func TestWaitCommand(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := sidecarDaemonTestCommand("exit")
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("start true: %v", err)
+		t.Fatalf("start exit helper: %v", err)
 	}
 	if err := WaitCommand(cmd, time.Second); err != nil {
-		t.Fatalf("wait true: %v", err)
+		t.Fatalf("wait exit helper: %v", err)
 	}
 
-	slow := exec.Command("sh", "-c", "sleep 10")
+	slow := sidecarDaemonTestCommand("sleep")
 	if err := slow.Start(); err != nil {
-		t.Fatalf("start sleep: %v", err)
+		t.Fatalf("start sleep helper: %v", err)
 	}
 	start := time.Now()
 	err := WaitCommand(slow, 10*time.Millisecond)
@@ -45,5 +46,23 @@ func TestWaitCommand(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("wait sleep took %s, want timeout kill", elapsed)
+	}
+}
+
+func sidecarDaemonTestCommand(mode string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestSidecarDaemonHelperProcess")
+	cmd.Env = append(os.Environ(), "CCX3_SIDECAR_DAEMON_TEST_HELPER="+mode)
+	return cmd
+}
+
+func TestSidecarDaemonHelperProcess(t *testing.T) {
+	switch os.Getenv("CCX3_SIDECAR_DAEMON_TEST_HELPER") {
+	case "exit":
+		os.Exit(0)
+	case "sleep":
+		time.Sleep(10 * time.Second)
+		os.Exit(0)
+	default:
+		return
 	}
 }

--- a/internal/vm/sidecar/protocol.go
+++ b/internal/vm/sidecar/protocol.go
@@ -30,6 +30,7 @@ const (
 	WorkerFrameExecInput    = "exec_input"
 	WorkerFrameCancel       = "cancel"
 	WorkerFrameFlush        = "flush"
+	WorkerFrameAddShare     = "add_share"
 	WorkerFrameConsole      = "console"
 	WorkerFrameDone         = "done"
 	WorkerFrameEvent        = "event"
@@ -86,6 +87,11 @@ type WorkerWaitRequest struct {
 
 type WorkerFlushRequest struct {
 	ID string `json:"id,omitempty"`
+}
+
+type WorkerAddShareRequest struct {
+	ID    string            `json:"id,omitempty"`
+	Share client.ShareMount `json:"share"`
 }
 
 type WorkerConsoleRequest struct {

--- a/internal/vm/sidecar_host.go
+++ b/internal/vm/sidecar_host.go
@@ -596,7 +596,9 @@ func (i *sidecarInstance) addCoordinatorShare(share client.ShareMount) error {
 }
 
 func (i *sidecarInstance) AddShare(ctx context.Context, share client.ShareMount) error {
-	_ = ctx
+	if i != nil && i.sidecar != nil {
+		return i.sidecar.Worker().AddShare(ctx, i.id, share)
+	}
 	return i.addCoordinatorShare(share)
 }
 
@@ -656,7 +658,7 @@ func (i *sidecarInstance) managedCore() *managedInstanceCore {
 }
 
 func sidecarShouldPassthroughToWorker(hasImageRoot bool, core *managedInstanceCore, req client.ExecRequest) bool {
-	return core == nil || (req.Kind == "" && !req.SkipResolve && !hasImageRoot)
+	return core == nil || ((req.Kind == "" || req.Kind == "exec") && !req.SkipResolve && !hasImageRoot)
 }
 
 func (i *sidecarInstance) Flush(ctx context.Context) error {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -128,6 +128,7 @@ func HostCapabilities() client.CapabilitiesResponse {
 		caps.Notes = append(caps.Notes, "macOS HVF currently limits ccx3 to one running instance")
 	}
 	if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
+		caps.MaxInstances = 1
 		caps.Notes = append(caps.Notes, "Windows WHP currently supports one vCPU per instance")
 	}
 	if supported, err := hv.NestedVirtualizationSupported(); err == nil && supported {
@@ -467,6 +468,17 @@ func (m *Manager) StreamIn(ctx context.Context, id string, req client.ExecReques
 
 func (m *Manager) AddPortForward(ctx context.Context, forward client.PortForward) error {
 	return m.AddPortForwardTo(ctx, DefaultInstanceID, forward)
+}
+
+func (m *Manager) AddShareTo(ctx context.Context, id string, share client.ShareMount) error {
+	id = instanceID(id)
+	m.mu.Lock()
+	machine := m.running[id]
+	m.mu.Unlock()
+	if machine == nil {
+		return fmt.Errorf("no VM %q is running", id)
+	}
+	return machine.instance.AddShare(ctx, share)
 }
 
 func (m *Manager) AddPortForwardTo(ctx context.Context, id string, forward client.PortForward) error {

--- a/internal/vm/worker_protocol_alias.go
+++ b/internal/vm/worker_protocol_alias.go
@@ -23,6 +23,7 @@ const (
 	WorkerFrameExecInput    = sidecarproto.WorkerFrameExecInput
 	WorkerFrameCancel       = sidecarproto.WorkerFrameCancel
 	WorkerFrameFlush        = sidecarproto.WorkerFrameFlush
+	WorkerFrameAddShare     = sidecarproto.WorkerFrameAddShare
 	WorkerFrameConsole      = sidecarproto.WorkerFrameConsole
 	WorkerFrameDone         = sidecarproto.WorkerFrameDone
 	WorkerFrameEvent        = sidecarproto.WorkerFrameEvent
@@ -40,6 +41,7 @@ type WorkerStatusResponse = sidecarproto.WorkerStatusResponse
 type WorkerStopRequest = sidecarproto.WorkerStopRequest
 type WorkerWaitRequest = sidecarproto.WorkerWaitRequest
 type WorkerFlushRequest = sidecarproto.WorkerFlushRequest
+type WorkerAddShareRequest = sidecarproto.WorkerAddShareRequest
 type WorkerConsoleRequest = sidecarproto.WorkerConsoleRequest
 type WorkerConsoleResponse = sidecarproto.WorkerConsoleResponse
 type WorkerExecRequest = sidecarproto.WorkerExecRequest


### PR DESCRIPTION
## Summary

Fix Windows/amd64 guest support across the WHP Linux path and the BSD/rootfs package suite.

The Linux/WHP changes route image-backed blank starts through the image-aware startup path, enable sidecars by default on Windows/amd64, add worker share mounting, serialize `/vm/start` boot event streams, harden WHP support detection, and fix WHP PIT shutdown re-arm races.

The BSD/Windows changes make FreeBSD, NetBSD, and OpenBSD rootfs tests close seekable tar handles, preserve FFS executable-mode expectations through explicit metadata instead of Windows host mode bits, fix NetBSD guestinit cwd cleanup ordering, close virtual-memory temp files before cleanup, and report passthrough hardlinks with stable Windows file-index inode/link-count metadata.

Windows/amd64 built-in BSD requests now take the managed-guest path instead of falling through to the OCI image-store path (`images/@freebsd/image.json`). The current blocker is now explicit: WHP managed BSD guest sessions are not implemented yet.

## Root Cause

Windows-specific behavior differed in several places: blank-start image requests bypassed Linux image startup, sidecar workers could not receive runtime share mounts, boot streams could be written concurrently or after close, Windows filesystem mode bits could not represent guest executable bits, temp file handles and cwd state blocked cleanup, and passthrough hardlinks lacked real host inode metadata on Windows.

For BSD built-ins, the Windows runtime backend did not intercept managed BSD image names before opening the OCI image store, unlike the Linux/Darwin built-in paths.

## Validation

- Windows/amd64 PowerShell: `go test ./internal/vm -run "TestWindowsRuntimeBuiltinBSDDoesNotFallThroughToImageStore" -count=1`
- Windows/amd64 PowerShell: `go test ./internal/vm -count=1`
- Windows/amd64 PowerShell: `go test ./... -count=1`
- Earlier focused WHP path check also passed: `go test ./internal/ccvmd ./internal/vm ./internal/hv/whp ./internal/vm/host/whp ./internal/vm/host ./internal/vm/mounts ./internal/vm/sidecar -count=1`