### PR TITLE
[codex] support BSD NFS shares across hosts

### DIFF
--- a/client/protocol.go
+++ b/client/protocol.go
@@ -358,6 +358,7 @@ type StartInstanceRequest struct {
 	Image          string         `json:"image,omitempty"`
 	InitSystem     string         `json:"init,omitempty"`
 	Kernel         string         `json:"kernel,omitempty"`
+	Shares         []ShareMount   `json:"shares,omitempty"`
 	Network        *NetworkConfig `json:"network,omitempty"`
 	KernelModules  []string       `json:"kernel_modules,omitempty"`
 	MemoryMB       uint64         `json:"memory_mb,omitempty"`

--- a/internal/nfs/rpc.go
+++ b/internal/nfs/rpc.go
@@ -28,6 +28,9 @@ const (
 	progMount   = 100005
 	progNFS     = 100003
 
+	ipProtoTCP = 6
+	ipProtoUDP = 17
+
 	portmapVersion  = 2
 	rpcbindVersion3 = 3
 	rpcbindVersion4 = 4

--- a/internal/nfs/server.go
+++ b/internal/nfs/server.go
@@ -115,13 +115,21 @@ func (s *Server) Start() error {
 		serveRPCListener(ln, spec.fn, &s.wg)
 	}
 	if packetNet, ok := s.network.(packetNetwork); ok {
-		pc, err := packetNet.ListenPacketInternal("udp", fmt.Sprintf(":%d", PortmapPort))
-		if err != nil {
-			s.Close()
-			return fmt.Errorf("listen nfs udp/%d: %w", PortmapPort, err)
+		for _, spec := range []struct {
+			port int
+			fn   rpcHandler
+		}{
+			{PortmapPort, s.handlePortmap},
+			{MountPort, s.handleMount},
+		} {
+			pc, err := packetNet.ListenPacketInternal("udp", fmt.Sprintf(":%d", spec.port))
+			if err != nil {
+				s.Close()
+				return fmt.Errorf("listen nfs udp/%d: %w", spec.port, err)
+			}
+			s.packets = append(s.packets, pc)
+			serveRPCPacketConn(pc, spec.fn, &s.wg)
 		}
-		s.packets = append(s.packets, pc)
-		serveRPCPacketConn(pc, s.handlePortmap, &s.wg)
 	}
 	return nil
 }
@@ -305,15 +313,15 @@ func (s *Server) handlePortmap(call rpcCall) ([]byte, uint32) {
 		if err != nil {
 			return nil, rpcGarbageArgs
 		}
-		_, _ = r.Uint32() // protocol
+		proto, _ := r.Uint32()
 		_, _ = r.Uint32() // port
 		port := uint32(0)
 		switch {
 		case prog == progPortmap && vers == portmapVersion:
 			port = PortmapPort
-		case prog == progMount && vers == mountVersion3:
+		case prog == progMount && vers == mountVersion3 && (proto == ipProtoTCP || proto == ipProtoUDP):
 			port = MountPort
-		case prog == progNFS && vers == nfsVersion3:
+		case prog == progNFS && vers == nfsVersion3 && proto == ipProtoTCP:
 			port = NFSPort
 		}
 		w.Uint32(port)
@@ -331,12 +339,15 @@ func rpcbindUniversalAddress(prog, vers uint32, netid string) string {
 	case prog == progMount && vers == mountVersion3:
 		port = MountPort
 	case prog == progNFS && vers == nfsVersion3:
+		if netid == "udp" || netid == "udp4" {
+			return ""
+		}
 		port = NFSPort
 	default:
 		return ""
 	}
 	switch netid {
-	case "tcp", "tcp4":
+	case "tcp", "tcp4", "udp", "udp4":
 		return fmt.Sprintf("10.42.0.1.%d.%d", port/256, port%256)
 	default:
 		return ""
@@ -1183,7 +1194,7 @@ func MountCommand(osName, serverAddr, exportName, mountPath string) []string {
 	case "openbsd":
 		return []string{"/sbin/mount", "-t", "nfs", "-o", fmt.Sprintf("tcp,port=%d", NFSPort), target, mountPath}
 	case "freebsd":
-		return []string{"/sbin/mount", "-t", "nfs", "-o", fmt.Sprintf("nfsv3,tcp,port=%d,mountport=%d,nolockd", NFSPort, MountPort), target, mountPath}
+		return []string{"/sbin/mount", "-t", "nfs", "-o", fmt.Sprintf("nfsv3,proto=tcp,soft,retrycnt=1,port=%d,mountport=%d,nolockd", NFSPort, MountPort), target, mountPath}
 	case "netbsd":
 		return []string{"/sbin/mount_nfs", "-3", "-T", "-p", "-R", "1", "-t", "1", target, mountPath}
 	default:
@@ -1195,14 +1206,18 @@ func MountShare(ctx context.Context, osName string, exec func(context.Context, c
 	if exp == nil {
 		return fmt.Errorf("nfs export is not configured")
 	}
+	mountCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
 	mkdir := client.ExecRequest{Command: []string{"/bin/mkdir", "-p", exp.Mount}, SkipResolve: true}
-	if resp, err := exec(ctx, mkdir); err != nil {
+	debugf("mount share mkdir %s", exp.Mount)
+	if resp, err := exec(mountCtx, mkdir); err != nil {
 		return err
 	} else if resp.ExitCode != 0 {
 		return fmt.Errorf("mkdir %s failed: %s", exp.Mount, resp.Output)
 	}
 	req := client.ExecRequest{Command: MountCommand(osName, "10.42.0.1", exp.Name, exp.Mount), SkipResolve: true}
-	resp, err := exec(ctx, req)
+	debugf("mount share command %q", strings.Join(req.Command, " "))
+	resp, err := exec(mountCtx, req)
 	if err != nil {
 		return err
 	}

--- a/internal/nfs/server_test.go
+++ b/internal/nfs/server_test.go
@@ -207,6 +207,25 @@ func TestRPCBindGetAddrReturnsTCPUniversalAddress(t *testing.T) {
 	if addr != "10.42.0.1.78.80" {
 		t.Fatalf("mountd universal address = %q", addr)
 	}
+
+	req = xdrWriter{}
+	req.Uint32(progMount)
+	req.Uint32(mountVersion3)
+	req.String("udp")
+	req.String("")
+	req.String("")
+	body, accept = server.handlePortmap(rpcCall{prog: progPortmap, version: rpcbindVersion4, proc: rpcbindProcGetAddr, body: req.Bytes()})
+	if accept != rpcAcceptSuccess {
+		t.Fatalf("GETADDR mount udp accept = %d", accept)
+	}
+	r = newXDRReader(body)
+	addr, err = r.String(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != "10.42.0.1.78.80" {
+		t.Fatalf("mountd udp universal address = %q", addr)
+	}
 }
 
 func TestMountReplyAdvertisesAuthUnix(t *testing.T) {
@@ -253,7 +272,7 @@ func TestMountCommandUsesOSCompatibleOptions(t *testing.T) {
 		avoid  []string
 	}{
 		{osName: "openbsd", want: []string{"tcp", "port=2049"}, avoid: []string{"mountport", "nolock"}},
-		{osName: "freebsd", want: []string{"nfsv3", "tcp", "port=2049", "mountport=20048", "nolockd"}},
+		{osName: "freebsd", want: []string{"nfsv3", "proto=tcp", "soft", "retrycnt=1", "port=2049", "mountport=20048", "nolockd"}},
 		{osName: "netbsd", want: []string{"/sbin/mount_nfs", "-3", "-T", "-p"}, avoid: []string{"mountport", "nolock"}},
 	}
 	for _, tt := range tests {
@@ -301,4 +320,8 @@ type fakeNetwork struct{}
 
 func (fakeNetwork) ListenInternal(network, address string) (net.Listener, error) {
 	return (&net.ListenConfig{}).Listen(context.Background(), network, "127.0.0.1:0")
+}
+
+func (fakeNetwork) ListenPacketInternal(network, address string) (net.PacketConn, error) {
+	return (&net.ListenConfig{}).ListenPacket(context.Background(), network, "127.0.0.1:0")
 }

--- a/internal/vm/backend_builtin_bsd_darwin_arm64.go
+++ b/internal/vm/backend_builtin_bsd_darwin_arm64.go
@@ -11,7 +11,6 @@ import (
 	managedguest "j5.nz/cc/internal/managed/guest"
 	"j5.nz/cc/internal/managed/machine"
 	"j5.nz/cc/internal/vm/builtin"
-	"j5.nz/cc/internal/vm/execplan"
 )
 
 func builtinGuestForImage(image string) (managedguest.Profile, bool) {
@@ -55,6 +54,7 @@ func (b *runtimeBackend) startBuiltinGuestBlankStream(ctx context.Context, req c
 		Image:          profile.Canonical,
 		InitSystem:     req.InitSystem,
 		Kernel:         req.Kernel,
+		Shares:         append([]client.ShareMount(nil), req.Shares...),
 		Network:        req.Network,
 		KernelModules:  append([]string(nil), req.KernelModules...),
 		MemoryMB:       req.MemoryMB,
@@ -160,9 +160,6 @@ func (b *runtimeBackend) startBSDArm64ManagedStream(ctx context.Context, req cli
 	if displayName == "" {
 		displayName = def.BootKind
 	}
-	if len(req.Shares) != 0 {
-		return nil, execplan.UnsupportedFeature(displayName, def.Profile.Caps, "filesystem shares")
-	}
 	if req.Network != nil && !req.Network.Enabled {
 		return nil, fmt.Errorf("%s runtime requires virtio-net for the managed control channel", displayName)
 	}
@@ -213,17 +210,24 @@ func (b *runtimeBackend) startBSDArm64ManagedStream(ctx context.Context, req cli
 		_ = artifact.Close()
 		return nil, err
 	}
-	return newDarwinBSDInstance(darwinBSDInstanceConfig{
+	nfsServer, err := startBSDNFSServer(network.stack)
+	if err != nil {
+		_ = session.Close()
+		_ = artifact.Close()
+		return nil, err
+	}
+	base := newDarwinBSDInstance(darwinBSDInstanceConfig{
 		OSName:       displayName,
 		Session:      session,
-		CloseRuntime: artifact.Close,
+		CloseRuntime: closeBSDNFSRuntime(nfsServer, artifact.Close),
 		Root:         artifact.RootFS,
 		BaseEnv:      builtin.EffectiveExecEnv(nil, nil, false),
 		WorkDir:      "/",
 		Network:      network,
 		Capabilities: def.Profile.Caps,
 		Env:          builtin.EffectiveExecEnv,
-	}), nil
+	})
+	return wrapBSDNFSInstance(ctx, displayName, base, nfsServer, req.Shares)
 }
 
 func builtinGuestCapabilities(image string) guestCapabilities {

--- a/internal/vm/backend_builtin_bsd_linux_amd64.go
+++ b/internal/vm/backend_builtin_bsd_linux_amd64.go
@@ -11,7 +11,6 @@ import (
 	managedguest "j5.nz/cc/internal/managed/guest"
 	"j5.nz/cc/internal/managed/machine"
 	managedruntime "j5.nz/cc/internal/managed/runtime"
-	"j5.nz/cc/internal/nfs"
 	"j5.nz/cc/internal/vm/builtin"
 )
 
@@ -56,6 +55,7 @@ func (b *runtimeBackend) startBuiltinGuestBlankStream(ctx context.Context, req c
 		Image:          profile.Canonical,
 		InitSystem:     req.InitSystem,
 		Kernel:         req.Kernel,
+		Shares:         append([]client.ShareMount(nil), req.Shares...),
 		Network:        req.Network,
 		KernelModules:  append([]string(nil), req.KernelModules...),
 		MemoryMB:       req.MemoryMB,
@@ -181,40 +181,23 @@ func (b *runtimeBackend) startBSDManagedStream(ctx context.Context, req client.C
 	if err != nil {
 		return nil, err
 	}
-	nfsServer := nfs.New(network.stack)
-	if err := nfsServer.Start(); err != nil {
+	nfsServer, err := startBSDNFSServer(network.stack)
+	if err != nil {
 		_ = started.Session.Close()
 		return nil, err
 	}
 	base := &managedInstance{
-		osName:  displayName,
-		session: started.Session,
-		closeRuntime: func() error {
-			nfsErr := nfsServer.Close()
-			artifactErr := started.Artifact.Close()
-			if nfsErr != nil {
-				return nfsErr
-			}
-			return artifactErr
-		},
-		root:    started.Artifact.RootFS,
-		baseEnv: builtin.EffectiveExecEnv(nil, nil, false),
-		workDir: "/",
-		network: network,
-		caps:    def.Profile.Caps,
-		env:     builtin.EffectiveExecEnv,
+		osName:       displayName,
+		session:      started.Session,
+		closeRuntime: closeBSDNFSRuntime(nfsServer, started.Artifact.Close),
+		root:         started.Artifact.RootFS,
+		baseEnv:      builtin.EffectiveExecEnv(nil, nil, false),
+		workDir:      "/",
+		network:      network,
+		caps:         def.Profile.Caps,
+		env:          builtin.EffectiveExecEnv,
 	}
-	bsdInst := &bsdNFSInstance{
-		managedInstance: base,
-		nfs:             nfsServer,
-	}
-	for _, share := range req.Shares {
-		if err := bsdInst.AddShare(ctx, share); err != nil {
-			_ = bsdInst.Close()
-			return nil, err
-		}
-	}
-	return bsdInst, nil
+	return wrapBSDNFSInstance(ctx, displayName, base, nfsServer, req.Shares)
 }
 
 func builtinGuestCapabilities(image string) guestCapabilities {
@@ -223,20 +206,4 @@ func builtinGuestCapabilities(image string) guestCapabilities {
 		return guestCapabilities{}
 	}
 	return profile.Caps
-}
-
-type bsdNFSInstance struct {
-	*managedInstance
-	nfs *nfs.Server
-}
-
-func (i *bsdNFSInstance) AddShare(ctx context.Context, share client.ShareMount) error {
-	if i == nil || i.nfs == nil {
-		return (&managedInstance{}).AddShare(ctx, share)
-	}
-	exp, err := i.nfs.AddShare(share)
-	if err != nil {
-		return err
-	}
-	return nfs.MountShare(ctx, i.osName, i.Exec, exp)
 }

--- a/internal/vm/backend_builtin_bsd_linux_arm64.go
+++ b/internal/vm/backend_builtin_bsd_linux_arm64.go
@@ -11,7 +11,6 @@ import (
 	managedguest "j5.nz/cc/internal/managed/guest"
 	"j5.nz/cc/internal/managed/machine"
 	"j5.nz/cc/internal/vm/builtin"
-	"j5.nz/cc/internal/vm/execplan"
 )
 
 func builtinGuestForImage(image string) (managedguest.Profile, bool) {
@@ -55,6 +54,7 @@ func (b *runtimeBackend) startBuiltinGuestBlankStream(ctx context.Context, req c
 		Image:          profile.Canonical,
 		InitSystem:     req.InitSystem,
 		Kernel:         req.Kernel,
+		Shares:         append([]client.ShareMount(nil), req.Shares...),
 		Network:        req.Network,
 		KernelModules:  append([]string(nil), req.KernelModules...),
 		MemoryMB:       req.MemoryMB,
@@ -160,9 +160,6 @@ func (b *runtimeBackend) startBSDArm64ManagedStream(ctx context.Context, req cli
 	if displayName == "" {
 		displayName = def.BootKind
 	}
-	if len(req.Shares) != 0 {
-		return nil, execplan.UnsupportedFeature(displayName, def.Profile.Caps, "filesystem shares")
-	}
 	if req.Network != nil && !req.Network.Enabled {
 		return nil, fmt.Errorf("%s runtime requires virtio-net for the managed control channel", displayName)
 	}
@@ -210,17 +207,24 @@ func (b *runtimeBackend) startBSDArm64ManagedStream(ctx context.Context, req cli
 		_ = artifact.Close()
 		return nil, err
 	}
-	return &managedInstance{
+	nfsServer, err := startBSDNFSServer(network.stack)
+	if err != nil {
+		_ = session.Close()
+		_ = artifact.Close()
+		return nil, err
+	}
+	base := &managedInstance{
 		osName:       displayName,
 		session:      session,
-		closeRuntime: artifact.Close,
+		closeRuntime: closeBSDNFSRuntime(nfsServer, artifact.Close),
 		root:         artifact.RootFS,
 		baseEnv:      builtin.EffectiveExecEnv(nil, nil, false),
 		workDir:      "/",
 		network:      network,
 		caps:         def.Profile.Caps,
 		env:          builtin.EffectiveExecEnv,
-	}, nil
+	}
+	return wrapBSDNFSInstance(ctx, displayName, base, nfsServer, req.Shares)
 }
 
 func builtinGuestCapabilities(image string) guestCapabilities {

--- a/internal/vm/backend_darwin_arm64.go
+++ b/internal/vm/backend_darwin_arm64.go
@@ -133,25 +133,6 @@ func ubuntuRuntimeKernelRequirements(extra []string) ([]string, map[string]strin
 	return configVars, moduleMap
 }
 
-func sameRuntimeImage(targetImage, runningImage string) bool {
-	targetImage = strings.TrimSpace(targetImage)
-	runningImage = strings.TrimSpace(runningImage)
-	if targetImage == "" || targetImage == runningImage {
-		return true
-	}
-	if isBuiltinGuestImage(targetImage) || isBuiltinGuestImage(runningImage) {
-		return canonicalBuiltinRuntimeImage(targetImage) == canonicalBuiltinRuntimeImage(runningImage)
-	}
-	return false
-}
-
-func canonicalBuiltinRuntimeImage(image string) string {
-	if profile, ok := builtinGuestForImage(image); ok {
-		return profile.Canonical
-	}
-	return strings.TrimSpace(image)
-}
-
 func (b *runtimeBackend) Start(ctx context.Context, req client.CreateInstanceRequest) (Instance, error) {
 	return b.StartStream(ctx, req, nil)
 }

--- a/internal/vm/bsd_nfs_instance.go
+++ b/internal/vm/bsd_nfs_instance.go
@@ -1,0 +1,128 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/nfs"
+)
+
+type bsdNFSInstance struct {
+	Instance
+	osName  string
+	nfs     *nfs.Server
+	mu      sync.Mutex
+	mounted map[string]client.ShareMount
+}
+
+func startBSDNFSServer(network nfs.Network) (*nfs.Server, error) {
+	nfsServer := nfs.New(network)
+	if err := nfsServer.Start(); err != nil {
+		return nil, err
+	}
+	return nfsServer, nil
+}
+
+func closeBSDNFSRuntime(nfsServer *nfs.Server, closeArtifact func() error) func() error {
+	return func() error {
+		var nfsErr error
+		if nfsServer != nil {
+			nfsErr = nfsServer.Close()
+		}
+		var artifactErr error
+		if closeArtifact != nil {
+			artifactErr = closeArtifact()
+		}
+		if nfsErr != nil {
+			return nfsErr
+		}
+		return artifactErr
+	}
+}
+
+func wrapBSDNFSInstance(ctx context.Context, osName string, base Instance, nfsServer *nfs.Server, shares []client.ShareMount) (Instance, error) {
+	inst := &bsdNFSInstance{
+		Instance: base,
+		osName:   osName,
+		nfs:      nfsServer,
+	}
+	for _, share := range shares {
+		if err := inst.AddShare(ctx, share); err != nil {
+			_ = inst.Close()
+			return nil, err
+		}
+	}
+	return inst, nil
+}
+
+func (i *bsdNFSInstance) AddShare(ctx context.Context, share client.ShareMount) error {
+	if i == nil || i.nfs == nil {
+		if i != nil && i.Instance != nil {
+			return i.Instance.AddShare(ctx, share)
+		}
+		return fmt.Errorf("BSD NFS share support is not configured")
+	}
+	key := path.Clean(share.Mount)
+	if key == "." {
+		key = "/"
+	}
+	i.mu.Lock()
+	if existing, ok := i.mounted[key]; ok {
+		i.mu.Unlock()
+		if existing.Source == share.Source && existing.Writable == share.Writable {
+			return nil
+		}
+	} else {
+		i.mu.Unlock()
+	}
+	exp, err := i.nfs.AddShare(share)
+	if err != nil {
+		return err
+	}
+	if err := nfs.MountShare(ctx, i.osName, i.execStreamResponse, exp); err != nil {
+		return err
+	}
+	i.mu.Lock()
+	if i.mounted == nil {
+		i.mounted = map[string]client.ShareMount{}
+	}
+	i.mounted[key] = share
+	i.mu.Unlock()
+	return nil
+}
+
+func (i *bsdNFSInstance) execStreamResponse(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {
+	if i == nil || i.Instance == nil {
+		return client.ExecResponse{}, fmt.Errorf("instance is not running")
+	}
+	var output strings.Builder
+	exitCode := 0
+	exitSeen := false
+	err := i.ExecStream(ctx, req, nil, func(event client.ExecEvent) error {
+		switch event.Kind {
+		case "stdout", "stderr", "output":
+			output.WriteString(event.Output)
+		case "error":
+			if event.Error != "" {
+				output.WriteString(event.Error)
+			} else {
+				output.WriteString(event.Output)
+			}
+		case "exit":
+			exitCode = event.ExitCode
+			exitSeen = true
+		}
+		return nil
+	})
+	if err != nil {
+		return client.ExecResponse{}, err
+	}
+	if !exitSeen {
+		return client.ExecResponse{}, fmt.Errorf("exec stream did not report exit")
+	}
+	return client.ExecResponse{ExitCode: exitCode, Output: output.String()}, nil
+}

--- a/internal/vm/bsd_nfs_instance.go
+++ b/internal/vm/bsd_nfs_instance.go
@@ -8,7 +8,9 @@ import (
 	"sync"
 
 	"j5.nz/cc/client"
+	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/nfs"
+	"j5.nz/cc/internal/virtio"
 )
 
 type bsdNFSInstance struct {
@@ -93,6 +95,62 @@ func (i *bsdNFSInstance) AddShare(ctx context.Context, share client.ShareMount) 
 	i.mounted[key] = share
 	i.mu.Unlock()
 	return nil
+}
+
+func (i *bsdNFSInstance) Flush(ctx context.Context) error {
+	flusher, ok := i.Instance.(instanceFlushProvider)
+	if !ok {
+		return fmt.Errorf("root filesystem cannot be flushed")
+	}
+	return flusher.Flush(ctx)
+}
+
+func (i *bsdNFSInstance) ConsoleHistory(ctx context.Context) (string, error) {
+	provider, ok := i.Instance.(consoleHistoryProvider)
+	if !ok {
+		return "", fmt.Errorf("console history is not available")
+	}
+	return provider.ConsoleHistory(ctx)
+}
+
+func (i *bsdNFSInstance) RootSnapshot() (imagefs.Directory, error) {
+	snapshotter, ok := i.Instance.(rootSnapshotProvider)
+	if !ok {
+		return nil, fmt.Errorf("root filesystem cannot be snapshotted")
+	}
+	return snapshotter.RootSnapshot()
+}
+
+func (i *bsdNFSInstance) SnapshotImage(imageName string) (imagefs.Directory, error) {
+	snapshotter, ok := i.Instance.(imageSnapshotProvider)
+	if !ok {
+		return nil, fmt.Errorf("image %q cannot be snapshotted", imageName)
+	}
+	return snapshotter.SnapshotImage(imageName)
+}
+
+func (i *bsdNFSInstance) NetworkIPv4() string {
+	provider, ok := i.Instance.(networkIPv4Provider)
+	if !ok {
+		return ""
+	}
+	return provider.NetworkIPv4()
+}
+
+func (i *bsdNFSInstance) VirtioFSStats() []virtio.FSStats {
+	provider, ok := i.Instance.(virtioFSStatsProvider)
+	if !ok {
+		return nil
+	}
+	return provider.VirtioFSStats()
+}
+
+func (i *bsdNFSInstance) AllowServiceProxyPort(ctx context.Context, port int) error {
+	allower, ok := i.Instance.(serviceProxyPortAllower)
+	if !ok {
+		return fmt.Errorf("network does not support service proxy port updates")
+	}
+	return allower.AllowServiceProxyPort(ctx, port)
 }
 
 func (i *bsdNFSInstance) execStreamResponse(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {

--- a/internal/vm/bsd_nfs_instance_test.go
+++ b/internal/vm/bsd_nfs_instance_test.go
@@ -1,0 +1,115 @@
+package vm
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/nfs"
+)
+
+func TestBSDNFSInstanceAddShareMountsExport(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	base := &recordingBSDNFSInstance{}
+	inst := &bsdNFSInstance{
+		Instance: base,
+		osName:   "FreeBSD",
+		nfs:      nfs.New(nil),
+	}
+
+	if err := inst.AddShare(ctx, client.ShareMount{Source: source, Mount: "/mnt/host", Writable: true}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	want := [][]string{
+		{"/bin/mkdir", "-p", "/mnt/host"},
+		{"/sbin/mount", "-t", "nfs", "-o", "nfsv3,proto=tcp,soft,retrycnt=1,port=2049,mountport=20048,nolockd", "10.42.0.1:/ccx3/1", "/mnt/host"},
+	}
+	if !reflect.DeepEqual(base.commands, want) {
+		t.Fatalf("commands mismatch\n got: %#v\nwant: %#v", base.commands, want)
+	}
+	for _, req := range base.requests {
+		if !req.SkipResolve {
+			t.Fatalf("request %#v did not skip resolve", req.Command)
+		}
+	}
+}
+
+func TestWrapBSDNFSInstanceClosesBaseOnInitialShareFailure(t *testing.T) {
+	ctx := context.Background()
+	base := &recordingBSDNFSInstance{}
+	inst, err := wrapBSDNFSInstance(ctx, "OpenBSD", base, nfs.New(nil), []client.ShareMount{{Source: "/does/not/exist", Mount: "/mnt/host"}})
+	if err == nil {
+		t.Fatalf("wrapBSDNFSInstance succeeded with missing source")
+	}
+	if inst != nil {
+		t.Fatalf("wrapBSDNFSInstance returned instance on error")
+	}
+	if !base.closed {
+		t.Fatalf("base instance was not closed after initial share failure")
+	}
+}
+
+func TestBSDNFSInstanceAddShareSkipsAlreadyMountedShare(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	base := &recordingBSDNFSInstance{}
+	inst := &bsdNFSInstance{
+		Instance: base,
+		osName:   "FreeBSD",
+		nfs:      nfs.New(nil),
+	}
+	share := client.ShareMount{Source: source, Mount: "/mnt/host", Writable: true}
+
+	if err := inst.AddShare(ctx, share); err != nil {
+		t.Fatalf("first AddShare: %v", err)
+	}
+	if err := inst.AddShare(ctx, share); err != nil {
+		t.Fatalf("second AddShare: %v", err)
+	}
+	if got, want := len(base.commands), 2; got != want {
+		t.Fatalf("commands after duplicate AddShare = %d, want %d", got, want)
+	}
+}
+
+type recordingBSDNFSInstance struct {
+	requests []client.ExecRequest
+	commands [][]string
+	closed   bool
+}
+
+func (i *recordingBSDNFSInstance) AddShare(context.Context, client.ShareMount) error {
+	return nil
+}
+
+func (i *recordingBSDNFSInstance) AddPortForward(context.Context, client.PortForward) error {
+	return nil
+}
+
+func (i *recordingBSDNFSInstance) Exec(_ context.Context, req client.ExecRequest) (client.ExecResponse, error) {
+	i.requests = append(i.requests, req)
+	i.commands = append(i.commands, append([]string(nil), req.Command...))
+	return client.ExecResponse{}, nil
+}
+
+func (i *recordingBSDNFSInstance) ExecStream(_ context.Context, req client.ExecRequest, _ <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	i.requests = append(i.requests, req)
+	i.commands = append(i.commands, append([]string(nil), req.Command...))
+	if onEvent != nil {
+		if err := onEvent(client.ExecEvent{Kind: "exit", ExitCode: 0}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *recordingBSDNFSInstance) Wait() error {
+	return nil
+}
+
+func (i *recordingBSDNFSInstance) Close() error {
+	i.closed = true
+	return nil
+}

--- a/internal/vm/bsd_nfs_instance_test.go
+++ b/internal/vm/bsd_nfs_instance_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"j5.nz/cc/client"
+	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/nfs"
+	"j5.nz/cc/internal/virtio"
 )
 
 func TestBSDNFSInstanceAddShareMountsExport(t *testing.T) {
@@ -74,10 +76,60 @@ func TestBSDNFSInstanceAddShareSkipsAlreadyMountedShare(t *testing.T) {
 	}
 }
 
+func TestBSDNFSInstanceForwardsOptionalInstanceCapabilities(t *testing.T) {
+	ctx := context.Background()
+	base := &recordingBSDNFSInstance{
+		networkIPv4: "10.42.0.2",
+		stats:       []virtio.FSStats{{Tag: "root"}},
+	}
+	inst := &bsdNFSInstance{Instance: base, osName: "OpenBSD", nfs: nfs.New(nil)}
+
+	flusher, ok := any(inst).(instanceFlushProvider)
+	if !ok {
+		t.Fatalf("bsdNFSInstance does not expose flush")
+	}
+	if err := flusher.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if !base.flushed {
+		t.Fatalf("base instance was not flushed")
+	}
+
+	history, err := inst.ConsoleHistory(ctx)
+	if err != nil {
+		t.Fatalf("ConsoleHistory: %v", err)
+	}
+	if history != "console" {
+		t.Fatalf("ConsoleHistory = %q, want console", history)
+	}
+	if _, err := inst.RootSnapshot(); err != nil {
+		t.Fatalf("RootSnapshot: %v", err)
+	}
+	if _, err := inst.SnapshotImage("alternate"); err != nil {
+		t.Fatalf("SnapshotImage: %v", err)
+	}
+	if got := inst.NetworkIPv4(); got != "10.42.0.2" {
+		t.Fatalf("NetworkIPv4 = %q, want 10.42.0.2", got)
+	}
+	if !reflect.DeepEqual(inst.VirtioFSStats(), base.stats) {
+		t.Fatalf("VirtioFSStats = %+v, want %+v", inst.VirtioFSStats(), base.stats)
+	}
+	if err := inst.AllowServiceProxyPort(ctx, 8080); err != nil {
+		t.Fatalf("AllowServiceProxyPort: %v", err)
+	}
+	if base.allowedPort != 8080 {
+		t.Fatalf("allowed port = %d, want 8080", base.allowedPort)
+	}
+}
+
 type recordingBSDNFSInstance struct {
-	requests []client.ExecRequest
-	commands [][]string
-	closed   bool
+	requests    []client.ExecRequest
+	commands    [][]string
+	closed      bool
+	flushed     bool
+	networkIPv4 string
+	stats       []virtio.FSStats
+	allowedPort int
 }
 
 func (i *recordingBSDNFSInstance) AddShare(context.Context, client.ShareMount) error {
@@ -111,5 +163,35 @@ func (i *recordingBSDNFSInstance) Wait() error {
 
 func (i *recordingBSDNFSInstance) Close() error {
 	i.closed = true
+	return nil
+}
+
+func (i *recordingBSDNFSInstance) Flush(context.Context) error {
+	i.flushed = true
+	return nil
+}
+
+func (i *recordingBSDNFSInstance) ConsoleHistory(context.Context) (string, error) {
+	return "console", nil
+}
+
+func (i *recordingBSDNFSInstance) RootSnapshot() (imagefs.Directory, error) {
+	return nil, nil
+}
+
+func (i *recordingBSDNFSInstance) SnapshotImage(string) (imagefs.Directory, error) {
+	return nil, nil
+}
+
+func (i *recordingBSDNFSInstance) NetworkIPv4() string {
+	return i.networkIPv4
+}
+
+func (i *recordingBSDNFSInstance) VirtioFSStats() []virtio.FSStats {
+	return i.stats
+}
+
+func (i *recordingBSDNFSInstance) AllowServiceProxyPort(_ context.Context, port int) error {
+	i.allowedPort = port
 	return nil
 }

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -54,13 +54,13 @@ func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	}, nil, appendExecEvents(&runEvents)); err != nil {
 		t.Fatalf("run stream in existing instance: %v", err)
 	}
-	if len(inst.shares) != 0 {
+	if len(inst.shares) != 1 || inst.shares[0] != share {
 		t.Fatalf("instance shares = %+v", inst.shares)
 	}
-	if got := host.runInStreamCalls(); len(got) != 1 || got[0].runningImage != "alpine" || len(got[0].req.Shares) != 1 || got[0].req.Shares[0] != share {
+	if got := host.runInStreamCalls(); len(got) != 0 {
 		t.Fatalf("host run-in-stream calls = %+v", got)
 	}
-	if len(inst.execStreamReqs) != 0 {
+	if len(inst.execStreamReqs) != 1 {
 		t.Fatalf("instance exec stream reqs = %+v", inst.execStreamReqs)
 	}
 	if len(runEvents) == 0 || runEvents[len(runEvents)-1].Kind != "exit" {
@@ -70,8 +70,8 @@ func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	if err := manager.StreamIn(ctx, "alpha", client.ExecRequest{Command: []string{"id"}}, nil, nil); err != nil {
 		t.Fatalf("exec stream in instance: %v", err)
 	}
-	if len(inst.execStreamReqs) != 1 {
-		t.Fatalf("exec stream count = %d, want 1", len(inst.execStreamReqs))
+	if len(inst.execStreamReqs) != 2 {
+		t.Fatalf("exec stream count = %d, want 2", len(inst.execStreamReqs))
 	}
 	if err := manager.StreamIn(ctx, "alpha", client.ExecRequest{Image: "other", Command: []string{"true"}}, nil, nil); err != nil {
 		t.Fatalf("multi-image exec stream: %v", err)

--- a/internal/vm/runtime_image.go
+++ b/internal/vm/runtime_image.go
@@ -1,0 +1,26 @@
+package vm
+
+import (
+	"strings"
+
+	"j5.nz/cc/internal/vm/builtin"
+)
+
+func sameRuntimeImage(targetImage, runningImage string) bool {
+	targetImage = strings.TrimSpace(targetImage)
+	runningImage = strings.TrimSpace(runningImage)
+	if targetImage == "" || targetImage == runningImage {
+		return true
+	}
+	if builtin.IsGuestImage(targetImage) || builtin.IsGuestImage(runningImage) {
+		return canonicalBuiltinRuntimeImage(targetImage) == canonicalBuiltinRuntimeImage(runningImage)
+	}
+	return false
+}
+
+func canonicalBuiltinRuntimeImage(image string) string {
+	if profile, ok := builtin.GuestForImage(image); ok {
+		return profile.Canonical
+	}
+	return strings.TrimSpace(image)
+}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -304,10 +304,19 @@ func (m *Manager) StartBlankInstanceStream(
 	m.starting[id] = struct{}{}
 	m.mu.Unlock()
 
+	shares := append([]client.ShareMount(nil), req.Shares...)
+	req.Shares = nil
 	inst, err := m.host.StartBlankStream(ctx, req, onEvent)
 	if err != nil {
 		m.clearStarting(id)
 		return client.InstanceState{}, err
+	}
+	for _, share := range shares {
+		if err := inst.AddShare(ctx, share); err != nil {
+			_ = inst.Close()
+			m.clearStarting(id)
+			return client.InstanceState{}, err
+		}
 	}
 
 	machine := &Machine{
@@ -439,7 +448,7 @@ func (m *Manager) RunStreamIn(ctx context.Context, id string, req client.RunRequ
 		return m.host.RunStream(ctx, req, inputs, onEvent)
 	}
 	targetImage := strings.TrimSpace(req.Image)
-	if vmhost.IsHostedInstance(machine.instance) || len(req.Shares) != 0 || (targetImage != "" && targetImage != machine.image) {
+	if !sameRuntimeImage(targetImage, machine.image) {
 		return m.host.RunInInstanceStream(ctx, machine.instance, machine.image, req, inputs, onEvent)
 	}
 	for _, share := range req.Shares {


### PR DESCRIPTION
## Summary

- Factor BSD NFS share mounting into shared VM code instead of linux/amd64-only backend code.
- Enable managed BSD NFS shares on linux/arm64 and darwin/arm64.
- Add bounded, transport-explicit NFS mount setup for BSD guests and UDP mountd/rpcbind support.
- Route BSD NFS setup through ExecStream and skip duplicate remounts.
- Add focused NFS and VM tests.

## Root Cause

BSD built-in guests advertised dynamic NFS shares, but the implementation lived in a linux/amd64-only backend. The arm64 backends rejected shares, and the shell/runtime flow could re-enter backend run handling while trying to install the host share.

## Validation

- `go test ./internal/nfs ./internal/vm -run 'TestManager|TestBSDNFSInstance|TestMountCommand|TestRPCBind|TestMountReply' -count=1`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/vm-linux-amd64.test ./internal/vm`
- `GOOS=linux GOARCH=arm64 go test -c -o /tmp/vm-linux-arm64.test ./internal/vm`
- `GOOS=darwin GOARCH=arm64 go test -c -o /tmp/vm-darwin-arm64.test ./internal/vm`
- Local darwin/arm64 runtime probes through vmsh for FreeBSD, OpenBSD, and NetBSD host-share read/write.