### PR TITLE
Embed native BSD guest init payloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,4 +112,9 @@ jobs:
           set -euo pipefail
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -o internal/guestinit/guest-init-linux-arm64 ./internal/cmd/init
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o internal/guestinit/guest-init-linux-amd64 ./internal/cmd/init
+          for goarch in arm64 amd64; do
+            for bsd in openbsd freebsd netbsd; do
+              CGO_ENABLED=0 GOOS="$bsd" GOARCH="$goarch" go build -trimpath -o "internal/${bsd}/guestinit/guest-init-${bsd}-${goarch}" "./internal/cmd/${bsd}-init"
+            done
+          done
           go test -tags embed_guestinit -p 1 ./... -count=1 -timeout 75m

--- a/cmd/ccvm/main.go
+++ b/cmd/ccvm/main.go
@@ -3,15 +3,29 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"j5.nz/cc/internal/ccvmd"
+	freebsdguestinit "j5.nz/cc/internal/freebsd/guestinit"
 	"j5.nz/cc/internal/guestinit"
+	netbsdguestinit "j5.nz/cc/internal/netbsd/guestinit"
+	openbsdguestinit "j5.nz/cc/internal/openbsd/guestinit"
 )
 
 func main() {
 	if err := guestinit.RequireEmbedded(); err != nil {
 		fmt.Fprintln(os.Stderr, "ccvm:", err)
 		os.Exit(1)
+	}
+	for _, check := range []func(string) error{
+		openbsdguestinit.RequireEmbeddedForArch,
+		freebsdguestinit.RequireEmbeddedForArch,
+		netbsdguestinit.RequireEmbeddedForArch,
+	} {
+		if err := check(runtime.GOARCH); err != nil {
+			fmt.Fprintln(os.Stderr, "ccvm:", err)
+			os.Exit(1)
+		}
 	}
 	ccvmd.Main(os.Args[1:])
 }

--- a/internal/freebsd/guestinit/guestinit.go
+++ b/internal/freebsd/guestinit/guestinit.go
@@ -17,6 +17,9 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 	if arch == "" {
 		arch = "amd64"
 	}
+	if payload := embeddedPayload(arch); len(payload) != 0 {
+		return append([]byte(nil), payload...), nil
+	}
 	if cacheDir == "" {
 		var err error
 		cacheDir, err = os.MkdirTemp("", "cc-freebsd-guestinit-*")
@@ -45,4 +48,18 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 		return nil, fmt.Errorf("read FreeBSD guest init: %w", err)
 	}
 	return bin, nil
+}
+
+func RequireEmbeddedForArch(arch string) error {
+	return validateEmbeddedPayload("FreeBSD", arch, embeddedPayload(arch))
+}
+
+func validateEmbeddedPayload(name, arch string, payload []byte) error {
+	if len(payload) == 0 {
+		return fmt.Errorf("%s guest init payload for %q is not embedded; build ccvm with -tags embed_guestinit", name, arch)
+	}
+	if len(payload) < 4 || string(payload[:4]) != "\x7fELF" {
+		return fmt.Errorf("%s guest init payload for %q is not an ELF binary", name, arch)
+	}
+	return nil
 }

--- a/internal/freebsd/guestinit/payload_embed_amd64.go
+++ b/internal/freebsd/guestinit/payload_embed_amd64.go
@@ -1,0 +1,15 @@
+//go:build embed_guestinit && amd64
+
+package guestinit
+
+import _ "embed"
+
+//go:embed guest-init-freebsd-amd64
+var guestInitFreeBSD []byte
+
+func embeddedPayload(arch string) []byte {
+	if arch == "amd64" {
+		return guestInitFreeBSD
+	}
+	return nil
+}

--- a/internal/freebsd/guestinit/payload_embed_arm64.go
+++ b/internal/freebsd/guestinit/payload_embed_arm64.go
@@ -1,0 +1,15 @@
+//go:build embed_guestinit && arm64
+
+package guestinit
+
+import _ "embed"
+
+//go:embed guest-init-freebsd-arm64
+var guestInitFreeBSD []byte
+
+func embeddedPayload(arch string) []byte {
+	if arch == "arm64" {
+		return guestInitFreeBSD
+	}
+	return nil
+}

--- a/internal/freebsd/guestinit/payload_empty.go
+++ b/internal/freebsd/guestinit/payload_empty.go
@@ -1,0 +1,7 @@
+//go:build !embed_guestinit || (!amd64 && !arm64)
+
+package guestinit
+
+func embeddedPayload(arch string) []byte {
+	return nil
+}

--- a/internal/netbsd/guestinit/guestinit.go
+++ b/internal/netbsd/guestinit/guestinit.go
@@ -17,6 +17,9 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 	if arch == "" {
 		arch = "amd64"
 	}
+	if payload := embeddedPayload(arch); len(payload) != 0 {
+		return append([]byte(nil), payload...), nil
+	}
 	if cacheDir == "" {
 		var err error
 		cacheDir, err = os.MkdirTemp("", "cc-netbsd-guestinit-*")
@@ -47,4 +50,18 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 		return nil, fmt.Errorf("read NetBSD guest init: %w", err)
 	}
 	return data, nil
+}
+
+func RequireEmbeddedForArch(arch string) error {
+	return validateEmbeddedPayload("NetBSD", arch, embeddedPayload(arch))
+}
+
+func validateEmbeddedPayload(name, arch string, payload []byte) error {
+	if len(payload) == 0 {
+		return fmt.Errorf("%s guest init payload for %q is not embedded; build ccvm with -tags embed_guestinit", name, arch)
+	}
+	if len(payload) < 4 || string(payload[:4]) != "\x7fELF" {
+		return fmt.Errorf("%s guest init payload for %q is not an ELF binary", name, arch)
+	}
+	return nil
 }

--- a/internal/netbsd/guestinit/payload_embed_amd64.go
+++ b/internal/netbsd/guestinit/payload_embed_amd64.go
@@ -1,0 +1,15 @@
+//go:build embed_guestinit && amd64
+
+package guestinit
+
+import _ "embed"
+
+//go:embed guest-init-netbsd-amd64
+var guestInitNetBSD []byte
+
+func embeddedPayload(arch string) []byte {
+	if arch == "amd64" {
+		return guestInitNetBSD
+	}
+	return nil
+}

--- a/internal/netbsd/guestinit/payload_embed_arm64.go
+++ b/internal/netbsd/guestinit/payload_embed_arm64.go
@@ -1,0 +1,15 @@
+//go:build embed_guestinit && arm64
+
+package guestinit
+
+import _ "embed"
+
+//go:embed guest-init-netbsd-arm64
+var guestInitNetBSD []byte
+
+func embeddedPayload(arch string) []byte {
+	if arch == "arm64" {
+		return guestInitNetBSD
+	}
+	return nil
+}

--- a/internal/netbsd/guestinit/payload_empty.go
+++ b/internal/netbsd/guestinit/payload_empty.go
@@ -1,0 +1,7 @@
+//go:build !embed_guestinit || (!amd64 && !arm64)
+
+package guestinit
+
+func embeddedPayload(arch string) []byte {
+	return nil
+}

--- a/internal/openbsd/guestinit/guestinit.go
+++ b/internal/openbsd/guestinit/guestinit.go
@@ -17,6 +17,9 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 	if arch == "" {
 		arch = "amd64"
 	}
+	if payload := embeddedPayload(arch); len(payload) != 0 {
+		return append([]byte(nil), payload...), nil
+	}
 	if cacheDir == "" {
 		var err error
 		cacheDir, err = os.MkdirTemp("", "cc-openbsd-guestinit-*")
@@ -48,4 +51,18 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 		return nil, fmt.Errorf("read OpenBSD guest init: %w", err)
 	}
 	return bin, nil
+}
+
+func RequireEmbeddedForArch(arch string) error {
+	return validateEmbeddedPayload("OpenBSD", arch, embeddedPayload(arch))
+}
+
+func validateEmbeddedPayload(name, arch string, payload []byte) error {
+	if len(payload) == 0 {
+		return fmt.Errorf("%s guest init payload for %q is not embedded; build ccvm with -tags embed_guestinit", name, arch)
+	}
+	if len(payload) < 4 || string(payload[:4]) != "\x7fELF" {
+		return fmt.Errorf("%s guest init payload for %q is not an ELF binary", name, arch)
+	}
+	return nil
 }

--- a/internal/openbsd/guestinit/payload_embed_amd64.go
+++ b/internal/openbsd/guestinit/payload_embed_amd64.go
@@ -1,0 +1,15 @@
+//go:build embed_guestinit && amd64
+
+package guestinit
+
+import _ "embed"
+
+//go:embed guest-init-openbsd-amd64
+var guestInitOpenBSD []byte
+
+func embeddedPayload(arch string) []byte {
+	if arch == "amd64" {
+		return guestInitOpenBSD
+	}
+	return nil
+}

--- a/internal/openbsd/guestinit/payload_embed_arm64.go
+++ b/internal/openbsd/guestinit/payload_embed_arm64.go
@@ -1,0 +1,15 @@
+//go:build embed_guestinit && arm64
+
+package guestinit
+
+import _ "embed"
+
+//go:embed guest-init-openbsd-arm64
+var guestInitOpenBSD []byte
+
+func embeddedPayload(arch string) []byte {
+	if arch == "arm64" {
+		return guestInitOpenBSD
+	}
+	return nil
+}

--- a/internal/openbsd/guestinit/payload_empty.go
+++ b/internal/openbsd/guestinit/payload_empty.go
@@ -1,0 +1,7 @@
+//go:build !embed_guestinit || (!amd64 && !arm64)
+
+package guestinit
+
+func embeddedPayload(arch string) []byte {
+	return nil
+}

--- a/pyneurodesk/build_backend/neurodesk_build_backend.py
+++ b/pyneurodesk/build_backend/neurodesk_build_backend.py
@@ -129,7 +129,7 @@ def has_embedded_guestinit(binary: Path) -> bool:
     except OSError:
         return False
     # A wheel ccvm must not need a source checkout at runtime to boot a VM.
-    return data.count(b"\x7fELF") >= 2
+    return data.count(b"\x7fELF") >= 5
 
 
 def build_embedded_ccvm(destination: Path, root: Path) -> None:
@@ -137,8 +137,10 @@ def build_embedded_ccvm(destination: Path, root: Path) -> None:
     goarch = python_goarch()
     if goos is None or goarch is None:
         raise RuntimeError(f"cannot infer Go target for {platform.system()}/{platform.machine()}")
-    build_guestinit_payload(root, "arm64")
-    build_guestinit_payload(root, "amd64")
+    build_linux_guestinit_payload(root, "arm64")
+    build_linux_guestinit_payload(root, "amd64")
+    for bsd in ("openbsd", "freebsd", "netbsd"):
+        build_bsd_guestinit_payload(root, bsd, goarch)
     env = os.environ.copy()
     env.update({"CGO_ENABLED": "0", "GOOS": goos, "GOARCH": goarch})
     proc = subprocess.run(
@@ -154,7 +156,7 @@ def build_embedded_ccvm(destination: Path, root: Path) -> None:
         raise RuntimeError(f"failed to build embedded ccvm binary: {detail}")
 
 
-def build_guestinit_payload(root: Path, goarch: str) -> None:
+def build_linux_guestinit_payload(root: Path, goarch: str) -> None:
     out_path = root / "build" / f"init-linux-{goarch}"
     embed_path = root / "internal" / "guestinit" / f"guest-init-linux-{goarch}"
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -171,6 +173,26 @@ def build_guestinit_payload(root: Path, goarch: str) -> None:
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or f"exit status {proc.returncode}"
         raise RuntimeError(f"failed to build guest-init payload for {goarch}: {detail}")
+    shutil.copy2(out_path, embed_path)
+
+
+def build_bsd_guestinit_payload(root: Path, bsd: str, goarch: str) -> None:
+    out_path = root / "build" / f"guest-init-{bsd}-{goarch}"
+    embed_path = root / "internal" / bsd / "guestinit" / f"guest-init-{bsd}-{goarch}"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update({"CGO_ENABLED": "0", "GOOS": bsd, "GOARCH": goarch})
+    proc = subprocess.run(
+        ["go", "build", "-o", str(out_path), f"./internal/cmd/{bsd}-init"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit status {proc.returncode}"
+        raise RuntimeError(f"failed to build {bsd}/{goarch} guest-init payload: {detail}")
     shutil.copy2(out_path, embed_path)
 
 

--- a/pyneurodesk/src/pyneurodesk/api.py
+++ b/pyneurodesk/src/pyneurodesk/api.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import json
 import os
+import platform
 import posixpath
 import re
 import subprocess
@@ -1176,6 +1177,33 @@ def _build_guestinit_payloads(root: Path) -> None:
             detail = proc.stderr.strip() or proc.stdout.strip() or f"exit status {proc.returncode}"
             raise RuntimeError(f"failed to build linux/{goarch} guest init payload: {detail}")
         embed.write_bytes(out.read_bytes())
+    goarch = _host_goarch()
+    for bsd in ("openbsd", "freebsd", "netbsd"):
+        out = build_dir / f"guest-init-{bsd}-{goarch}"
+        embed = root / "internal" / bsd / "guestinit" / f"guest-init-{bsd}-{goarch}"
+        env = os.environ.copy()
+        env.update({"CGO_ENABLED": "0", "GOOS": bsd, "GOARCH": goarch})
+        proc = subprocess.run(
+            ["go", "build", "-o", str(out), f"./internal/cmd/{bsd}-init"],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            detail = proc.stderr.strip() or proc.stdout.strip() or f"exit status {proc.returncode}"
+            raise RuntimeError(f"failed to build {bsd}/{goarch} guest init payload: {detail}")
+        embed.write_bytes(out.read_bytes())
+
+
+def _host_goarch() -> str:
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "amd64"
+    if machine in {"aarch64", "arm64"}:
+        return "arm64"
+    raise RuntimeError(f"unsupported host architecture for bundled BSD guest init: {platform.machine()}")
 
 
 def _sign_ccvm_binary_if_needed(binary_path: Path, root: Path) -> None:

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -27,6 +27,11 @@ install -m 644 "${BUILD_DIR}/init-linux-arm64" "${GUESTINIT_ARM64_EMBED_PATH}"
 GOOS=linux GOARCH=amd64 go build -o "${BUILD_DIR}/init-linux-amd64" ./internal/cmd/init
 install -m 644 "${BUILD_DIR}/init-linux-amd64" "${GUESTINIT_AMD64_EMBED_PATH}"
 
+for bsd in openbsd freebsd netbsd; do
+  GOOS="${bsd}" GOARCH="${TARGET_GOARCH}" go build -o "${BUILD_DIR}/guest-init-${bsd}-${TARGET_GOARCH}" "./internal/cmd/${bsd}-init"
+  install -m 644 "${BUILD_DIR}/guest-init-${bsd}-${TARGET_GOARCH}" "${ROOT_DIR}/internal/${bsd}/guestinit/guest-init-${bsd}-${TARGET_GOARCH}"
+done
+
 GOOS="${TARGET_GOOS}" GOARCH="${TARGET_GOARCH}" go build -tags embed_guestinit -o "${CCVM_OUTPUT}" ./cmd/ccvm
 GOOS="${TARGET_GOOS}" GOARCH="${TARGET_GOARCH}" go build -o "${BUILD_DIR}/cc-${TARGET_GOOS}-${TARGET_GOARCH}${TARGET_SUFFIX}" ./cmd/cc
 

--- a/tools/fs_benchmark.py
+++ b/tools/fs_benchmark.py
@@ -458,6 +458,23 @@ def build_guestinit_payloads() -> None:
         env.update({"CGO_ENABLED": "0", "GOOS": "linux", "GOARCH": goarch})
         subprocess.run(["go", "build", "-o", str(out), "./internal/cmd/init"], cwd=REPO_ROOT, env=env, check=True)
         embed.write_bytes(out.read_bytes())
+    goarch = host_goarch()
+    for bsd in ("openbsd", "freebsd", "netbsd"):
+        out = build_dir / f"guest-init-{bsd}-{goarch}"
+        embed = REPO_ROOT / "internal" / bsd / "guestinit" / f"guest-init-{bsd}-{goarch}"
+        env = os.environ.copy()
+        env.update({"CGO_ENABLED": "0", "GOOS": bsd, "GOARCH": goarch})
+        subprocess.run(["go", "build", "-o", str(out), f"./internal/cmd/{bsd}-init"], cwd=REPO_ROOT, env=env, check=True)
+        embed.write_bytes(out.read_bytes())
+
+
+def host_goarch() -> str:
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "amd64"
+    if machine in {"aarch64", "arm64"}:
+        return "arm64"
+    raise RuntimeError(f"unsupported host architecture for bundled BSD guest init: {platform.machine()}")
 
 
 def benchmark_args(label: str, work_dir: str, args: argparse.Namespace) -> list[str]:

--- a/tools/publish_neurodesk.sh
+++ b/tools/publish_neurodesk.sh
@@ -139,6 +139,8 @@ target_binary_name() {
 }
 
 build_guestinit_payloads() {
+  local target_goarch="$1"
+
   mkdir -p "${ROOT_DIR}/build"
   CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
     go build -o "${ROOT_DIR}/build/init-linux-arm64" ./internal/cmd/init
@@ -147,6 +149,13 @@ build_guestinit_payloads() {
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -o "${ROOT_DIR}/build/init-linux-amd64" ./internal/cmd/init
   install -m 644 "${ROOT_DIR}/build/init-linux-amd64" "${GUESTINIT_AMD64_EMBED_PATH}"
+
+  for bsd in openbsd freebsd netbsd; do
+    CGO_ENABLED=0 GOOS="${bsd}" GOARCH="${target_goarch}" \
+      go build -o "${ROOT_DIR}/build/guest-init-${bsd}-${target_goarch}" "./internal/cmd/${bsd}-init"
+    install -m 644 "${ROOT_DIR}/build/guest-init-${bsd}-${target_goarch}" \
+      "${ROOT_DIR}/internal/${bsd}/guestinit/guest-init-${bsd}-${target_goarch}"
+  done
 }
 
 build_ccvm_for_target() {
@@ -156,6 +165,8 @@ build_ccvm_for_target() {
   local suffix
   suffix="$(target_suffix "${target}")"
   local output="${ROOT_DIR}/build/ccvm-${goos}-${goarch}${suffix}"
+
+  build_guestinit_payloads "${goarch}"
 
   CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" \
     go build -tags embed_guestinit -o "${output}" ./cmd/ccvm


### PR DESCRIPTION
## Summary

- Embed native OpenBSD, FreeBSD, and NetBSD guest init payloads for the target architecture when building with `embed_guestinit`.
- Keep the existing source-tree `go build` path as a development fallback.
- Extend `ccvm` startup validation so release-style embedded builds fail early if BSD init payloads are missing.
- Update cc packaging/build helpers that produce embedded `ccvm` binaries so they generate the native BSD init payloads first.

## Testing

- `go test ./cmd/ccvm ./internal/openbsd/guestinit ./internal/freebsd/guestinit ./internal/netbsd/guestinit`
- `go test ./internal/openbsd/rootfs ./internal/freebsd/rootfs ./internal/netbsd/rootfs`
- `python3 -m py_compile pyneurodesk/build_backend/neurodesk_build_backend.py pyneurodesk/src/pyneurodesk/api.py tools/fs_benchmark.py`
- `bash -n tools/build.sh tools/publish_neurodesk.sh`
- From vmsh checkout: `go run ./tools --build-dir build/vmsh-bsd-init-size build`
- Started built `ccvm`; it emitted a server banner successfully.
