### PR TITLE
Fix NFS parent directory identity

### DIFF
--- a/internal/nfs/server.go
+++ b/internal/nfs/server.go
@@ -930,12 +930,16 @@ func (s *Server) handleReaddir(proc uint32, r *xdrReader, w *xdrWriter) ([]byte,
 	}
 	for i := start; i < len(entries); i++ {
 		ent := entries[i]
+		childID, childAttr, childErr := lookupDirent(exp.Backend, node, ent)
+		fileID := ent.ino
+		if childErr == 0 {
+			fileID = childAttr.Ino
+		}
 		w.Bool(true)
-		w.Uint64(ent.ino)
+		w.Uint64(fileID)
 		w.String(ent.name)
 		w.Uint64(uint64(i + 1))
 		if proc == nfsProcReaddirPlus {
-			childID, childAttr, childErr := lookupDirent(exp.Backend, node, ent)
 			if childErr == 0 {
 				writePostOpAttr(w, childAttr)
 				w.Bool(true)
@@ -957,8 +961,7 @@ func lookupDirent(backend virtio.FSBackend, parent uint64, ent fuseDirent) (uint
 		attr, errno := backend.GetAttr(parent)
 		return parent, attr, errno
 	case "..":
-		attr, errno := backend.GetAttr(parent)
-		return parent, attr, errno
+		return backend.Lookup(parent, ent.name)
 	default:
 		return backend.Lookup(parent, ent.name)
 	}

--- a/internal/nfs/server_test.go
+++ b/internal/nfs/server_test.go
@@ -168,6 +168,95 @@ func TestFSInfoResponseIncludesProperties(t *testing.T) {
 	}
 }
 
+func TestReadDirPlusParentEntryUsesParentHandle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "a", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server := New(nil)
+	exp, err := server.AddShare(client.ShareMount{Source: dir, Mount: "/host"})
+	if err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	aID := lookupNode(t, server, exp, 1, "a")
+	bID := lookupNode(t, server, exp, aID, "b")
+
+	req := xdrWriter{}
+	req.Opaque(fileHandle(exp.ID, bID))
+	req.Uint64(0)
+	req.FixedOpaque(make([]byte, 8))
+	req.Uint32(4096)
+	req.Uint32(4096)
+	body, err := server.handleNFSProc(nfsProcReaddirPlus, req.Bytes())
+	if err != nil {
+		t.Fatalf("READDIRPLUS: %v", err)
+	}
+	r := newXDRReader(body)
+	status, _ := r.Uint32()
+	if status != nfsOK {
+		t.Fatalf("READDIRPLUS status = %d", status)
+	}
+	if err := skipPostOpAttr(r); err != nil {
+		t.Fatal(err)
+	}
+	if err := skipFixedOpaque(r, 8); err != nil {
+		t.Fatal(err)
+	}
+	handles := map[string]uint64{}
+	fileIDs := map[string]uint64{}
+	attrFileIDs := map[string]uint64{}
+	for {
+		present, err := r.Uint32()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if present == 0 {
+			break
+		}
+		fileID, _ := r.Uint64()
+		name, err := r.String(255)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[name] = fileID
+		_, _ = r.Uint64()
+		attrFileID, haveAttr, err := readPostOpAttrFileID(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if haveAttr {
+			attrFileIDs[name] = attrFileID
+		}
+		haveHandle, err := r.Uint32()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if haveHandle != 0 {
+			fh, err := r.Opaque(64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, nodeID, err := parseFileHandle(newXDRReader(encodeOpaque(fh)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			handles[name] = nodeID
+		}
+	}
+	if got := handles["."]; got != bID {
+		t.Fatalf("READDIRPLUS . handle node = %d, want %d", got, bID)
+	}
+	if got := handles[".."]; got != aID {
+		t.Fatalf("READDIRPLUS .. handle node = %d, want %d", got, aID)
+	}
+	if fileIDs[".."] == 0 || attrFileIDs[".."] == 0 {
+		t.Fatalf("READDIRPLUS .. file IDs missing: entry=%d attr=%d", fileIDs[".."], attrFileIDs[".."])
+	}
+	if fileIDs[".."] != attrFileIDs[".."] {
+		t.Fatalf("READDIRPLUS .. file ID = %d, attr file ID = %d", fileIDs[".."], attrFileIDs[".."])
+	}
+}
+
 func TestRPCBindGetAddrReturnsTCPUniversalAddress(t *testing.T) {
 	server := New(nil)
 	req := xdrWriter{}
@@ -301,6 +390,88 @@ func skipFAttr(r *xdrReader) error {
 		}
 	}
 	return nil
+}
+
+func skipPostOpAttr(r *xdrReader) error {
+	present, err := r.Uint32()
+	if err != nil || present == 0 {
+		return err
+	}
+	return skipFAttr(r)
+}
+
+func readPostOpAttrFileID(r *xdrReader) (uint64, bool, error) {
+	present, err := r.Uint32()
+	if err != nil || present == 0 {
+		return 0, false, err
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := r.Uint32(); err != nil {
+			return 0, false, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := r.Uint64(); err != nil {
+			return 0, false, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := r.Uint32(); err != nil {
+			return 0, false, err
+		}
+	}
+	if _, err := r.Uint64(); err != nil {
+		return 0, false, err
+	}
+	fileID, err := r.Uint64()
+	if err != nil {
+		return 0, false, err
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := r.Uint32(); err != nil {
+			return 0, false, err
+		}
+	}
+	return fileID, true, nil
+}
+
+func skipFixedOpaque(r *xdrReader, n int) error {
+	if r.remaining() < n+xdrPad(n) {
+		return os.ErrInvalid
+	}
+	r.off += n + xdrPad(n)
+	return nil
+}
+
+func encodeOpaque(data []byte) []byte {
+	w := xdrWriter{}
+	w.Opaque(data)
+	return w.Bytes()
+}
+
+func lookupNode(t *testing.T, server *Server, exp *Export, parent uint64, name string) uint64 {
+	t.Helper()
+	req := xdrWriter{}
+	req.Opaque(fileHandle(exp.ID, parent))
+	req.String(name)
+	body, err := server.handleNFSProc(nfsProcLookup, req.Bytes())
+	if err != nil {
+		t.Fatalf("LOOKUP %s: %v", name, err)
+	}
+	r := newXDRReader(body)
+	status, _ := r.Uint32()
+	if status != nfsOK {
+		t.Fatalf("LOOKUP %s status = %d", name, status)
+	}
+	fh, err := r.Opaque(64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, nodeID, err := parseFileHandle(newXDRReader(encodeOpaque(fh)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nodeID
 }
 
 func contains(s, sub string) bool {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -3092,10 +3092,22 @@ func (p *passthroughFS) Lookup(parent uint64, name string) (uint64, FuseAttr, in
 	if errno != 0 {
 		return 0, FuseAttr{}, errno
 	}
-	rel, ok := cleanChildName(name)
-	if !ok {
+	switch name {
+	case ".":
 		attr, errno := p.GetAttr(parent)
 		return parent, attr, errno
+	case "..":
+		guestPath := path.Dir(guestParent)
+		if guestPath == "." {
+			guestPath = "/"
+		}
+		nodeID := p.ensureNode(guestPath)
+		attr, errno := p.GetAttr(nodeID)
+		return nodeID, attr, errno
+	}
+	rel, ok := cleanChildName(name)
+	if !ok {
+		return 0, FuseAttr{}, -linuxEINVAL
 	}
 	host := filepath.Join(hostParent, filepath.FromSlash(rel))
 	info, err := os.Lstat(host)
@@ -3371,9 +3383,13 @@ func (p *passthroughFS) OpenDir(nodeID uint64, _ uint32) (uint64, int32) {
 	if err != nil {
 		return 0, errnoFromError(err)
 	}
+	parentID := nodeID
+	if guest != "/" {
+		parentID = p.ensureNode(path.Dir(guest))
+	}
 	dirEntries := []dirEntry{
 		{name: ".", typ: dirTypeDir, ino: nodeID},
-		{name: "..", typ: dirTypeDir, ino: nodeID},
+		{name: "..", typ: dirTypeDir, ino: parentID},
 	}
 	for _, entry := range entries {
 		childPath := joinGuestChild(guest, entry.Name())
@@ -3871,16 +3887,26 @@ func (p *imageFS) Lookup(parent uint64, name string) (uint64, FuseAttr, int32) {
 		p.mu.Unlock()
 		return 0, FuseAttr{}, -linuxENOENT
 	}
+	switch name {
+	case ".":
+		attr := p.attr(parentNode)
+		p.mu.Unlock()
+		return parentNode.id, attr, 0
+	case "..":
+		node := p.nodes[parentNode.parent]
+		if node == nil {
+			p.mu.Unlock()
+			return 0, FuseAttr{}, -linuxENOENT
+		}
+		attr := p.attr(node)
+		p.mu.Unlock()
+		return node.id, attr, 0
+	}
 	var ok bool
 	name, ok = cleanChildName(name)
 	if !ok {
 		p.mu.Unlock()
 		return 0, FuseAttr{}, -linuxEINVAL
-	}
-	if name == "." {
-		attr := p.attr(parentNode)
-		p.mu.Unlock()
-		return parentNode.id, attr, 0
 	}
 	p.debugChildfLocked("lookup", parent, name, "")
 	childID, ok := parentNode.entries[name]

--- a/internal/virtio/fs_passthrough_test.go
+++ b/internal/virtio/fs_passthrough_test.go
@@ -1,0 +1,64 @@
+package virtio
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPassthroughFSParentLookupAndReadDirUseParentNode(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewPassthroughFS(root, nil)
+	aID, _, errno := fsys.Lookup(1, "a")
+	if errno != 0 {
+		t.Fatalf("lookup a errno = %d", errno)
+	}
+	bID, _, errno := fsys.Lookup(aID, "b")
+	if errno != 0 {
+		t.Fatalf("lookup b errno = %d", errno)
+	}
+	parentID, _, errno := fsys.Lookup(bID, "..")
+	if errno != 0 {
+		t.Fatalf("lookup .. errno = %d", errno)
+	}
+	if parentID != aID {
+		t.Fatalf("lookup .. node = %d, want %d", parentID, aID)
+	}
+
+	fh, errno := fsys.OpenDir(bID, 0)
+	if errno != 0 {
+		t.Fatalf("opendir b errno = %d", errno)
+	}
+	defer fsys.ReleaseDir(bID, fh)
+	data, errno := fsys.ReadDir(bID, fh, 0, 4096)
+	if errno != 0 {
+		t.Fatalf("readdir b errno = %d", errno)
+	}
+	entries := parseTestFuseDirents(data)
+	if got := entries["."]; got != bID {
+		t.Fatalf("readdir . ino = %d, want %d", got, bID)
+	}
+	if got := entries[".."]; got != aID {
+		t.Fatalf("readdir .. ino = %d, want %d", got, aID)
+	}
+}
+
+func parseTestFuseDirents(data []byte) map[string]uint64 {
+	out := map[string]uint64{}
+	for off := 0; off+fuseDirentBaseSize <= len(data); {
+		ino := binary.LittleEndian.Uint64(data[off:])
+		nameLen := int(binary.LittleEndian.Uint32(data[off+16:]))
+		recLen := align8(fuseDirentBaseSize + nameLen)
+		if off+recLen > len(data) || off+fuseDirentBaseSize+nameLen > len(data) {
+			break
+		}
+		name := string(data[off+fuseDirentBaseSize : off+fuseDirentBaseSize+nameLen])
+		out[name] = ino
+		off += recLen
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- resolve `.` and `..` to real parent nodes in passthrough/image filesystem lookups
- return the real parent node from passthrough readdir `..` entries
- make NFS READDIR/READDIRPLUS file IDs match the attributes returned for each entry

## Tests
- `go test ./internal/virtio ./internal/nfs`
- `go test ./... -run '^$' -timeout 60s`

Related to tinyrange/vmsh#62.