### PR TITLE
[codex] Expose runtime shutdown to vmshd

### DIFF
--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -1,6 +1,7 @@
 package ccvmd
 
 import (
+	"context"
 	"net/http"
 
 	"j5.nz/cc/client"
@@ -16,6 +17,7 @@ type ServerOptions struct {
 
 type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
+	RunStreamIn(context.Context, string, client.RunRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
 }
 
 func Main(args []string) {

--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -1,7 +1,27 @@
 package ccvmd
 
-import internal "j5.nz/cc/internal/ccvmd"
+import (
+	"net/http"
+
+	internal "j5.nz/cc/internal/ccvmd"
+)
+
+type ServerOptions struct {
+	Kind             string
+	TokenPath        string
+	RegisterHandlers func(*http.ServeMux)
+	WrapHandler      func(http.Handler) http.Handler
+}
 
 func Main(args []string) {
 	internal.Main(args)
+}
+
+func RunServer(args []string, opts ServerOptions) (bool, error) {
+	return internal.RunServer(args, internal.ServerOptions{
+		Kind:             opts.Kind,
+		TokenPath:        opts.TokenPath,
+		RegisterHandlers: opts.RegisterHandlers,
+		WrapHandler:      opts.WrapHandler,
+	})
 }

--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -3,14 +3,19 @@ package ccvmd
 import (
 	"net/http"
 
+	"j5.nz/cc/client"
 	internal "j5.nz/cc/internal/ccvmd"
 )
 
 type ServerOptions struct {
 	Kind             string
 	TokenPath        string
-	RegisterHandlers func(*http.ServeMux)
+	RegisterHandlers func(*http.ServeMux, RuntimeView)
 	WrapHandler      func(http.Handler) http.Handler
+}
+
+type RuntimeView interface {
+	InstanceStatuses() []client.InstanceState
 }
 
 func Main(args []string) {
@@ -19,9 +24,13 @@ func Main(args []string) {
 
 func RunServer(args []string, opts ServerOptions) (bool, error) {
 	return internal.RunServer(args, internal.ServerOptions{
-		Kind:             opts.Kind,
-		TokenPath:        opts.TokenPath,
-		RegisterHandlers: opts.RegisterHandlers,
-		WrapHandler:      opts.WrapHandler,
+		Kind:      opts.Kind,
+		TokenPath: opts.TokenPath,
+		RegisterHandlers: func(mux *http.ServeMux, runtime internal.RuntimeView) {
+			if opts.RegisterHandlers != nil {
+				opts.RegisterHandlers(mux, runtime)
+			}
+		},
+		WrapHandler: opts.WrapHandler,
 	})
 }

--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -18,6 +18,7 @@ type ServerOptions struct {
 type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
 	RunStreamIn(context.Context, string, client.RunRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
+	ShutdownInstance(context.Context, string) error
 }
 
 func Main(args []string) {

--- a/client/client.go
+++ b/client/client.go
@@ -15,23 +15,49 @@ import (
 )
 
 type Client struct {
-	url    string
-	dialer func() (net.Conn, error)
-	client http.Client
+	url       string
+	dialer    func() (net.Conn, error)
+	authToken string
+	client    http.Client
 }
 
 func NewClient(url string, dialer func() (net.Conn, error)) *Client {
-	return &Client{
+	c := &Client{
 		url:    url,
 		dialer: dialer,
-		client: http.Client{
-			Transport: &http.Transport{
+	}
+	c.client = http.Client{
+		Transport: &authTransport{
+			base: &http.Transport{
 				Dial: func(_, _ string) (net.Conn, error) {
-					return dialer()
+					return c.dialer()
 				},
+			},
+			token: func() string {
+				return c.authToken
 			},
 		},
 	}
+	return c
+}
+
+type authTransport struct {
+	base  http.RoundTripper
+	token func() string
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.token != nil {
+		if token := strings.TrimSpace(t.token()); token != "" {
+			req = req.Clone(req.Context())
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+func (c *Client) SetBearerToken(token string) {
+	c.authToken = strings.TrimSpace(token)
 }
 
 func (c *Client) HealthCheck() error {
@@ -62,6 +88,15 @@ func (c *Client) Shutdown() error {
 		return decodeErrorResponse(resp)
 	}
 	return nil
+}
+
+func (c *Client) RouteExists(path string) bool {
+	resp, err := c.client.Get(c.url + path)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode != http.StatusNotFound
 }
 
 func (c *Client) KernelStatus() (KernelState, error) {
@@ -386,6 +421,7 @@ func (c *Client) RunInteractiveStreamContext(ctx context.Context, req RunRequest
 	if err != nil {
 		return err
 	}
+	c.applyWebSocketAuth(cfg)
 	if c.dialer != nil {
 		cfg.Dialer = &net.Dialer{}
 	}
@@ -539,6 +575,7 @@ func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs 
 	if err != nil {
 		return err
 	}
+	c.applyWebSocketAuth(cfg)
 	if c.dialer != nil {
 		cfg.Dialer = &net.Dialer{}
 	}
@@ -572,6 +609,18 @@ func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs 
 		return sendErrValue
 	}
 	return err
+}
+
+func (c *Client) applyWebSocketAuth(cfg *websocket.Config) {
+	if cfg == nil {
+		return
+	}
+	if token := strings.TrimSpace(c.authToken); token != "" {
+		if cfg.Header == nil {
+			cfg.Header = http.Header{}
+		}
+		cfg.Header.Set("Authorization", "Bearer "+token)
+	}
 }
 
 func (c *Client) ExecStreamIn(id string, req ExecRequest, inputs <-chan ExecInput, onEvent func(ExecEvent) error) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -74,6 +74,32 @@ func TestClientRunForwardStatusAndErrorDecoding(t *testing.T) {
 	}
 }
 
+func TestClientBearerTokenIsSent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		writeTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		url:       srv.URL,
+		authToken: "secret",
+		client: http.Client{
+			Transport: &authTransport{
+				base: srv.Client().Transport,
+				token: func() string {
+					return "secret"
+				},
+			},
+		},
+	}
+	if err := c.HealthCheck(); err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+}
+
 func TestClientRunStreamDecodesNDJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/vm/run" || r.URL.Query().Get("stream") != "1" {

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -8,10 +8,11 @@ import (
 )
 
 type ServerHello struct {
-	Addr   string `json:"addr,omitempty"`
-	Kind   string `json:"kind,omitempty"`
-	Error  string `json:"error,omitempty"`
-	Detail string `json:"detail,omitempty"`
+	Addr      string `json:"addr,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	TokenPath string `json:"token_path,omitempty"`
+	Error     string `json:"error,omitempty"`
+	Detail    string `json:"detail,omitempty"`
 }
 
 type ErrorResponse struct {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -77,6 +77,13 @@ type server struct {
 	cvmfsCacheDir string
 }
 
+type ServerOptions struct {
+	Kind             string
+	TokenPath        string
+	RegisterHandlers func(*http.ServeMux)
+	WrapHandler      func(http.Handler) http.Handler
+}
+
 type watchdogController struct {
 	mu          sync.Mutex
 	timeout     time.Duration
@@ -288,7 +295,7 @@ func newWatchdogLeaseID() (string, error) {
 }
 
 func Main(args []string) {
-	started, err := run(args)
+	started, err := RunServer(args, ServerOptions{})
 	if err == nil {
 		return
 	}
@@ -299,7 +306,7 @@ func Main(args []string) {
 	os.Exit(1)
 }
 
-func run(args []string) (bool, error) {
+func RunServer(args []string, opts ServerOptions) (bool, error) {
 	if err := macos.EnsureExecutableIsSigned(); err != nil {
 		return false, fmt.Errorf("prepare ccvm executable: %w", err)
 	}
@@ -343,9 +350,12 @@ func run(args []string) (bool, error) {
 		return false, fmt.Errorf("listen on %q: %w", *addr, err)
 	}
 
-	if err := json.NewEncoder(os.Stdout).Encode(client.ServerHello{
-		Addr: l.Addr().String(),
-	}); err != nil {
+	hello := client.ServerHello{
+		Addr:      l.Addr().String(),
+		Kind:      opts.Kind,
+		TokenPath: opts.TokenPath,
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(hello); err != nil {
 		_ = l.Close()
 		return false, fmt.Errorf("write startup banner: %w", err)
 	}
@@ -356,8 +366,15 @@ func run(args []string) (bool, error) {
 	defer watchdog.Stop()
 	srvState.images.CVMFSActivity = watchdog.RecordCVMFSActivity
 	mux := newMux(srvState, watchdog, shutdown)
+	if opts.RegisterHandlers != nil {
+		opts.RegisterHandlers(mux)
+	}
 
-	httpServer = http.Server{Handler: mux}
+	var handler http.Handler = mux
+	if opts.WrapHandler != nil {
+		handler = opts.WrapHandler(handler)
+	}
+	httpServer = http.Server{Handler: handler}
 	if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return true, fmt.Errorf("serve daemon API: %w", err)
 	}

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -86,6 +86,7 @@ type ServerOptions struct {
 
 type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
+	RunStreamIn(context.Context, string, client.RunRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
 }
 
 func (s *server) InstanceStatuses() []client.InstanceState {
@@ -93,6 +94,15 @@ func (s *server) InstanceStatuses() []client.InstanceState {
 		return nil
 	}
 	return s.vms.Statuses()
+}
+
+func (s *server) RunStreamIn(ctx context.Context, id string, req client.RunRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	if s == nil || s.vms == nil {
+		return fmt.Errorf("runtime is not available")
+	}
+	runCtx, cancel := runRequestContext(ctx, req)
+	defer cancel()
+	return s.vms.RunStreamIn(runCtx, id, req, inputs, onEvent)
 }
 
 type watchdogController struct {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -87,6 +87,7 @@ type ServerOptions struct {
 type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
 	RunStreamIn(context.Context, string, client.RunRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
+	ShutdownInstance(context.Context, string) error
 }
 
 func (s *server) InstanceStatuses() []client.InstanceState {
@@ -103,6 +104,13 @@ func (s *server) RunStreamIn(ctx context.Context, id string, req client.RunReque
 	runCtx, cancel := runRequestContext(ctx, req)
 	defer cancel()
 	return s.vms.RunStreamIn(runCtx, id, req, inputs, onEvent)
+}
+
+func (s *server) ShutdownInstance(ctx context.Context, id string) error {
+	if s == nil || s.vms == nil {
+		return fmt.Errorf("runtime is not available")
+	}
+	return s.vms.ShutdownInstance(ctx, id)
 }
 
 type watchdogController struct {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -80,8 +80,19 @@ type server struct {
 type ServerOptions struct {
 	Kind             string
 	TokenPath        string
-	RegisterHandlers func(*http.ServeMux)
+	RegisterHandlers func(*http.ServeMux, RuntimeView)
 	WrapHandler      func(http.Handler) http.Handler
+}
+
+type RuntimeView interface {
+	InstanceStatuses() []client.InstanceState
+}
+
+func (s *server) InstanceStatuses() []client.InstanceState {
+	if s == nil || s.vms == nil {
+		return nil
+	}
+	return s.vms.Statuses()
 }
 
 type watchdogController struct {
@@ -310,6 +321,9 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 	if err := macos.EnsureExecutableIsSigned(); err != nil {
 		return false, fmt.Errorf("prepare ccvm executable: %w", err)
 	}
+	if strings.TrimSpace(opts.TokenPath) != "" {
+		defer os.Remove(opts.TokenPath)
+	}
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
@@ -367,7 +381,7 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 	srvState.images.CVMFSActivity = watchdog.RecordCVMFSActivity
 	mux := newMux(srvState, watchdog, shutdown)
 	if opts.RegisterHandlers != nil {
-		opts.RegisterHandlers(mux)
+		opts.RegisterHandlers(mux, srvState)
 	}
 
 	var handler http.Handler = mux


### PR DESCRIPTION
## Summary

Adds `ShutdownInstance` to the ccvmd runtime view and wires the server implementation through to the VM runtime.

This is the small supporting change needed by vmshd frontend/session lifecycle cleanup so a frontend-owned session can shut down isolated VM resources when the frontend closes.

## Validation

- `go test ./...`
