### PR TITLE
Fix Darwin sidecar networking leases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /.tmp-virtiofs-exit-sweep
 /internal/guestinit/guest-init-linux-arm64
 /internal/guestinit/guest-init-linux-amd64
+/internal/freebsd/guestinit/guest-init-freebsd-arm64
+/internal/netbsd/guestinit/guest-init-netbsd-arm64
+/internal/openbsd/guestinit/guest-init-openbsd-arm64
 /tools/__pycache__
 /tools/*.pyc
 /tools/*.pyo

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -300,6 +300,8 @@ type NetworkConfig struct {
 	Enabled                  bool          `json:"enabled,omitempty"`
 	AllowInternet            bool          `json:"allow_internet,omitempty"`
 	BlockHostAccess          bool          `json:"block_host_access,omitempty"`
+	GuestIPv4                string        `json:"guest_ipv4,omitempty"`
+	GuestMAC                 string        `json:"guest_mac,omitempty"`
 	HostDNSName              string        `json:"host_dns_name,omitempty"`
 	AllowedServiceProxyPorts []int         `json:"allowed_service_proxy_ports,omitempty"`
 	PortForwards             []PortForward `json:"port_forwards,omitempty"`

--- a/internal/vm/backend_builtin_bsd_darwin_arm64.go
+++ b/internal/vm/backend_builtin_bsd_darwin_arm64.go
@@ -172,7 +172,7 @@ func (b *runtimeBackend) startBSDArm64ManagedStream(ctx context.Context, req cli
 	if def.BuildArtifact == nil {
 		return nil, fmt.Errorf("%s runtime root builder is not configured", displayName)
 	}
-	network, err := newDarwinARM64NetworkRuntime(managedBSDNetworkConfig(req.Network))
+	network, err := newDarwinARM64NetworkRuntime(req.ID, managedBSDNetworkConfig(req.Network))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/backend_darwin_arm64.go
+++ b/internal/vm/backend_darwin_arm64.go
@@ -146,7 +146,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		return inst, err
 	}
 	start := time.Now()
-	network, err := newDarwinARM64NetworkRuntime(req.Network)
+	network, err := newDarwinARM64NetworkRuntime(req.ID, req.Network)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (b *runtimeBackend) StartBlankStream(
 		return inst, err
 	}
 	start := time.Now()
-	network, err := newDarwinARM64NetworkRuntime(req.Network)
+	network, err := newDarwinARM64NetworkRuntime(req.ID, req.Network)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 	if resp, ok, err := b.runBuiltinGuest(ctx, req); ok || err != nil {
 		return resp, err
 	}
-	network, err := newDarwinARM64NetworkRuntime(req.Network)
+	network, err := newDarwinARM64NetworkRuntime(req.ID, req.Network)
 	if err != nil {
 		return client.ExecResponse{}, err
 	}

--- a/internal/vm/execplan/execplan.go
+++ b/internal/vm/execplan/execplan.go
@@ -66,6 +66,7 @@ func ResolveExecRequest(req client.ExecRequest, resolver Resolver) (client.ExecR
 		skipResolve = true
 	}
 	return client.ExecRequest{
+		ID:          req.ID,
 		Kind:        req.Kind,
 		Command:     command,
 		Env:         env,
@@ -86,6 +87,7 @@ func ResolveExecRequest(req client.ExecRequest, resolver Resolver) (client.ExecR
 
 func ResolveRunRequest(req client.RunRequest, rootDir string, resolver Resolver) (client.ExecRequest, error) {
 	execReq := client.ExecRequest{
+		ID:         req.ID,
 		Command:    append([]string(nil), req.Command...),
 		Env:        append([]string(nil), req.Env...),
 		RootDir:    rootDir,
@@ -113,6 +115,7 @@ func ControlRequest(req client.ExecRequest, defaultWorkDir string) client.ExecRe
 		workDir = defaultWorkDir
 	}
 	return client.ExecRequest{
+		ID:        req.ID,
 		Kind:      req.Kind,
 		RootDir:   req.RootDir,
 		Path:      req.Path,

--- a/internal/vm/execplan/execplan_test.go
+++ b/internal/vm/execplan/execplan_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestResolveExecRequest(t *testing.T) {
 	got, err := ResolveExecRequest(client.ExecRequest{
+		ID:      "exec-7",
 		Command: []string{"tool", "arg"},
 		Env:     []string{"EXTRA=1"},
 		Stdin:   []byte("input"),
@@ -36,6 +37,9 @@ func TestResolveExecRequest(t *testing.T) {
 	}
 	if strings.Join(got.Command, " ") != "/bin/tool arg" {
 		t.Fatalf("command = %#v", got.Command)
+	}
+	if got.ID != "exec-7" {
+		t.Fatalf("id = %q", got.ID)
 	}
 	if got.WorkDir != "/work" {
 		t.Fatalf("workdir = %q", got.WorkDir)
@@ -90,6 +94,7 @@ func TestResolveExecRequestCanMarkHostResolved(t *testing.T) {
 
 func TestResolveRunRequestMarksResolvedAlternateRoot(t *testing.T) {
 	got, err := ResolveRunRequest(client.RunRequest{
+		ID:      "exec-9",
 		Command: []string{"tool"},
 		Env:     []string{"EXTRA=1"},
 		Stdin:   []byte("input"),
@@ -106,6 +111,9 @@ func TestResolveRunRequestMarksResolvedAlternateRoot(t *testing.T) {
 	}
 	if strings.Join(got.Command, " ") != "/bin/tool" {
 		t.Fatalf("command = %#v", got.Command)
+	}
+	if got.ID != "exec-9" {
+		t.Fatalf("id = %q", got.ID)
 	}
 	if got.RootDir != "/run/image" {
 		t.Fatalf("rootdir = %q", got.RootDir)

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -63,6 +63,9 @@ func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	if len(inst.execStreamReqs) != 1 {
 		t.Fatalf("instance exec stream reqs = %+v", inst.execStreamReqs)
 	}
+	if inst.execStreamReqs[0].ID == "" || inst.execStreamReqs[0].ID == "alpha" {
+		t.Fatalf("run stream exec id = %q, want unique guest exec id", inst.execStreamReqs[0].ID)
+	}
 	if len(runEvents) == 0 || runEvents[len(runEvents)-1].Kind != "exit" {
 		t.Fatalf("run stream events = %+v", runEvents)
 	}
@@ -73,11 +76,16 @@ func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	if len(inst.execStreamReqs) != 2 {
 		t.Fatalf("exec stream count = %d, want 2", len(inst.execStreamReqs))
 	}
+	if inst.execStreamReqs[1].ID == "" || inst.execStreamReqs[1].ID == "alpha" || inst.execStreamReqs[1].ID == inst.execStreamReqs[0].ID {
+		t.Fatalf("exec stream ids = %q, %q; want unique guest exec ids", inst.execStreamReqs[0].ID, inst.execStreamReqs[1].ID)
+	}
 	if err := manager.StreamIn(ctx, "alpha", client.ExecRequest{Image: "other", Command: []string{"true"}}, nil, nil); err != nil {
 		t.Fatalf("multi-image exec stream: %v", err)
 	}
 	if got := host.execInStreamCalls(); len(got) != 1 || got[0].runningImage != "alpine" || got[0].req.Image != "other" {
 		t.Fatalf("host exec-in-stream calls = %+v", got)
+	} else if got[0].req.ID == "" || got[0].req.ID == "alpha" || got[0].req.ID == inst.execStreamReqs[0].ID || got[0].req.ID == inst.execStreamReqs[1].ID {
+		t.Fatalf("alternate exec stream id = %q, previous ids = %q/%q", got[0].req.ID, inst.execStreamReqs[0].ID, inst.execStreamReqs[1].ID)
 	}
 }
 
@@ -136,6 +144,113 @@ func TestManagerRunWithoutInstanceRequiresOrUsesImage(t *testing.T) {
 	}
 	if len(events) == 0 || events[len(events)-1].Kind != "exit" {
 		t.Fatalf("run stream events = %+v", events)
+	}
+}
+
+func TestManagerAssignsDistinctNetworkLeasesBeforeStart(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
+	host.queueInstance(newFakeInstance())
+	host.queueInstance(newFakeInstance())
+	manager := testManager(host)
+	defer manager.ShutdownAll(ctx)
+
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "freebsd", Image: "@freebsd", Network: &client.NetworkConfig{Enabled: true}}); err != nil {
+		t.Fatalf("start freebsd: %v", err)
+	}
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "openbsd", Image: "@openbsd", Network: &client.NetworkConfig{Enabled: true}}); err != nil {
+		t.Fatalf("start openbsd: %v", err)
+	}
+
+	if len(host.starts) != 2 {
+		t.Fatalf("starts = %+v", host.starts)
+	}
+	first := host.starts[0].Network
+	second := host.starts[1].Network
+	if first == nil || second == nil {
+		t.Fatalf("network configs = %+v, %+v", first, second)
+	}
+	if first.GuestIPv4 != "10.42.0.2" || second.GuestIPv4 != "10.42.0.3" {
+		t.Fatalf("guest IPv4 leases = %q, %q", first.GuestIPv4, second.GuestIPv4)
+	}
+	if first.GuestMAC != "02:42:0a:2a:00:02" || second.GuestMAC != "02:42:0a:2a:00:03" {
+		t.Fatalf("guest MAC leases = %q, %q", first.GuestMAC, second.GuestMAC)
+	}
+}
+
+func TestManagerAssignsNetworkLeasesForBuiltinDefaultNetwork(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
+	host.queueInstance(newFakeInstance())
+	host.queueInstance(newFakeInstance())
+	manager := testManager(host)
+	defer manager.ShutdownAll(ctx)
+
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "freebsd", Image: "@freebsd"}); err != nil {
+		t.Fatalf("start freebsd: %v", err)
+	}
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "openbsd", Image: "@openbsd"}); err != nil {
+		t.Fatalf("start openbsd: %v", err)
+	}
+
+	if len(host.starts) != 2 {
+		t.Fatalf("starts = %+v", host.starts)
+	}
+	first := host.starts[0].Network
+	second := host.starts[1].Network
+	if first == nil || second == nil {
+		t.Fatalf("network configs = %+v, %+v", first, second)
+	}
+	if !first.Enabled || !second.Enabled {
+		t.Fatalf("network enabled = %v, %v", first.Enabled, second.Enabled)
+	}
+	if first.GuestIPv4 != "10.42.0.2" || second.GuestIPv4 != "10.42.0.3" {
+		t.Fatalf("guest IPv4 leases = %q, %q", first.GuestIPv4, second.GuestIPv4)
+	}
+	if first.GuestMAC != "02:42:0a:2a:00:02" || second.GuestMAC != "02:42:0a:2a:00:03" {
+		t.Fatalf("guest MAC leases = %q, %q", first.GuestMAC, second.GuestMAC)
+	}
+}
+
+func TestManagerConcurrentStreamsUseDistinctGuestExecIDs(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
+	inst := newFakeInstance()
+	host.queueInstance(inst)
+	manager := testManager(host)
+	defer manager.ShutdownAll(ctx)
+
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "alpha", Image: "alpine"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	started := make(chan client.ExecRequest, 2)
+	release := make(chan struct{})
+	inst.execStream = func(req client.ExecRequest, onEvent func(client.ExecEvent) error) error {
+		started <- req
+		<-release
+		return emitFakeExecEvents(onEvent, strings.Join(req.Command, " "))
+	}
+
+	errs := make(chan error, 2)
+	go func() {
+		errs <- manager.RunStreamIn(ctx, "alpha", client.RunRequest{Command: []string{"one"}}, nil, nil)
+	}()
+	go func() {
+		errs <- manager.RunStreamIn(ctx, "alpha", client.RunRequest{Command: []string{"two"}}, nil, nil)
+	}()
+
+	first := <-started
+	second := <-started
+	if first.ID == "" || second.ID == "" || first.ID == second.ID || first.ID == "alpha" || second.ID == "alpha" {
+		close(release)
+		t.Fatalf("concurrent exec ids = %q, %q; want unique guest exec ids", first.ID, second.ID)
+	}
+	close(release)
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("stream %d: %v", i, err)
+		}
 	}
 }
 
@@ -394,6 +509,7 @@ type fakeInstance struct {
 	snapshots      map[string]imagefs.Directory
 	stats          []virtio.FSStats
 	ipv4           string
+	execStream     func(client.ExecRequest, func(client.ExecEvent) error) error
 }
 
 func newFakeInstance() *fakeInstance {
@@ -429,6 +545,9 @@ func (i *fakeInstance) ExecStream(_ context.Context, req client.ExecRequest, _ <
 	i.mu.Lock()
 	i.execStreamReqs = append(i.execStreamReqs, req)
 	i.mu.Unlock()
+	if i.execStream != nil {
+		return i.execStream(req, onEvent)
+	}
 	return emitFakeExecEvents(onEvent, strings.Join(req.Command, " "))
 }
 

--- a/internal/vm/network_common.go
+++ b/internal/vm/network_common.go
@@ -55,7 +55,21 @@ func newNetworkRuntime(cfg networkDeviceConfig) (_ *networkRuntime, retErr error
 		return nil, nil
 	}
 	if cfg.IP == nil {
+		if ip := net.ParseIP(strings.TrimSpace(cfg.Config.GuestIPv4)).To4(); ip != nil {
+			cfg.IP = ip
+		}
+	}
+	if cfg.IP == nil {
 		cfg.IP = net.IPv4(10, 42, 0, 2)
+	}
+	if cfg.MAC == nil {
+		if macText := strings.TrimSpace(cfg.Config.GuestMAC); macText != "" {
+			mac, err := net.ParseMAC(macText)
+			if err != nil {
+				return nil, fmt.Errorf("parse guest network MAC %q: %w", macText, err)
+			}
+			cfg.MAC = mac
+		}
 	}
 	if cfg.MAC == nil {
 		cfg.MAC = net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}

--- a/internal/vm/network_darwin_arm64.go
+++ b/internal/vm/network_darwin_arm64.go
@@ -17,24 +17,49 @@ import (
 
 type darwinNetworkRuntime struct {
 	*networkRuntime
+	switchID string
+	closeFn  func() error
 }
 
-func newDarwinARM64NetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRuntime, error) {
+func newDarwinARM64NetworkRuntime(id string, cfg *client.NetworkConfig) (*darwinNetworkRuntime, error) {
 	if remote, err := newDarwinRemoteNetworkRuntime(cfg); err != nil || remote != nil {
 		return remote, err
 	}
+	lease, explicit := darwinSidecarLeaseFromConfig(id, cfg)
+	if !explicit {
+		lease = defaultDarwinSidecarSwitch.Register(id)
+	}
 	common, err := newNetworkRuntime(networkDeviceConfig{
+		ID:     lease.id,
 		Config: cfg,
-		IP:     net.IPv4(10, 42, 0, 2),
-		MAC:    net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02},
+		IP:     lease.ip,
+		MAC:    lease.mac,
 		Base:   arm64vm.NetBase,
 		Size:   arm64vm.NetSize,
 		IRQ:    arm64vm.NetIRQ,
+		TXHook: func(packet []byte) {
+			defaultDarwinSidecarSwitch.Forward(lease.id, packet)
+		},
 	})
 	if err != nil || common == nil {
+		if !explicit {
+			defaultDarwinSidecarSwitch.Unregister(lease.id)
+		}
 		return nil, err
 	}
-	return &darwinNetworkRuntime{networkRuntime: common}, nil
+	runtime := &darwinNetworkRuntime{networkRuntime: common, switchID: lease.id}
+	defaultDarwinSidecarSwitch.Attach(darwinSidecarEndpoint{
+		id:  lease.id,
+		ip:  lease.ip,
+		mac: lease.mac,
+		rx: func(frame []byte) {
+			copied := append([]byte(nil), frame...)
+			go func() {
+				_ = common.dev.EnqueueRxPacketOwned(copied)
+			}()
+		},
+	})
+	return runtime, nil
 }
 
 func newDarwinRemoteNetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRuntime, error) {
@@ -58,6 +83,40 @@ func newDarwinRemoteNetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRun
 		return nil, fmt.Errorf("dial coordinator net backend: %w", err)
 	}
 	codec := virtio.NewNetPacketCodec(conn)
+	if strings.TrimSpace(os.Getenv(sidecarNetModeEnv)) == "bridge" {
+		common, err := newNetworkRuntime(networkDeviceConfig{
+			ID:     DefaultInstanceID,
+			Config: cfg,
+			IP:     ip,
+			MAC:    mac,
+			Base:   arm64vm.NetBase,
+			Size:   arm64vm.NetSize,
+			IRQ:    arm64vm.NetIRQ,
+			TXHook: func(packet []byte) {
+				_ = codec.Send(virtio.NetPacket{
+					Kind:     virtio.NetPacketTX,
+					VMID:     DefaultInstanceID,
+					DeviceID: "eth0",
+					Frame:    append([]byte(nil), packet...),
+				})
+			},
+		})
+		if err != nil {
+			_ = codec.Close()
+			return nil, err
+		}
+		if common == nil {
+			_ = codec.Close()
+			return nil, nil
+		}
+		go func() {
+			_ = virtio.ReceiveNetRXPackets(context.Background(), codec, common.dev)
+		}()
+		return &darwinNetworkRuntime{
+			networkRuntime: common,
+			closeFn:        codec.Close,
+		}, nil
+	}
 	dev := virtio.NewNet(arm64vm.NetBase, arm64vm.NetSize, arm64vm.NetIRQ, mac, virtio.NewNetRemoteBackend(codec, DefaultInstanceID, "eth0"))
 	go func() {
 		_ = virtio.ReceiveNetRXPackets(context.Background(), codec, dev)
@@ -66,7 +125,30 @@ func newDarwinRemoteNetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRun
 		ip:  ip,
 		mac: mac,
 		dev: dev,
-	}}, nil
+	}, closeFn: codec.Close}, nil
+}
+
+func (n *darwinNetworkRuntime) Close() error {
+	if n == nil {
+		return nil
+	}
+	if n.switchID != "" {
+		defaultDarwinSidecarSwitch.Unregister(n.switchID)
+		n.switchID = ""
+	}
+	if n.networkRuntime == nil {
+		if n.closeFn != nil {
+			return n.closeFn()
+		}
+		return nil
+	}
+	err := n.networkRuntime.Close()
+	if n.closeFn != nil {
+		if closeErr := n.closeFn(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}
+	return err
 }
 
 func (n *darwinNetworkRuntime) guestInitConfig() *vmruntime.GuestNetworkConfig {

--- a/internal/vm/network_darwin_arm64_test.go
+++ b/internal/vm/network_darwin_arm64_test.go
@@ -1,0 +1,67 @@
+//go:build darwin && arm64
+
+package vm
+
+import (
+	"testing"
+
+	"j5.nz/cc/client"
+)
+
+func TestDarwinVirtualSwitchAllocatesDistinctLeases(t *testing.T) {
+	defaultDarwinSidecarSwitch.Unregister("freebsd")
+	defaultDarwinSidecarSwitch.Unregister("openbsd")
+	leaseA := defaultDarwinSidecarSwitch.Register("freebsd")
+	t.Cleanup(func() { defaultDarwinSidecarSwitch.Unregister(leaseA.id) })
+	leaseB := defaultDarwinSidecarSwitch.Register("openbsd")
+	t.Cleanup(func() { defaultDarwinSidecarSwitch.Unregister(leaseB.id) })
+
+	if got := leaseA.ip.String(); got != "10.42.0.2" {
+		t.Fatalf("first lease IP = %s, want 10.42.0.2", got)
+	}
+	if got := leaseA.mac.String(); got != "02:42:0a:2a:00:02" {
+		t.Fatalf("first lease MAC = %s, want 02:42:0a:2a:00:02", got)
+	}
+	if got := leaseB.ip.String(); got != "10.42.0.3" {
+		t.Fatalf("second lease IP = %s, want 10.42.0.3", got)
+	}
+	if got := leaseB.mac.String(); got != "02:42:0a:2a:00:03" {
+		t.Fatalf("second lease MAC = %s, want 02:42:0a:2a:00:03", got)
+	}
+}
+
+func TestDarwinNetworkRuntimeAllocatesDistinctAddresses(t *testing.T) {
+	defaultDarwinSidecarSwitch.Unregister("freebsd")
+	defaultDarwinSidecarSwitch.Unregister("openbsd")
+
+	freebsdNet, err := newDarwinARM64NetworkRuntime("freebsd", &client.NetworkConfig{Enabled: true})
+	if err != nil {
+		t.Fatalf("create FreeBSD network runtime: %v", err)
+	}
+	openbsdNet, err := newDarwinARM64NetworkRuntime("openbsd", &client.NetworkConfig{Enabled: true})
+	if err != nil {
+		_ = freebsdNet.Close()
+		t.Fatalf("create OpenBSD network runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = freebsdNet.Close() })
+	t.Cleanup(func() { _ = openbsdNet.Close() })
+
+	if got := freebsdNet.GuestAddress(); got != "10.42.0.2" {
+		t.Fatalf("FreeBSD runtime IP = %s, want 10.42.0.2", got)
+	}
+	if got := openbsdNet.GuestAddress(); got != "10.42.0.3" {
+		t.Fatalf("OpenBSD runtime IP = %s, want 10.42.0.3", got)
+	}
+
+	if err := freebsdNet.Close(); err != nil {
+		t.Fatalf("close FreeBSD runtime: %v", err)
+	}
+	nextNet, err := newDarwinARM64NetworkRuntime("netbsd", &client.NetworkConfig{Enabled: true})
+	if err != nil {
+		t.Fatalf("create NetBSD network runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = nextNet.Close() })
+	if got := nextNet.GuestAddress(); got != "10.42.0.2" {
+		t.Fatalf("reused runtime IP = %s, want 10.42.0.2", got)
+	}
+}

--- a/internal/vm/run_request.go
+++ b/internal/vm/run_request.go
@@ -1,12 +1,30 @@
 package vm
 
 import (
+	"os"
+	"strconv"
+	"sync/atomic"
+
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/vmruntime"
 )
 
+var guestExecCounter atomic.Uint64
+
+func guestExecID() string {
+	return "exec-" + strconv.Itoa(os.Getpid()) + "-" + strconv.FormatUint(guestExecCounter.Add(1), 36)
+}
+
+func guestExecIDFor(id string) string {
+	if id != "" {
+		return id
+	}
+	return guestExecID()
+}
+
 func runExecRequest(req client.RunRequest) client.ExecRequest {
 	return client.ExecRequest{
+		ID:         guestExecIDFor(req.ID),
 		Command:    append([]string(nil), req.Command...),
 		Env:        append([]string(nil), req.Env...),
 		RootDir:    req.RootDir,

--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -12,11 +12,21 @@ import (
 )
 
 type Client struct {
-	conn   net.Conn
-	codec  *WorkerCodec
-	callMu sync.Mutex
-	idMu   sync.Mutex
-	next   uint64
+	conn  net.Conn
+	codec *WorkerCodec
+
+	idMu sync.Mutex
+	next uint64
+
+	pendingMu sync.Mutex
+	pending   map[uint64]chan workerFrameResult
+	closed    bool
+	recvErr   error
+}
+
+type workerFrameResult struct {
+	frame WorkerFrame
+	err   error
 }
 
 func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
@@ -38,8 +48,8 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	client := &Client{conn: conn, codec: NewWorkerCodec(conn)}
-	frame, err := client.codec.Receive()
+	worker := &Client{conn: conn, codec: NewWorkerCodec(conn), pending: map[uint64]chan workerFrameResult{}}
+	frame, err := worker.codec.Receive()
 	if err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("read sidecar worker hello: %w", err)
@@ -48,7 +58,8 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("sidecar worker sent %q before hello", frame.Type)
 	}
-	return client, nil
+	go worker.receiveLoop()
+	return worker, nil
 }
 
 func workerDialTarget(address string) (string, string) {
@@ -63,6 +74,63 @@ func (c *Client) Close() error {
 		return nil
 	}
 	return c.conn.Close()
+}
+
+func (c *Client) receiveLoop() {
+	for {
+		frame, err := c.codec.Receive()
+		if err != nil {
+			c.closePending(err)
+			return
+		}
+		c.pendingMu.Lock()
+		ch := c.pending[frame.ID]
+		c.pendingMu.Unlock()
+		if ch == nil {
+			continue
+		}
+		ch <- workerFrameResult{frame: frame}
+	}
+}
+
+func (c *Client) registerCall(id uint64) (chan workerFrameResult, error) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	if c.closed {
+		if c.recvErr != nil {
+			return nil, c.recvErr
+		}
+		return nil, fmt.Errorf("sidecar worker is closed")
+	}
+	ch := make(chan workerFrameResult, 256)
+	c.pending[id] = ch
+	return ch, nil
+}
+
+func (c *Client) unregisterCall(id uint64) {
+	c.pendingMu.Lock()
+	delete(c.pending, id)
+	c.pendingMu.Unlock()
+}
+
+func (c *Client) closePending(err error) {
+	if err == nil {
+		err = fmt.Errorf("sidecar worker is closed")
+	}
+	c.pendingMu.Lock()
+	if c.closed {
+		c.pendingMu.Unlock()
+		return
+	}
+	c.closed = true
+	c.recvErr = err
+	pending := c.pending
+	c.pending = map[uint64]chan workerFrameResult{}
+	c.pendingMu.Unlock()
+	for _, ch := range pending {
+		ch <- workerFrameResult{err: err}
+		close(ch)
+	}
 }
 
 func (c *Client) Start(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (client.InstanceState, error) {
@@ -154,10 +222,13 @@ func (c *Client) ExecStream(ctx context.Context, id string, req client.ExecReque
 	if c == nil || c.codec == nil {
 		return fmt.Errorf("sidecar worker is not connected")
 	}
-	c.callMu.Lock()
-	defer c.callMu.Unlock()
-
 	requestID := c.nextID()
+	frames, err := c.registerCall(requestID)
+	if err != nil {
+		return err
+	}
+	defer c.unregisterCall(requestID)
+
 	frame, err := NewWorkerFrame(requestID, WorkerServiceControl, WorkerFrameExec, WorkerExecRequest{
 		ID:          id,
 		Request:     req,
@@ -192,16 +263,11 @@ func (c *Client) ExecStream(ctx context.Context, id string, req client.ExecReque
 	}()
 
 	for {
-		got, err := c.codec.Receive()
+		result, err := c.nextFrame(ctx, frames)
 		if err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
 			return err
 		}
-		if got.ID != requestID {
-			continue
-		}
+		got := result.frame
 		switch got.Type {
 		case WorkerFrameError:
 			var workerErr WorkerError
@@ -235,21 +301,24 @@ func (c *Client) call(ctx context.Context, frameType string, payload any, onFram
 	if c == nil || c.codec == nil {
 		return fmt.Errorf("sidecar worker is not connected")
 	}
-	c.callMu.Lock()
-	defer c.callMu.Unlock()
+	id := c.nextID()
+	frames, err := c.registerCall(id)
+	if err != nil {
+		return err
+	}
+	defer c.unregisterCall(id)
+
 	cancelDone := make(chan struct{})
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = c.conn.SetReadDeadline(time.Now())
+			_ = c.sendCancel(id)
 		case <-cancelDone:
 		}
 	}()
 	defer func() {
 		close(cancelDone)
-		_ = c.conn.SetReadDeadline(time.Time{})
 	}()
-	id := c.nextID()
 	frame, err := NewWorkerFrame(id, WorkerServiceControl, frameType, payload)
 	if err != nil {
 		return err
@@ -258,18 +327,11 @@ func (c *Client) call(ctx context.Context, frameType string, payload any, onFram
 		return err
 	}
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		got, err := c.codec.Receive()
+		result, err := c.nextFrame(ctx, frames)
 		if err != nil {
 			return err
 		}
-		if got.ID != id {
-			continue
-		}
+		got := result.frame
 		switch got.Type {
 		case WorkerFrameError:
 			var workerErr WorkerError
@@ -289,6 +351,27 @@ func (c *Client) call(ctx context.Context, frameType string, payload any, onFram
 				}
 			}
 		}
+	}
+}
+
+func (c *Client) nextFrame(ctx context.Context, frames <-chan workerFrameResult) (workerFrameResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return workerFrameResult{}, ctx.Err()
+	case result, ok := <-frames:
+		if !ok {
+			return workerFrameResult{}, fmt.Errorf("sidecar worker is closed")
+		}
+		if result.err != nil {
+			if ctx.Err() != nil {
+				return workerFrameResult{}, ctx.Err()
+			}
+			return workerFrameResult{}, result.err
+		}
+		return result, nil
 	}
 }
 

--- a/internal/vm/sidecar/client_test.go
+++ b/internal/vm/sidecar/client_test.go
@@ -2,8 +2,12 @@ package sidecar
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
+	"time"
+
+	"j5.nz/cc/client"
 )
 
 func TestWorkerDialTarget(t *testing.T) {
@@ -44,6 +48,114 @@ func TestDialWorkerRejectsNonHello(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatalf("server: %v", err)
 	}
+}
+
+func TestWorkerClientMultiplexesControlWhileExecStreams(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverErr := make(chan error, 1)
+	releaseExec := make(chan struct{})
+	execReceived := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		codec := NewWorkerCodec(conn)
+		defer codec.Close()
+		if err := codec.Send(WorkerFrame{Type: WorkerFrameHello}); err != nil {
+			serverErr <- err
+			return
+		}
+		execFrame, err := codec.Receive()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if execFrame.Type != WorkerFrameExec {
+			serverErr <- fmt.Errorf("first frame type = %q", execFrame.Type)
+			return
+		}
+		close(execReceived)
+		addShareFrame, err := codec.Receive()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if addShareFrame.Type != WorkerFrameAddShare {
+			serverErr <- fmt.Errorf("second frame type = %q", addShareFrame.Type)
+			return
+		}
+		if err := codec.Send(mustWorkerFrame(addShareFrame.ID, WorkerFrameDone, map[string]string{"status": "mounted"})); err != nil {
+			serverErr <- err
+			return
+		}
+		<-releaseExec
+		if err := codec.Send(mustWorkerFrame(execFrame.ID, WorkerFrameDone, map[string]string{"status": "done"})); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	worker, err := DialWorker(context.Background(), "tcp://"+ln.Addr().String())
+	if err != nil {
+		t.Fatalf("DialWorker: %v", err)
+	}
+	defer worker.Close()
+
+	execErr := make(chan error, 1)
+	go func() {
+		execErr <- worker.ExecStream(context.Background(), "vm", client.ExecRequest{Command: []string{"sh"}}, make(chan client.ExecInput), nil)
+	}()
+
+	select {
+	case <-execReceived:
+	case err := <-serverErr:
+		t.Fatalf("server: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("worker did not receive exec frame")
+	}
+
+	addShareDone := make(chan error, 1)
+	go func() {
+		addShareDone <- worker.AddShare(context.Background(), "vm", client.ShareMount{Source: "/host", Mount: "/host"})
+	}()
+
+	select {
+	case err := <-addShareDone:
+		if err != nil {
+			select {
+			case server := <-serverErr:
+				t.Fatalf("AddShare: %v; server: %v", err, server)
+			default:
+			}
+			t.Fatalf("AddShare: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AddShare blocked behind active exec stream")
+	}
+
+	close(releaseExec)
+	if err := <-execErr; err != nil {
+		t.Fatalf("ExecStream: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func mustWorkerFrame(id uint64, frameType string, payload any) WorkerFrame {
+	frame, err := NewWorkerFrame(id, WorkerServiceControl, frameType, payload)
+	if err != nil {
+		panic(err)
+	}
+	return frame
 }
 
 func serveWorkerFrame(t *testing.T, frame WorkerFrame) (string, <-chan error) {

--- a/internal/vm/sidecar_builtin_bsd.go
+++ b/internal/vm/sidecar_builtin_bsd.go
@@ -16,17 +16,27 @@ func (h *sidecarVMHost) startBuiltinGuestStream(ctx context.Context, req client.
 	if !ok {
 		return nil, false, nil
 	}
+	networkID := req.ID
 	req.Image = profile.Canonical
 	req.ID = DefaultInstanceID
-	sidecar, err := h.launch(ctx, nil)
+	netResources, err := prepareSidecarBuiltinGuestResources(h, networkID, req.Network)
 	if err != nil {
 		return nil, true, err
 	}
-	if _, err := sidecar.Worker().Start(ctx, req, onEvent); err != nil {
+	sidecar, err := h.launch(ctx, netResources.env)
+	if err != nil {
+		netResources.closeAll()
+		return nil, true, err
+	}
+	sidecar.AddCleanup(netResources.close)
+	state, err := sidecar.Worker().Start(ctx, req, onEvent)
+	if err != nil {
 		_ = sidecar.Close()
 		return nil, true, err
 	}
-	return newSidecarInstance(DefaultInstanceID, sidecar, req.Image, builtinSidecarResources(profile)), true, nil
+	resources := combineSidecarResources(builtinSidecarResources(profile), netResources)
+	resources.networkIPv4 = state.NetworkIPv4
+	return newSidecarInstance(DefaultInstanceID, sidecar, req.Image, resources), true, nil
 }
 
 func (h *sidecarVMHost) startBuiltinGuestBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
@@ -34,17 +44,27 @@ func (h *sidecarVMHost) startBuiltinGuestBlankStream(ctx context.Context, req cl
 	if !ok {
 		return nil, false, nil
 	}
+	networkID := req.ID
 	req.Image = profile.Canonical
 	req.ID = DefaultInstanceID
-	sidecar, err := h.launch(ctx, nil)
+	netResources, err := prepareSidecarBuiltinGuestResources(h, networkID, req.Network)
 	if err != nil {
 		return nil, true, err
 	}
-	if _, err := sidecar.Worker().StartBlank(ctx, req, onEvent); err != nil {
+	sidecar, err := h.launch(ctx, netResources.env)
+	if err != nil {
+		netResources.closeAll()
+		return nil, true, err
+	}
+	sidecar.AddCleanup(netResources.close)
+	state, err := sidecar.Worker().StartBlank(ctx, req, onEvent)
+	if err != nil {
 		_ = sidecar.Close()
 		return nil, true, err
 	}
-	return newSidecarInstance(DefaultInstanceID, sidecar, req.Image, builtinSidecarResources(profile)), true, nil
+	resources := combineSidecarResources(builtinSidecarResources(profile), netResources)
+	resources.networkIPv4 = state.NetworkIPv4
+	return newSidecarInstance(DefaultInstanceID, sidecar, req.Image, resources), true, nil
 }
 
 func builtinSidecarResources(profile managedguest.Profile) sidecarStartResources {

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -31,6 +31,7 @@ const (
 	sidecarNetSocketEnv = "CCX3_WORKER_NET_SOCKET"
 	sidecarNetIPv4Env   = "CCX3_WORKER_NET_IPV4"
 	sidecarNetMACEnv    = "CCX3_WORKER_NET_MAC"
+	sidecarNetModeEnv   = "CCX3_WORKER_NET_MODE"
 )
 
 const (
@@ -135,6 +136,13 @@ func prepareSidecarBlankResources(h *sidecarVMHost, ctx context.Context, req cli
 		return sidecarStartResources{}, err
 	}
 	return combineSidecarResources(fsResources, bootResources, netResources), nil
+}
+
+func prepareSidecarBuiltinGuestResources(h *sidecarVMHost, id string, cfg *client.NetworkConfig) (sidecarStartResources, error) {
+	if h == nil {
+		return sidecarStartResources{}, nil
+	}
+	return prepareSidecarNetResourcesWithMode(h.cacheDir, id, cfg, "bridge")
 }
 
 func sidecarSnapshotRoot(backend virtio.FSBackend) (sidecarRootFS, error) {
@@ -283,10 +291,17 @@ func serveSidecarFS(cacheDir string, backend sidecarRootFS) (sidecarStartResourc
 }
 
 func prepareSidecarNetResources(cacheDir, id string, cfg *client.NetworkConfig) (sidecarStartResources, error) {
+	return prepareSidecarNetResourcesWithMode(cacheDir, id, cfg, "")
+}
+
+func prepareSidecarNetResourcesWithMode(cacheDir, id string, cfg *client.NetworkConfig, mode string) (sidecarStartResources, error) {
 	if cfg == nil || !cfg.Enabled {
 		return sidecarStartResources{}, nil
 	}
-	lease := defaultDarwinSidecarSwitch.Register(id)
+	lease, explicit := darwinSidecarLeaseFromConfig(id, cfg)
+	if !explicit {
+		lease = defaultDarwinSidecarSwitch.Register(id)
+	}
 	var codecMu sync.Mutex
 	var codec *virtio.NetPacketCodec
 	runtime, err := newNetworkRuntime(networkDeviceConfig{
@@ -311,11 +326,15 @@ func prepareSidecarNetResources(cacheDir, id string, cfg *client.NetworkConfig) 
 			})
 		},
 		Cleanup: func() {
-			defaultDarwinSidecarSwitch.Unregister(lease.id)
+			if !explicit {
+				defaultDarwinSidecarSwitch.Unregister(lease.id)
+			}
 		},
 	})
 	if err != nil {
-		defaultDarwinSidecarSwitch.Unregister(lease.id)
+		if !explicit {
+			defaultDarwinSidecarSwitch.Unregister(lease.id)
+		}
 		return sidecarStartResources{}, err
 	}
 	socketPath, cleanupListener, err := serveSidecarUnixOnceConn(cacheDir, "net", false, func(conn net.Conn) error {
@@ -341,6 +360,9 @@ func prepareSidecarNetResources(cacheDir, id string, cfg *client.NetworkConfig) 
 				return nil
 			}
 			defaultDarwinSidecarSwitch.Forward(lease.id, packet.Frame)
+			if mode == "bridge" {
+				return nil
+			}
 			if runtime == nil {
 				return nil
 			}
@@ -369,12 +391,37 @@ func prepareSidecarNetResources(cacheDir, id string, cfg *client.NetworkConfig) 
 			sidecarNetSocketEnv + "=" + socketPath,
 			sidecarNetIPv4Env + "=" + lease.ip.String(),
 			sidecarNetMACEnv + "=" + lease.mac.String(),
+			sidecarNetModeEnv + "=" + mode,
 		},
 		close:       closeFn,
 		remote:      true,
 		networkIPv4: lease.ip.String(),
 		network:     runtime,
 	}, nil
+}
+
+func darwinSidecarLeaseFromConfig(id string, cfg *client.NetworkConfig) (darwinSidecarLease, bool) {
+	if cfg == nil {
+		return darwinSidecarLease{}, false
+	}
+	ip := net.ParseIP(strings.TrimSpace(cfg.GuestIPv4)).To4()
+	if ip == nil {
+		return darwinSidecarLease{}, false
+	}
+	macText := strings.TrimSpace(cfg.GuestMAC)
+	if macText == "" {
+		ip4 := ip.To4()
+		macText = net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, ip4[3]}.String()
+	}
+	mac, err := net.ParseMAC(macText)
+	if err != nil {
+		return darwinSidecarLease{}, false
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		id = DefaultInstanceID
+	}
+	return darwinSidecarLease{id: id, ip: ip, mac: mac}, true
 }
 
 type darwinSidecarSwitch struct {
@@ -408,6 +455,12 @@ func (s *darwinSidecarSwitch) Register(id string) darwinSidecarLease {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if lease, ok := s.leases[id]; ok {
+		return lease
+	}
+	if endpoint, ok := s.endpoints[id]; ok {
+		return darwinSidecarLease{id: endpoint.id, ip: endpoint.ip, mac: endpoint.mac}
+	}
 	used := map[byte]bool{1: true}
 	for _, lease := range s.leases {
 		if ip4 := lease.ip.To4(); ip4 != nil {

--- a/internal/vm/sidecar_resources_darwin_arm64_test.go
+++ b/internal/vm/sidecar_resources_darwin_arm64_test.go
@@ -1,0 +1,35 @@
+//go:build darwin && arm64
+
+package vm
+
+import "testing"
+
+func TestDarwinSidecarSwitchAllocatesDistinctLeases(t *testing.T) {
+	defaultDarwinSidecarSwitch.Unregister("freebsd")
+	defaultDarwinSidecarSwitch.Unregister("openbsd")
+	leaseA := defaultDarwinSidecarSwitch.Register("freebsd")
+	t.Cleanup(func() { defaultDarwinSidecarSwitch.Unregister(leaseA.id) })
+	leaseB := defaultDarwinSidecarSwitch.Register("openbsd")
+	t.Cleanup(func() { defaultDarwinSidecarSwitch.Unregister(leaseB.id) })
+
+	if got := leaseA.ip.String(); got != "10.42.0.2" {
+		t.Fatalf("first lease IP = %s, want 10.42.0.2", got)
+	}
+	if got := leaseB.ip.String(); got != "10.42.0.3" {
+		t.Fatalf("second lease IP = %s, want 10.42.0.3", got)
+	}
+}
+
+func TestDarwinSidecarSwitchKeepsPendingLeaseForSameID(t *testing.T) {
+	defaultDarwinSidecarSwitch.Unregister("freebsd")
+	leaseA := defaultDarwinSidecarSwitch.Register("freebsd")
+	t.Cleanup(func() { defaultDarwinSidecarSwitch.Unregister(leaseA.id) })
+	leaseB := defaultDarwinSidecarSwitch.Register("freebsd")
+
+	if !leaseA.ip.Equal(leaseB.ip) {
+		t.Fatalf("pending lease changed from %s to %s", leaseA.ip, leaseB.ip)
+	}
+	if leaseA.mac.String() != leaseB.mac.String() {
+		t.Fatalf("pending lease MAC changed from %s to %s", leaseA.mac, leaseB.mac)
+	}
+}

--- a/internal/vm/sidecar_resources_other.go
+++ b/internal/vm/sidecar_resources_other.go
@@ -24,6 +24,13 @@ func prepareSidecarBlankResources(h *sidecarVMHost, ctx context.Context, req cli
 	return sidecarStartResources{}, nil
 }
 
+func prepareSidecarBuiltinGuestResources(h *sidecarVMHost, id string, cfg *client.NetworkConfig) (sidecarStartResources, error) {
+	_ = h
+	_ = id
+	_ = cfg
+	return sidecarStartResources{}, nil
+}
+
 func sidecarRuntimeShareMount(share client.ShareMount) (virtio.ShareMount, error) {
 	_ = share
 	return virtio.ShareMount{}, fmt.Errorf("sidecar runtime shares are not supported on this platform")

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"runtime"
 	"sort"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"j5.nz/cc/internal/hv"
 	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vm/builtin"
 	vmhost "j5.nz/cc/internal/vm/host"
 )
 
@@ -58,12 +60,13 @@ type imageSnapshotProvider interface {
 }
 
 type Manager struct {
-	mu           sync.Mutex
-	host         VMHost
-	supports     func() error
-	capabilities func() client.CapabilitiesResponse
-	running      map[string]*Machine
-	starting     map[string]struct{}
+	mu            sync.Mutex
+	host          VMHost
+	supports      func() error
+	capabilities  func() client.CapabilitiesResponse
+	running       map[string]*Machine
+	starting      map[string]struct{}
+	networkLeases map[string]managerNetworkLease
 }
 
 type Machine struct {
@@ -81,6 +84,11 @@ type Machine struct {
 	shutdownCh   chan struct{}
 	shutdownOnce sync.Once
 	stopping     bool
+}
+
+type managerNetworkLease struct {
+	ip  net.IP
+	mac net.HardwareAddr
 }
 
 func NewManager() *Manager {
@@ -222,11 +230,13 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		return client.InstanceState{}, err
 	}
 	m.starting[id] = struct{}{}
+	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
 	inst, err := m.host.StartStream(ctx, req, onEvent)
 	if err != nil {
 		m.clearStarting(id)
+		m.releaseNetworkLease(id)
 		return client.InstanceState{}, err
 	}
 
@@ -303,6 +313,7 @@ func (m *Manager) StartBlankInstanceStream(
 		return client.InstanceState{}, err
 	}
 	m.starting[id] = struct{}{}
+	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
 	shares := append([]client.ShareMount(nil), req.Shares...)
@@ -310,12 +321,14 @@ func (m *Manager) StartBlankInstanceStream(
 	inst, err := m.host.StartBlankStream(ctx, req, onEvent)
 	if err != nil {
 		m.clearStarting(id)
+		m.releaseNetworkLease(id)
 		return client.InstanceState{}, err
 	}
 	for _, share := range shares {
 		if err := inst.AddShare(ctx, share); err != nil {
 			_ = inst.Close()
 			m.clearStarting(id)
+			m.releaseNetworkLease(id)
 			return client.InstanceState{}, err
 		}
 	}
@@ -401,6 +414,7 @@ func (m *Manager) ShutdownInstance(ctx context.Context, id string) error {
 	if m.running != nil && m.running[id] == machine {
 		delete(m.running, id)
 	}
+	delete(m.networkLeases, id)
 	m.mu.Unlock()
 	return nil
 }
@@ -438,6 +452,7 @@ func (m *Manager) RunStreamIn(ctx context.Context, id string, req client.RunRequ
 	id = instanceID(id)
 	m.mu.Lock()
 	machine := m.running[id]
+	stopping := machine != nil && machine.stopping
 	m.mu.Unlock()
 	if machine == nil {
 		if req.Image == "" {
@@ -448,31 +463,77 @@ func (m *Manager) RunStreamIn(ctx context.Context, id string, req client.RunRequ
 		}
 		return m.host.RunStream(ctx, req, inputs, onEvent)
 	}
+	if stopping {
+		return stoppedVMError(id)
+	}
+	req.ID = guestExecID()
 	targetImage := strings.TrimSpace(req.Image)
 	if !sameRuntimeImage(targetImage, machine.image) {
-		return m.host.RunInInstanceStream(ctx, machine.instance, machine.image, req, inputs, onEvent)
+		err := m.host.RunInInstanceStream(ctx, machine.instance, machine.image, req, inputs, onEvent)
+		if err != nil && m.instanceIsStopping(id, machine) {
+			return stoppedVMError(id)
+		}
+		return err
 	}
 	for _, share := range req.Shares {
 		if err := machine.instance.AddShare(ctx, share); err != nil {
+			if m.instanceIsStopping(id, machine) {
+				return stoppedVMError(id)
+			}
 			return err
 		}
 	}
-	return machine.instance.ExecStream(ctx, runExecRequest(req), inputs, onEvent)
+	err := machine.instance.ExecStream(ctx, runExecRequest(req), inputs, onEvent)
+	if err != nil && m.instanceIsStopping(id, machine) {
+		return stoppedVMError(id)
+	}
+	return err
 }
 
 func (m *Manager) StreamIn(ctx context.Context, id string, req client.ExecRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
 	id = instanceID(id)
 	m.mu.Lock()
 	machine := m.running[id]
+	stopping := machine != nil && machine.stopping
 	m.mu.Unlock()
 	if machine == nil {
 		return fmt.Errorf("no VM %q is running", id)
 	}
+	if stopping {
+		return stoppedVMError(id)
+	}
+	req.ID = guestExecID()
 	targetImage := strings.TrimSpace(req.Image)
 	if vmhost.IsHostedInstance(machine.instance) || targetImage != "" {
-		return m.host.ExecInInstanceStream(ctx, machine.instance, machine.image, req, inputs, onEvent)
+		err := m.host.ExecInInstanceStream(ctx, machine.instance, machine.image, req, inputs, onEvent)
+		if err != nil && m.instanceIsStopping(id, machine) {
+			return stoppedVMError(id)
+		}
+		return err
 	}
-	return machine.instance.ExecStream(ctx, req, inputs, onEvent)
+	err := machine.instance.ExecStream(ctx, req, inputs, onEvent)
+	if err != nil && m.instanceIsStopping(id, machine) {
+		return stoppedVMError(id)
+	}
+	return err
+}
+
+func (m *Manager) instanceIsStopping(id string, machine *Machine) bool {
+	if machine == nil {
+		return false
+	}
+	select {
+	case <-machine.shutdownCh:
+		return true
+	default:
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return machine.stopping || m.running[id] != machine
+}
+
+func stoppedVMError(id string) error {
+	return fmt.Errorf("VM %q stopped", id)
 }
 
 func (m *Manager) AddPortForward(ctx context.Context, forward client.PortForward) error {
@@ -666,6 +727,7 @@ func (m *Manager) watch(machine *Machine) {
 	if m.running != nil && m.running[machine.id] == machine {
 		delete(m.running, machine.id)
 	}
+	delete(m.networkLeases, machine.id)
 	machine.lastErr = err
 	machine.exitedAt = time.Now().UTC()
 }
@@ -682,6 +744,60 @@ func (m *Manager) clearStarting(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.starting, id)
+}
+
+func (m *Manager) ensureNetworkLeaseLocked(id, image string, cfg *client.NetworkConfig) *client.NetworkConfig {
+	if cfg == nil {
+		if !builtin.IsGuestImage(image) {
+			return nil
+		}
+		cfg = &client.NetworkConfig{Enabled: true}
+	}
+	if !cfg.Enabled {
+		return cfg
+	}
+	if strings.TrimSpace(cfg.GuestIPv4) != "" && strings.TrimSpace(cfg.GuestMAC) != "" {
+		return cfg
+	}
+	id = instanceID(id)
+	if m.networkLeases == nil {
+		m.networkLeases = make(map[string]managerNetworkLease)
+	}
+	lease, ok := m.networkLeases[id]
+	if !ok {
+		used := map[byte]bool{1: true}
+		for _, existing := range m.networkLeases {
+			if ip4 := existing.ip.To4(); ip4 != nil {
+				used[ip4[3]] = true
+			}
+		}
+		host := byte(2)
+		for ; host <= 254; host++ {
+			if !used[host] {
+				break
+			}
+		}
+		lease = managerNetworkLease{
+			ip:  net.IPv4(10, 42, 0, host),
+			mac: net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, host},
+		}
+		m.networkLeases[id] = lease
+	}
+	next := *cfg
+	if strings.TrimSpace(next.GuestIPv4) == "" {
+		next.GuestIPv4 = lease.ip.String()
+	}
+	if strings.TrimSpace(next.GuestMAC) == "" {
+		next.GuestMAC = lease.mac.String()
+	}
+	return &next
+}
+
+func (m *Manager) releaseNetworkLease(id string) {
+	id = instanceID(id)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.networkLeases, id)
 }
 
 func instanceID(id string) string {


### PR DESCRIPTION
## Summary
- Allocate stable per-instance guest IP/MAC leases in the VM manager and pass them through network config
- Bridge Darwin sidecar networking through the shared switch so BSD guests can reach each other
- Preserve distinct exec IDs, improve sidecar client multiplexing, and cover the new network/sidecar behavior with tests
- Ignore generated BSD guest-init payload binaries

## Tests
- `go test -timeout 45s ./internal/vm ./internal/vm/netstate ./internal/vm/sidecar ./internal/vm/execplan`