### PR TITLE
Prune low-value tests

### DIFF
--- a/cmd/cc/main_test.go
+++ b/cmd/cc/main_test.go
@@ -23,52 +23,6 @@ func TestParsePortForwardSpec(t *testing.T) {
 	}
 }
 
-func TestFulltestBackendFromArgs(t *testing.T) {
-	for _, tc := range []struct {
-		args []string
-		want string
-	}{
-		{args: nil, want: "ccvm"},
-		{args: []string{"-backend", "docker"}, want: "docker"},
-		{args: []string{"--backend=HVF"}, want: "hvf"},
-		{args: []string{"-backend=qemu"}, want: "qemu"},
-		{args: []string{"--", "-backend", "docker"}, want: "ccvm"},
-		{args: []string{"--backend"}, want: ""},
-	} {
-		if got := fulltestBackendFromArgs(tc.args); got != tc.want {
-			t.Fatalf("fulltestBackendFromArgs(%#v) = %q, want %q", tc.args, got, tc.want)
-		}
-	}
-}
-
-func TestFormatProgressAndBootEvents(t *testing.T) {
-	progress := formatProgressEvent(client.ProgressEvent{
-		Status:             "downloading",
-		Artifact:           "kernel",
-		Blob:               "vmlinuz",
-		BytesDownloaded:    1024,
-		BytesTotal:         2048,
-		RateBytesPerSecond: 512,
-		ETASeconds:         2,
-	}, "")
-	if progress != "Downloading kernel | vmlinuz | 1.0 KB/2.0 KB | 512 B/s | ETA 2s" {
-		t.Fatalf("progress = %q", progress)
-	}
-	if got := formatProgressEvent(client.ProgressEvent{Status: "error", Error: "boom"}, "image"); got != "Error image | boom" {
-		t.Fatalf("error progress = %q", got)
-	}
-
-	if got := formatBootEvent(client.BootEvent{Kind: "status", Message: "starting"}); got != "Boot: starting" {
-		t.Fatalf("status boot = %q", got)
-	}
-	if got := formatBootEvent(client.BootEvent{Kind: "ready", State: client.InstanceState{Image: "alpine"}}); got != "Boot: ready alpine" {
-		t.Fatalf("ready boot = %q", got)
-	}
-	if got := formatBootEvent(client.BootEvent{Kind: "serial", Data: "console"}); got != "console" {
-		t.Fatalf("serial boot = %q", got)
-	}
-}
-
 func TestHandleVMForwardDispatchesToAPI(t *testing.T) {
 	api := &fakeCCAPI{}
 	if err := handleVMCommand(api, []string{"forward", "alpha", "8080:80"}); err != nil {

--- a/internal/fsimage/fat/deterministic_test.go
+++ b/internal/fsimage/fat/deterministic_test.go
@@ -13,108 +13,38 @@ import (
 func TestDeterministicGeneration(t *testing.T) {
 	const size = 1024 * 1024 * 1024 // 1GB - forces FAT32
 
-	// Test with deterministic config
-	t.Run("WithDeterministicConfig", func(t *testing.T) {
-		config := DefaultDeterministicConfig()
+	config := DefaultDeterministicConfig()
+	filesystem1 := createTestFilesystem(t, size, config)
+	filesystem2 := createTestFilesystem(t, size, config)
 
-		// Generate first filesystem
-		filesystem1 := createTestFilesystem(t, size, config)
-
-		// Generate second filesystem with identical config
-		filesystem2 := createTestFilesystem(t, size, config)
-
-		// Compare byte-for-byte
-		if !compareBytesEqual(filesystem1, filesystem2) {
-			t.Error("Deterministic filesystems should be byte-identical but differ")
-		}
-
-		// Verify using SHA256 hashes
-		hash1 := sha256.Sum256(filesystem1)
-		hash2 := sha256.Sum256(filesystem2)
-
-		if hash1 != hash2 {
-			t.Errorf("Filesystem hashes differ:\nFirst:  %x\nSecond: %x", hash1, hash2)
-		}
-	})
-
-	// Test without deterministic config (should be non-deterministic due to timestamps)
-	t.Run("WithoutDeterministicConfig", func(t *testing.T) {
-		// Generate first filesystem
-		filesystem1 := createTestFilesystem(t, size, nil)
-
-		// Longer delay to ensure different timestamps (FAT only has 2-second precision)
-		time.Sleep(3 * time.Second)
-
-		// Generate second filesystem
-		filesystem2 := createTestFilesystem(t, size, nil)
-
-		// Should be different due to timestamps
-		if compareBytesEqual(filesystem1, filesystem2) {
-			// Compare hashes for debugging
-			hash1 := sha256.Sum256(filesystem1)
-			hash2 := sha256.Sum256(filesystem2)
-			t.Errorf("Non-deterministic filesystems should differ but are identical:\nHash1: %x\nHash2: %x", hash1, hash2)
-		}
-	})
+	if !compareBytesEqual(filesystem1, filesystem2) {
+		t.Error("Deterministic filesystems should be byte-identical but differ")
+	}
 }
 
 // TestCustomDeterministicConfig tests different deterministic configurations
 func TestCustomDeterministicConfig(t *testing.T) {
 	const size = 1024 * 1024 * 1024 // 1GB
 
-	// Test with custom timestamp
-	t.Run("CustomTimestamp", func(t *testing.T) {
-		customTime := time.Date(2023, 12, 25, 10, 30, 0, 0, time.UTC)
-		volumeSerial := uint32(0xDEADBEEF)
+	customTime := time.Date(2023, 12, 25, 10, 30, 0, 0, time.UTC)
+	volumeSerial := uint32(0xDEADBEEF)
+	config := &DeterministicConfig{
+		FixedTimestamp:       &customTime,
+		SortDirectoryEntries: true,
+		VolumeSerial:         &volumeSerial,
+	}
 
-		config := &DeterministicConfig{
-			FixedTimestamp:       &customTime,
-			SortDirectoryEntries: true,
-			VolumeSerial:         &volumeSerial,
-		}
-
-		// Generate two filesystems with same custom config
-		filesystem1 := createTestFilesystem(t, size, config)
-		filesystem2 := createTestFilesystem(t, size, config)
-
-		// Should be identical
-		hash1 := sha256.Sum256(filesystem1)
-		hash2 := sha256.Sum256(filesystem2)
-
-		if hash1 != hash2 {
-			t.Errorf("Custom config filesystems should be identical but differ")
-		}
-	})
-
-	// Test with different volume serials
-	t.Run("DifferentVolumeSerials", func(t *testing.T) {
-		fatEpoch := time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
-
-		serial1 := uint32(0x11111111)
-		config1 := &DeterministicConfig{
-			FixedTimestamp:       &fatEpoch,
-			SortDirectoryEntries: true,
-			VolumeSerial:         &serial1,
-		}
-
-		serial2 := uint32(0x22222222)
-		config2 := &DeterministicConfig{
-			FixedTimestamp:       &fatEpoch,
-			SortDirectoryEntries: true,
-			VolumeSerial:         &serial2,
-		}
-
-		filesystem1 := createTestFilesystem(t, size, config1)
-		filesystem2 := createTestFilesystem(t, size, config2)
-
-		// Should be different due to different volume serials
-		hash1 := sha256.Sum256(filesystem1)
-		hash2 := sha256.Sum256(filesystem2)
-
-		if hash1 == hash2 {
-			t.Error("Filesystems with different volume serials should differ")
-		}
-	})
+	vmFS := vm.NewVirtualMemory(size, 4096)
+	writer, err := CreateFATFileSystemWithConfig(vmFS, size, config)
+	if err != nil {
+		t.Fatalf("Failed to create FAT filesystem: %v", err)
+	}
+	if got := writer.getTimestamp(); !got.Equal(customTime) {
+		t.Fatalf("timestamp = %s, want %s", got, customTime)
+	}
+	if got := writer.layout.Fs().VolumeId(); got != volumeSerial {
+		t.Fatalf("volume serial = %#x, want %#x", got, volumeSerial)
+	}
 }
 
 // TestDirectoryEntrySorting verifies that directory entries are sorted deterministically

--- a/internal/fsimage/fat/fat32_compliance_test.go
+++ b/internal/fsimage/fat/fat32_compliance_test.go
@@ -76,9 +76,6 @@ func TestFAT32Compliance(t *testing.T) {
 		testFAT32FieldValidation(t, writer)
 	})
 
-	t.Run("RootDirectoryClusterCompliance", func(t *testing.T) {
-		testRootDirectoryClusterCompliance(t, writer)
-	})
 }
 
 // testBootSectorCompliance verifies the primary boot sector meets FAT32 requirements
@@ -218,18 +215,4 @@ func testFAT32FieldValidation(t *testing.T, writer *FATWriter) {
 	if fs.LargeSectorCount() == 0 {
 		t.Error("FAT32 should have non-zero largeSectorCount")
 	}
-}
-
-// testRootDirectoryClusterCompliance verifies FAT32 root directory cluster handling
-func testRootDirectoryClusterCompliance(t *testing.T, writer *FATWriter) {
-	fs := writer.layout.Fs()
-
-	// Verify root directory starts at cluster 2
-	if fs.RootDirectoryCluster() != 2 {
-		t.Errorf("FAT32 root directory should start at cluster 2, got %d", fs.RootDirectoryCluster())
-	}
-
-	// TODO: Update this test to work with VirtualStorage interface
-	// For now, skip this part of the test until we implement proper reader integration
-	t.Log("Skipping reader test - needs update for VirtualStorage interface")
 }

--- a/internal/fsimage/fat/simple_deterministic_test.go
+++ b/internal/fsimage/fat/simple_deterministic_test.go
@@ -1,35 +1,11 @@
 package fat
 
 import (
-	"crypto/sha256"
 	"testing"
 	"time"
 
-	"j5.nz/cc/internal/fsimage/common"
 	"j5.nz/cc/internal/fsimage/vm"
 )
-
-// TestSimpleDeterministic tests basic deterministic filesystem generation
-func TestSimpleDeterministic(t *testing.T) {
-	const size = 1024 * 1024 * 1024 // 1GB
-
-	// Create deterministic config
-	config := DefaultDeterministicConfig()
-
-	// Generate filesystem twice with identical config
-	fs1 := createSimpleFilesystem(t, size, config)
-	fs2 := createSimpleFilesystem(t, size, config)
-
-	// Calculate hashes
-	hash1 := sha256.Sum256(fs1)
-	hash2 := sha256.Sum256(fs2)
-
-	if hash1 != hash2 {
-		t.Errorf("Deterministic filesystems should be identical:\nFirst:  %x\nSecond: %x", hash1, hash2)
-	} else {
-		t.Logf("SUCCESS: Deterministic filesystems are byte-identical (hash: %x)", hash1)
-	}
-}
 
 // TestVolumeSerialDeterminism tests that volume serial numbers work deterministically
 func TestVolumeSerialDeterminism(t *testing.T) {
@@ -58,81 +34,5 @@ func TestVolumeSerialDeterminism(t *testing.T) {
 
 	if actualSerial != customSerial {
 		t.Errorf("Volume serial mismatch: expected 0x%08X, got 0x%08X", customSerial, actualSerial)
-	} else {
-		t.Logf("SUCCESS: Volume serial correctly set to 0x%08X", actualSerial)
 	}
-}
-
-// TestTimestampDeterminism tests that timestamps are set deterministically
-func TestTimestampDeterminism(t *testing.T) {
-	const size = 1024 * 1024 * 1024 // 1GB
-
-	// Use a specific timestamp
-	customTime := time.Date(2024, 1, 15, 14, 30, 45, 0, time.UTC)
-	volumeSerial := uint32(0x12345678)
-
-	config := &DeterministicConfig{
-		FixedTimestamp:       &customTime,
-		SortDirectoryEntries: true,
-		VolumeSerial:         &volumeSerial,
-	}
-
-	// Create two filesystems
-	fs1 := createSimpleFilesystem(t, size, config)
-	fs2 := createSimpleFilesystem(t, size, config)
-
-	// They should be identical
-	if !compareBytesEqual(fs1, fs2) {
-		t.Error("Filesystems with fixed timestamps should be identical")
-	} else {
-		t.Log("SUCCESS: Fixed timestamps produce identical filesystems")
-	}
-}
-
-// createSimpleFilesystem creates a simple filesystem with minimal content
-func createSimpleFilesystem(t *testing.T, size int64, config *DeterministicConfig) []byte {
-	vmFS := vm.NewVirtualMemory(size, 4096)
-	writer, err := CreateFATFileSystemWithConfig(vmFS, size, config)
-	if err != nil {
-		t.Fatalf("Failed to create filesystem: %v", err)
-	}
-
-	// Get root directory
-	root, err := writer.WritableRootDirectory()
-	if err != nil {
-		t.Fatalf("Failed to get root: %v", err)
-	}
-
-	// Create a single file
-	fileNode, err := writer.AllocateNode()
-	if err != nil {
-		t.Fatalf("Failed to allocate node: %v", err)
-	}
-
-	if err := fileNode.SetName("hello.txt"); err != nil {
-		t.Fatalf("Failed to set name: %v", err)
-	}
-
-	content := vm.RawRegion([]byte("Hello, deterministic world!"))
-	if err := writer.WriteContents(fileNode, &content); err != nil {
-		t.Fatalf("Failed to write contents: %v", err)
-	}
-
-	// Write root directory
-	if err := writer.WriteDirectory(root, []common.WritableNode{fileNode}); err != nil {
-		t.Fatalf("Failed to write directory: %v", err)
-	}
-
-	// Finalize
-	if err := writer.Finalize(); err != nil {
-		t.Fatalf("Failed to finalize: %v", err)
-	}
-
-	// Extract bytes
-	data := make([]byte, size)
-	if _, err := vmFS.ReadAt(data, 0); err != nil {
-		t.Fatalf("Failed to read data: %v", err)
-	}
-
-	return data
 }

--- a/internal/vm/netstate/netstate_test.go
+++ b/internal/vm/netstate/netstate_test.go
@@ -1,20 +1,10 @@
 package netstate
 
 import (
-	"context"
 	"testing"
 
 	"j5.nz/cc/client"
 )
-
-func TestNetworkInstanceHelpersRequireNetwork(t *testing.T) {
-	if err := AddPortForwardToNetwork(nil, client.PortForward{}); err == nil {
-		t.Fatalf("AddPortForwardToNetwork nil error = %v", err)
-	}
-	if err := AllowServiceProxyPortOnNetwork(nil, 8080); err == nil {
-		t.Fatalf("AllowServiceProxyPortOnNetwork nil error = %v", err)
-	}
-}
 
 func TestManagedNetworkStateRequiresNetwork(t *testing.T) {
 	state := State{}
@@ -29,44 +19,6 @@ func TestManagedNetworkStateRequiresNetwork(t *testing.T) {
 	}
 }
 
-func TestManagedNetworkStatePortForwardFallback(t *testing.T) {
-	state := State{}
-	forward := client.PortForward{HostPort: 1000, GuestPort: 2000}
-	fallback := &recordingPortForwardFallback{}
-	if err := state.AddPortForwardWithFallback(context.Background(), forward, fallback); err != nil {
-		t.Fatalf("AddPortForwardWithFallback: %v", err)
-	}
-	if fallback.calls != 1 || fallback.forward != forward {
-		t.Fatalf("fallback = (%d, %+v), want one call with %+v", fallback.calls, fallback.forward, forward)
-	}
-	if err := state.AddPortForwardWithFallback(context.Background(), forward, nil); err == nil {
-		t.Fatalf("nil fallback error = %v", err)
-	}
-}
-
-func TestManagedNetworkWrapperHelpersRequireNetwork(t *testing.T) {
-	if err := AddManagedNetworkPortForward(context.Background(), nil, client.PortForward{}); err == nil {
-		t.Fatalf("AddManagedNetworkPortForward nil error = %v", err)
-	}
-	if err := AllowManagedNetworkServiceProxyPort(context.Background(), nil, 8080); err == nil {
-		t.Fatalf("AllowManagedNetworkServiceProxyPort nil error = %v", err)
-	}
-	if got := IPv4(nil, "10.42.0.99"); got != "10.42.0.99" {
-		t.Fatalf("IPv4 explicit = %q, want explicit address", got)
-	}
-}
-
-func TestManagedNetworkPortForwardWrapperUsesFallback(t *testing.T) {
-	fallback := &recordingPortForwardFallback{}
-	forward := client.PortForward{HostPort: 1000, GuestPort: 2000}
-	if err := AddManagedNetworkPortForwardWithFallback(context.Background(), nil, forward, fallback); err != nil {
-		t.Fatalf("AddManagedNetworkPortForwardWithFallback: %v", err)
-	}
-	if fallback.calls != 1 || fallback.forward != forward {
-		t.Fatalf("fallback = (%d, %+v), want one call with %+v", fallback.calls, fallback.forward, forward)
-	}
-}
-
 func TestManagedNetworkStateIPv4(t *testing.T) {
 	if got := (State{IPv4Addr: "10.42.0.99"}).IPv4(); got != "10.42.0.99" {
 		t.Fatalf("explicit IPv4 = %q", got)
@@ -74,17 +26,6 @@ func TestManagedNetworkStateIPv4(t *testing.T) {
 	if got := (State{Runtime: fakeRuntime{}}).IPv4(); got != "10.42.0.2" {
 		t.Fatalf("runtime default IPv4 = %q", got)
 	}
-}
-
-type recordingPortForwardFallback struct {
-	calls   int
-	forward client.PortForward
-}
-
-func (f *recordingPortForwardFallback) AddPortForward(_ context.Context, forward client.PortForward) error {
-	f.calls++
-	f.forward = forward
-	return nil
 }
 
 type fakeRuntime struct{}


### PR DESCRIPTION
## Summary
- remove helper/prose tests that preserved implementation shape instead of user behavior
- prune duplicate FAT determinism coverage and the 3-second non-determinism sleep
- narrow custom FAT deterministic config coverage to concrete metadata fields

## Tests
- `go test ./cmd/cc ./internal/fsimage/fat ./internal/vm/netstate -count=1`
- `go test ./...`