### PR TITLE
[codex] optimize virtio-net and netstack host paths

### DIFF
--- a/client/protocol.go
+++ b/client/protocol.go
@@ -299,6 +299,7 @@ type ShareMount struct {
 
 type NetworkConfig struct {
 	Enabled                  bool          `json:"enabled,omitempty"`
+	Mode                     string        `json:"mode,omitempty"`
 	AllowInternet            bool          `json:"allow_internet,omitempty"`
 	BlockHostAccess          bool          `json:"block_host_access,omitempty"`
 	GuestIPv4                string        `json:"guest_ipv4,omitempty"`

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1059,6 +1059,7 @@
         "type": "object",
         "properties": {
           "enabled": { "type": "boolean" },
+          "mode": { "type": "string" },
           "allow_internet": { "type": "boolean" },
           "block_host_access": { "type": "boolean" },
           "host_dns_name": { "type": "string" },

--- a/internal/netstack/buffers.go
+++ b/internal/netstack/buffers.go
@@ -51,7 +51,7 @@ var retainedPayloadPool = newByteSlicePool(4096, maxRetainedPayloadPoolSize)
 
 var proxyCopyBufferPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 64*1024)
+		return make([]byte, 256*1024)
 	},
 }
 
@@ -90,7 +90,7 @@ func getProxyCopyBuffer(size int) []byte {
 }
 
 func releaseProxyCopyBuffer(buf []byte) {
-	if cap(buf) != 64*1024 {
+	if cap(buf) != 256*1024 {
 		return
 	}
 	proxyCopyBufferPool.Put(buf[:cap(buf)])

--- a/internal/netstack/buffers.go
+++ b/internal/netstack/buffers.go
@@ -3,12 +3,51 @@ package netstack
 import "sync"
 
 const maxRetainedPayloadPoolSize = 256 * 1024
+const byteSlicePoolDepth = 256
 
-var retainedPayloadPool = sync.Pool{
-	New: func() any {
-		return make([]byte, 0, 4096)
-	},
+type byteSlicePool struct {
+	ch         chan []byte
+	defaultCap int
+	maxCap     int
 }
+
+func newByteSlicePool(defaultCap, maxCap int) *byteSlicePool {
+	return &byteSlicePool{
+		ch:         make(chan []byte, byteSlicePoolDepth),
+		defaultCap: defaultCap,
+		maxCap:     maxCap,
+	}
+}
+
+func (p *byteSlicePool) get(size int) []byte {
+	if size > p.maxCap {
+		return make([]byte, size)
+	}
+	select {
+	case buf := <-p.ch:
+		if cap(buf) >= size {
+			return buf[:size]
+		}
+	default:
+	}
+	capacity := p.defaultCap
+	if capacity < size {
+		capacity = size
+	}
+	return make([]byte, size, capacity)
+}
+
+func (p *byteSlicePool) put(buf []byte) {
+	if buf == nil || cap(buf) > p.maxCap {
+		return
+	}
+	select {
+	case p.ch <- buf[:0]:
+	default:
+	}
+}
+
+var retainedPayloadPool = newByteSlicePool(4096, maxRetainedPayloadPoolSize)
 
 var proxyCopyBufferPool = sync.Pool{
 	New: func() any {
@@ -29,12 +68,7 @@ func retainPayload(src []byte) []byte {
 		copy(dst, src)
 		return dst
 	}
-	dst := retainedPayloadPool.Get().([]byte)
-	if cap(dst) < len(src) {
-		retainedPayloadPool.Put(dst[:0])
-		dst = make([]byte, len(src))
-	}
-	dst = dst[:len(src)]
+	dst := retainedPayloadPool.get(len(src))
 	copy(dst, src)
 	return dst
 }
@@ -43,7 +77,7 @@ func releasePayload(buf []byte) {
 	if buf == nil || cap(buf) > maxRetainedPayloadPoolSize {
 		return
 	}
-	retainedPayloadPool.Put(buf[:0])
+	retainedPayloadPool.put(buf)
 }
 
 func getProxyCopyBuffer(size int) []byte {

--- a/internal/netstack/host_path_benchmark_test.go
+++ b/internal/netstack/host_path_benchmark_test.go
@@ -1,0 +1,346 @@
+package netstack
+
+import (
+	"encoding/binary"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var (
+	benchmarkHostMAC  = net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x01}
+	benchmarkGuestMAC = net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}
+	benchmarkGuestIP  = net.IPv4(10, 42, 0, 2)
+	benchmarkHostIP   = net.IPv4(10, 42, 0, 1)
+)
+
+type benchmarkTCPFrame struct {
+	seq   uint32
+	ack   uint32
+	flags uint8
+}
+
+type benchmarkHarness struct {
+	stack *NetStack
+	nic   *NetworkInterface
+
+	tcpFrames chan benchmarkTCPFrame
+}
+
+func newBenchmarkHarness(tb testing.TB) *benchmarkHarness {
+	tb.Helper()
+
+	ns := New(nil)
+	if err := ns.SetGuestMAC(benchmarkGuestMAC); err != nil {
+		tb.Fatal(err)
+	}
+	if err := ns.SetHostMAC(benchmarkHostMAC); err != nil {
+		tb.Fatal(err)
+	}
+	nic, err := ns.AttachNetworkInterface()
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	h := &benchmarkHarness{
+		stack:     ns,
+		nic:       nic,
+		tcpFrames: make(chan benchmarkTCPFrame, 1024),
+	}
+	nic.AttachVirtioBackend(func(frame []byte) error {
+		if tcp, ok := parseBenchmarkTCPFrame(frame); ok {
+			select {
+			case h.tcpFrames <- tcp:
+			default:
+			}
+		}
+		return nil
+	})
+	tb.Cleanup(func() {
+		_ = ns.Close()
+	})
+	return h
+}
+
+func TestChecksumValidationIsOptIn(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		enable  bool
+		wantPkt uint64
+	}{
+		{name: "defaultDisabled", wantPkt: 1},
+		{name: "enabled", enable: true, wantPkt: 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newBenchmarkHarness(t)
+			h.stack.SetChecksumValidationEnabled(tt.enable)
+
+			var packets atomic.Uint64
+			if err := h.stack.BindUDPCallback(":10053", func(_ *udpCallbackEndpoint, data []byte, _ net.UDPAddr) {
+				if len(data) != 32 {
+					t.Fatalf("payload size = %d, want 32", len(data))
+				}
+				packets.Add(1)
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			frame := buildBenchmarkUDPFrame(40200, 10053, benchmarkPayload(32))
+			frame[len(frame)-1] ^= 0xff
+			if err := h.nic.DeliverGuestPacket(frame, true); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := packets.Load(); got != tt.wantPkt {
+				t.Fatalf("delivered packets = %d, want %d", got, tt.wantPkt)
+			}
+		})
+	}
+}
+
+func BenchmarkHostPathUDPReadFrom(b *testing.B) {
+	for _, size := range []int{64, 512, 1400} {
+		b.Run(payloadBenchmarkName(size), func(b *testing.B) {
+			h := newBenchmarkHarness(b)
+			pc, err := h.stack.ListenPacketInternal("udp", ":10053")
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			var readWG sync.WaitGroup
+			readWG.Add(1)
+			go func() {
+				defer readWG.Done()
+				buf := make([]byte, 2048)
+				for {
+					if _, _, err := pc.ReadFrom(buf); err != nil {
+						return
+					}
+				}
+			}()
+			b.Cleanup(func() {
+				_ = pc.Close()
+				readWG.Wait()
+			})
+
+			payload := benchmarkPayload(size)
+			frame := buildBenchmarkUDPFrame(40200, 10053, payload)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := h.nic.DeliverGuestPacket(frame, true); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkHostPathUDPCallback(b *testing.B) {
+	for _, size := range []int{64, 512, 1400} {
+		b.Run(payloadBenchmarkName(size), func(b *testing.B) {
+			h := newBenchmarkHarness(b)
+			var packets atomic.Uint64
+			if err := h.stack.BindUDPCallback(":10053", func(_ *udpCallbackEndpoint, data []byte, _ net.UDPAddr) {
+				if len(data) != size {
+					b.Fatalf("payload size = %d, want %d", len(data), size)
+				}
+				packets.Add(1)
+			}); err != nil {
+				b.Fatal(err)
+			}
+
+			payload := benchmarkPayload(size)
+			frame := buildBenchmarkUDPFrame(40200, 10053, payload)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := h.nic.DeliverGuestPacket(frame, true); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			if got := packets.Load(); got != uint64(b.N) {
+				b.Fatalf("delivered packets = %d, want %d", got, b.N)
+			}
+		})
+	}
+}
+
+func BenchmarkHostPathTCPListenerIngress(b *testing.B) {
+	for _, size := range []int{64, 512, 1400} {
+		b.Run(payloadBenchmarkName(size), func(b *testing.B) {
+			h := newBenchmarkHarness(b)
+			conn, guestSeq, hostAck := establishBenchmarkTCPConn(b, h, 40300, 10080)
+
+			var readWG sync.WaitGroup
+			readWG.Add(1)
+			go func() {
+				defer readWG.Done()
+				buf := make([]byte, 2048)
+				for {
+					if _, err := conn.Read(buf); err != nil {
+						return
+					}
+				}
+			}()
+			b.Cleanup(func() {
+				_ = conn.Close()
+				readWG.Wait()
+			})
+
+			payload := benchmarkPayload(size)
+			frame := buildBenchmarkTCPFrame(40300, 10080, guestSeq, hostAck, tcpFlagACK|tcpFlagPSH, payload)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				updateBenchmarkTCPFrame(frame, guestSeq+uint32(i*size), hostAck)
+				if err := h.nic.DeliverGuestPacket(frame, true); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func establishBenchmarkTCPConn(
+	b *testing.B,
+	h *benchmarkHarness,
+	srcPort, dstPort uint16,
+) (net.Conn, uint32, uint32) {
+	b.Helper()
+
+	ln, err := h.stack.ListenInternal("tcp", net.JoinHostPort("", itoa(int(dstPort))))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	const guestInitialSeq = 1_000_000
+	syn := buildBenchmarkTCPFrame(srcPort, dstPort, guestInitialSeq, 0, tcpFlagSYN, nil)
+	if err := h.nic.DeliverGuestPacket(syn, true); err != nil {
+		b.Fatal(err)
+	}
+
+	synAck := <-h.tcpFrames
+	if synAck.flags&(tcpFlagSYN|tcpFlagACK) != tcpFlagSYN|tcpFlagACK {
+		b.Fatalf("handshake frame flags = 0x%02x, want SYN|ACK", synAck.flags)
+	}
+
+	guestSeq := uint32(guestInitialSeq + 1)
+	hostAck := synAck.seq + 1
+	ack := buildBenchmarkTCPFrame(srcPort, dstPort, guestSeq, hostAck, tcpFlagACK, nil)
+	if err := h.nic.DeliverGuestPacket(ack, true); err != nil {
+		b.Fatal(err)
+	}
+
+	select {
+	case conn := <-accepted:
+		return conn, guestSeq, hostAck
+	case <-time.After(2 * time.Second):
+		b.Fatal("listener did not accept benchmark TCP connection")
+		return nil, 0, 0
+	}
+}
+
+func buildBenchmarkUDPFrame(srcPort, dstPort uint16, payload []byte) []byte {
+	frame := make([]byte, ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen+len(payload))
+	buildEthernetHeaderInto(frame[:ethernetHeaderLen], mustBenchmarkMAC(benchmarkHostMAC), mustBenchmarkMAC(benchmarkGuestMAC), etherTypeIPv4)
+
+	udp := frame[ethernetHeaderLen+ipv4HeaderLen:]
+	binary.BigEndian.PutUint16(udp[0:2], srcPort)
+	binary.BigEndian.PutUint16(udp[2:4], dstPort)
+	binary.BigEndian.PutUint16(udp[4:6], uint16(udpHeaderLen+len(payload)))
+	copy(udp[udpHeaderLen:], payload)
+	binary.BigEndian.PutUint16(udp[6:8], 0)
+	binary.BigEndian.PutUint16(udp[6:8], udpChecksum(benchmarkGuestIP, benchmarkHostIP, udp))
+
+	buildIPv4HeaderInto(frame[ethernetHeaderLen:ethernetHeaderLen+ipv4HeaderLen], benchmarkGuestIP, benchmarkHostIP, udpProtocolNumber, len(udp))
+	return frame
+}
+
+func buildBenchmarkTCPFrame(srcPort, dstPort uint16, seq, ack uint32, flags uint16, payload []byte) []byte {
+	frame := make([]byte, ethernetHeaderLen+ipv4HeaderLen+tcpHeaderLen+len(payload))
+	buildEthernetHeaderInto(frame[:ethernetHeaderLen], mustBenchmarkMAC(benchmarkHostMAC), mustBenchmarkMAC(benchmarkGuestMAC), etherTypeIPv4)
+
+	tcp := frame[ethernetHeaderLen+ipv4HeaderLen:]
+	binary.BigEndian.PutUint16(tcp[0:2], srcPort)
+	binary.BigEndian.PutUint16(tcp[2:4], dstPort)
+	tcp[12] = byte(tcpHeaderLen/4) << 4
+	tcp[13] = byte(flags)
+	binary.BigEndian.PutUint16(tcp[14:16], 0xffff)
+	copy(tcp[tcpHeaderLen:], payload)
+
+	buildIPv4HeaderInto(frame[ethernetHeaderLen:ethernetHeaderLen+ipv4HeaderLen], benchmarkGuestIP, benchmarkHostIP, tcpProtocolNumber, len(tcp))
+	updateBenchmarkTCPFrame(frame, seq, ack)
+	return frame
+}
+
+func updateBenchmarkTCPFrame(frame []byte, seq, ack uint32) {
+	tcp := frame[ethernetHeaderLen+ipv4HeaderLen:]
+	binary.BigEndian.PutUint32(tcp[4:8], seq)
+	binary.BigEndian.PutUint32(tcp[8:12], ack)
+	binary.BigEndian.PutUint16(tcp[16:18], 0)
+	binary.BigEndian.PutUint16(tcp[16:18], tcpChecksum(benchmarkGuestIP, benchmarkHostIP, tcp))
+}
+
+func parseBenchmarkTCPFrame(frame []byte) (benchmarkTCPFrame, bool) {
+	if len(frame) < ethernetHeaderLen+ipv4HeaderLen+tcpHeaderLen {
+		return benchmarkTCPFrame{}, false
+	}
+	if etherType(binary.BigEndian.Uint16(frame[12:14])) != etherTypeIPv4 {
+		return benchmarkTCPFrame{}, false
+	}
+	ip := frame[ethernetHeaderLen:]
+	if protocolNumber(ip[9]) != tcpProtocolNumber {
+		return benchmarkTCPFrame{}, false
+	}
+	ihl := int(ip[0]&0x0f) * 4
+	if len(ip) < ihl+tcpHeaderLen {
+		return benchmarkTCPFrame{}, false
+	}
+	tcp := ip[ihl:]
+	return benchmarkTCPFrame{
+		seq:   binary.BigEndian.Uint32(tcp[4:8]),
+		ack:   binary.BigEndian.Uint32(tcp[8:12]),
+		flags: tcp[13],
+	}, true
+}
+
+func benchmarkPayload(size int) []byte {
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	return payload
+}
+
+func payloadBenchmarkName(size int) string {
+	return itoa(size) + "B"
+}
+
+func mustBenchmarkMAC(mac net.HardwareAddr) macAddr {
+	value, ok := macToUint64(mac)
+	if !ok {
+		panic("invalid benchmark MAC")
+	}
+	return value
+}

--- a/internal/netstack/host_path_benchmark_test.go
+++ b/internal/netstack/host_path_benchmark_test.go
@@ -2,6 +2,8 @@ package netstack
 
 import (
 	"encoding/binary"
+	"errors"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -174,7 +176,7 @@ func BenchmarkHostPathUDPCallback(b *testing.B) {
 }
 
 func BenchmarkHostPathTCPListenerIngress(b *testing.B) {
-	for _, size := range []int{64, 512, 1400} {
+	for _, size := range []int{64, 512, 1400, 16 * 1024, 64 * 1024} {
 		b.Run(payloadBenchmarkName(size), func(b *testing.B) {
 			h := newBenchmarkHarness(b)
 			conn, guestSeq, hostAck := establishBenchmarkTCPConn(b, h, 40300, 10080)
@@ -209,6 +211,52 @@ func BenchmarkHostPathTCPListenerIngress(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkHostPathTCPWriteTo(b *testing.B) {
+	for _, size := range []int{512, 1400, 16 * 1024, 64 * 1024} {
+		b.Run(payloadBenchmarkName(size), func(b *testing.B) {
+			h := newBenchmarkHarness(b)
+			conn, _, _ := establishBenchmarkTCPConn(b, h, 40300, 10080)
+			tcpConn := conn.(*tcpConn)
+			writer := &benchmarkCountingWriter{}
+			done := make(chan error, 1)
+			go func() {
+				_, err := tcpConn.WriteTo(writer)
+				done <- err
+			}()
+
+			payload := benchmarkPayload(size)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tcpConn.recvBuf <- retainPayload(payload)
+			}
+			b.StopTimer()
+			tcpConn.recvBuf <- nil
+			if err := <-done; err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+				b.Fatal(err)
+			}
+			_ = conn.Close()
+			if got := writer.bytes.Load(); got != uint64(b.N*size) {
+				b.Fatalf("writer bytes = %d, want %d", got, b.N*size)
+			}
+			b.ReportMetric(float64(writer.writes.Load())/float64(b.N), "writes/pkt")
+		})
+	}
+}
+
+type benchmarkCountingWriter struct {
+	bytes  atomic.Uint64
+	writes atomic.Uint64
+}
+
+func (w *benchmarkCountingWriter) Write(p []byte) (int, error) {
+	w.writes.Add(1)
+	w.bytes.Add(uint64(len(p)))
+	return len(p), nil
 }
 
 func establishBenchmarkTCPConn(

--- a/internal/netstack/host_path_benchmark_test.go
+++ b/internal/netstack/host_path_benchmark_test.go
@@ -262,6 +262,10 @@ func establishBenchmarkTCPConn(
 }
 
 func buildBenchmarkUDPFrame(srcPort, dstPort uint16, payload []byte) []byte {
+	return buildBenchmarkUDPFrameTo(srcPort, dstPort, benchmarkHostIP, payload)
+}
+
+func buildBenchmarkUDPFrameTo(srcPort, dstPort uint16, dstIP net.IP, payload []byte) []byte {
 	frame := make([]byte, ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen+len(payload))
 	buildEthernetHeaderInto(frame[:ethernetHeaderLen], mustBenchmarkMAC(benchmarkHostMAC), mustBenchmarkMAC(benchmarkGuestMAC), etherTypeIPv4)
 
@@ -271,9 +275,9 @@ func buildBenchmarkUDPFrame(srcPort, dstPort uint16, payload []byte) []byte {
 	binary.BigEndian.PutUint16(udp[4:6], uint16(udpHeaderLen+len(payload)))
 	copy(udp[udpHeaderLen:], payload)
 	binary.BigEndian.PutUint16(udp[6:8], 0)
-	binary.BigEndian.PutUint16(udp[6:8], udpChecksum(benchmarkGuestIP, benchmarkHostIP, udp))
+	binary.BigEndian.PutUint16(udp[6:8], udpChecksum(benchmarkGuestIP, dstIP, udp))
 
-	buildIPv4HeaderInto(frame[ethernetHeaderLen:ethernetHeaderLen+ipv4HeaderLen], benchmarkGuestIP, benchmarkHostIP, udpProtocolNumber, len(udp))
+	buildIPv4HeaderInto(frame[ethernetHeaderLen:ethernetHeaderLen+ipv4HeaderLen], benchmarkGuestIP, dstIP, udpProtocolNumber, len(udp))
 	return frame
 }
 

--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -138,11 +138,7 @@ var (
 			return make([]byte, 0, defaultPacketCapacity)
 		},
 	}
-	ethernetFramePool = sync.Pool{
-		New: func() any {
-			return make([]byte, 0, defaultPacketCapacity+ethernetHeaderLen)
-		},
-	}
+	ethernetFramePool = newByteSlicePool(defaultPacketCapacity+ethernetHeaderLen, maxEthernetFramePoolLen)
 )
 
 func getTCPPacketBuffer(payloadLen int) []byte {
@@ -205,12 +201,7 @@ func getEthernetFrameBuffer(payloadLen int) []byte {
 	if total > maxEthernetFramePoolLen {
 		return make([]byte, total)
 	}
-	raw := ethernetFramePool.Get().([]byte)
-	if cap(raw) < total {
-		ethernetFramePool.Put(raw[:0])
-		return make([]byte, total)
-	}
-	return raw[:total]
+	return ethernetFramePool.get(total)
 }
 
 func putEthernetFrameBuffer(buf []byte) {
@@ -220,7 +211,7 @@ func putEthernetFrameBuffer(buf []byte) {
 	if cap(buf) > maxEthernetFramePoolLen {
 		return
 	}
-	ethernetFramePool.Put(buf[:0])
+	ethernetFramePool.put(buf)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -250,6 +241,7 @@ type NetStack struct {
 	serviceProxyEnabled bool // Forward connections destined to serviceIPv4
 	hostAccessEnabled   bool // Expose host/service addresses to guest-originated flows
 	allowInternet       bool // Allow DNS fallback et al
+	validateChecksums   atomic.Bool
 	serviceProxyPortsMu sync.RWMutex
 	serviceProxyPorts   map[uint16]struct{}
 
@@ -270,7 +262,8 @@ type NetStack struct {
 	randSource *rand.Rand
 
 	// UDP state.
-	udpSockets sync.Map
+	udpMu      sync.RWMutex
+	udpSockets map[uint16]udpEndpoint
 
 	// Embedded DNS server (optional).
 	dnsServer *dnsServer
@@ -303,6 +296,7 @@ func New(l *slog.Logger) *NetStack {
 		allowInternet:       true,
 		tcpListen:           make(map[uint16]*tcpListener),
 		tcpConns:            make(map[tcpFourTuple]*tcpConn),
+		udpSockets:          make(map[uint16]udpEndpoint),
 		randSource:          rand.New(rand.NewSource(now)),
 	}
 	stack.tcpDial = stack.defaultOutboundTCPDial
@@ -408,14 +402,20 @@ func (ns *NetStack) Close() error {
 			_ = c.Close()
 		}
 
-		// Close UDP endpoints.
-		ns.udpSockets.Range(func(key, value any) bool {
-			if c, ok := value.(io.Closer); ok {
-				_ = c.Close()
+		var udpEndpoints []udpEndpoint
+		ns.udpMu.Lock()
+		if ns.udpSockets != nil {
+			udpEndpoints = make([]udpEndpoint, 0, len(ns.udpSockets))
+			for _, ep := range ns.udpSockets {
+				udpEndpoints = append(udpEndpoints, ep)
 			}
-			ns.udpSockets.Delete(key)
-			return true
-		})
+			ns.udpSockets = make(map[uint16]udpEndpoint)
+		}
+		ns.udpMu.Unlock()
+
+		for _, ep := range udpEndpoints {
+			_ = ep.Close()
+		}
 
 		// Stop packet capture.
 		ns.pcapMu.Lock()
@@ -524,6 +524,14 @@ func (ns *NetStack) AllowServiceProxyPort(port int) {
 // SetInternetAccessEnabled toggles access to real DNS lookups, etc.
 func (ns *NetStack) SetInternetAccessEnabled(enabled bool) {
 	ns.allowInternet = enabled
+}
+
+// SetChecksumValidationEnabled toggles inbound IPv4, ICMP, UDP, and TCP
+// checksum validation. Validation is disabled by default because the managed
+// guest path is a same-host virtual link where the checksum cost is usually
+// higher than its value as a corruption detector.
+func (ns *NetStack) SetChecksumValidationEnabled(enabled bool) {
+	ns.validateChecksums.Store(enabled)
 }
 
 // SetHostDNSName configures the synthetic DNS name for the host computer.
@@ -1096,15 +1104,16 @@ func (ns *NetStack) handleIPv4Internal(srcMAC net.HardwareAddr, payload []byte, 
 			srcMAC.String(), hdr.src.String(), hdr.dst.String(), hdr.protocol.String(), len(hdr.payload), releaseUnsafe)
 	}
 
-	// Validate IPv4 header checksum before processing.
-	// A correct checksum will result in 0 when computed over the entire header.
-	headerLen := int(hdr.ihl) * 4
-	if headerLen <= len(payload) {
-		computed := ipv4Checksum(payload[:headerLen])
-		if computed != 0 {
-			tracef("netstack.handleIPv4 drop invalidHeaderChecksum", "computed=0x%04x", computed)
-			// Invalid checksum, drop silently
-			return nil
+	if ns.validateChecksums.Load() {
+		// A correct IPv4 header checksum results in 0 when computed over the
+		// entire header, including the checksum field itself.
+		headerLen := int(hdr.ihl) * 4
+		if headerLen <= len(payload) {
+			computed := ipv4Checksum(payload[:headerLen])
+			if computed != 0 {
+				tracef("netstack.handleIPv4 drop invalidHeaderChecksum", "computed=0x%04x", computed)
+				return nil
+			}
 		}
 	}
 
@@ -1149,17 +1158,18 @@ func (ns *NetStack) handleICMP(h ipv4Header, payload []byte) error {
 	}
 	tracef("netstack.handleICMP echoRequest", "src=%s dst=%s len=%d", h.src.String(), h.dst.String(), len(payload))
 
-	// Validate ICMP checksum
-	receivedChecksum := binary.BigEndian.Uint16(payload[2:4])
-	binary.BigEndian.PutUint16(payload[2:4], 0) // Zero checksum for validation
-	calculatedChecksum := checksum(payload)
-	binary.BigEndian.PutUint16(payload[2:4], receivedChecksum) // Restore original
-	if receivedChecksum != calculatedChecksum {
-		tracef("netstack.handleICMP drop invalidChecksum", "received=0x%04x calculated=0x%04x", receivedChecksum, calculatedChecksum)
-		slog.Error("raw: drop icmp packet with invalid checksum",
-			"received", fmt.Sprintf("0x%04x", receivedChecksum),
-			"calculated", fmt.Sprintf("0x%04x", calculatedChecksum))
-		return nil
+	if ns.validateChecksums.Load() {
+		receivedChecksum := binary.BigEndian.Uint16(payload[2:4])
+		binary.BigEndian.PutUint16(payload[2:4], 0)
+		calculatedChecksum := checksum(payload)
+		binary.BigEndian.PutUint16(payload[2:4], receivedChecksum)
+		if receivedChecksum != calculatedChecksum {
+			tracef("netstack.handleICMP drop invalidChecksum", "received=0x%04x calculated=0x%04x", receivedChecksum, calculatedChecksum)
+			slog.Error("raw: drop icmp packet with invalid checksum",
+				"received", fmt.Sprintf("0x%04x", receivedChecksum),
+				"calculated", fmt.Sprintf("0x%04x", calculatedChecksum))
+			return nil
+		}
 	}
 
 	return ns.sendICMPEchoReply(h.dst, h.src, payload)
@@ -1221,27 +1231,26 @@ func (ns *NetStack) handleUDPWithReuse(h ipv4Header, payload []byte, releaseUnsa
 		return fmt.Errorf("udp length exceeds payload: %d > %d", length, len(payload))
 	}
 
-	// Validate UDP checksum if present (checksum of 0 means not computed).
-	udpChksum := binary.BigEndian.Uint16(payload[6:8])
-	if udpChksum != 0 {
+	if ns.validateChecksums.Load() && binary.BigEndian.Uint16(payload[6:8]) != 0 {
 		computed := udpChecksum(h.src, h.dst, payload[:length])
 		if computed != 0 {
 			tracef("netstack.udpEndpointConn drop invalidChecksum", "src=%s:%d dst=%s:%d computed=0x%04x", h.src.String(), srcPort, h.dst.String(), dstPort, computed)
-			// Invalid checksum, drop silently
 			return nil
 		}
 	}
 
 	data := payload[8:length]
-	tracef("netstack.udpEndpointConn", "src=%s:%d dst=%s:%d dataLen=%d releaseUnsafe=%t", h.src.String(), srcPort, h.dst.String(), dstPort, len(data), releaseUnsafe)
+	if netstackTraceEnabled {
+		tracef("netstack.udpEndpointConn", "src=%s:%d dst=%s:%d dataLen=%d releaseUnsafe=%t", h.src.String(), srcPort, h.dst.String(), dstPort, len(data), releaseUnsafe)
+	}
 
-	v, ok := ns.udpSockets.Load(dstPort)
+	ns.udpMu.RLock()
+	ep, ok := ns.udpSockets[dstPort]
+	ns.udpMu.RUnlock()
 	if !ok {
 		tracef("netstack.udpEndpointConn drop noSocket", "dstPort=%d", dstPort)
 		return nil
 	}
-
-	ep := v.(udpEndpoint)
 
 	addrIP := h.src.To4()
 	if addrIP == nil {
@@ -1251,12 +1260,6 @@ func (ns *NetStack) handleUDPWithReuse(h ipv4Header, payload []byte, releaseUnsa
 	addr := net.UDPAddr{
 		IP:   addrIP,
 		Port: int(srcPort),
-	}
-
-	if releaseUnsafe {
-		if _, ok := ep.(*udpCallbackEndpoint); ok {
-			addr.IP = append([]byte(nil), addr.IP...)
-		}
 	}
 
 	if err := ep.enqueue(data, addr); err != nil {
@@ -1459,7 +1462,9 @@ func (ep *udpEndpointConn) Close() error {
 		case pkt := <-ep.incoming:
 			releasePayload(pkt.payload)
 		default:
-			ep.stack.udpSockets.Delete(ep.port)
+			ep.stack.udpMu.Lock()
+			delete(ep.stack.udpSockets, ep.port)
+			ep.stack.udpMu.Unlock()
 			return nil
 		}
 	}
@@ -1758,12 +1763,12 @@ func (c *tcpConn) completeDial(err error) {
 
 // handleTCP demuxes by 4-tuple to an existing conn or establishes a new one.
 func (ns *NetStack) handleTCP(h ipv4Header, payload []byte) error {
-	// Validate TCP checksum with pseudo-header before parsing.
-	computed := tcpChecksum(h.src, h.dst, payload)
-	if computed != 0 {
-		tracef("netstack.handleTCP drop invalidChecksum", "src=%s dst=%s computed=0x%04x", h.src.String(), h.dst.String(), computed)
-		// Invalid checksum, drop silently
-		return nil
+	if ns.validateChecksums.Load() {
+		computed := tcpChecksum(h.src, h.dst, payload)
+		if computed != 0 {
+			tracef("netstack.handleTCP drop invalidChecksum", "src=%s dst=%s computed=0x%04x", h.src.String(), h.dst.String(), computed)
+			return nil
+		}
 	}
 
 	hdr, err := parseTCPHeader(payload)
@@ -3024,15 +3029,21 @@ func (ns *NetStack) ListenPacketInternal(
 		return nil, err
 	}
 
-	ep, loaded := ns.udpSockets.LoadOrStore(addr.Port, newUDPEndpointConn(ns, addr.Port))
-	if loaded {
+	ep := newUDPEndpointConn(ns, addr.Port)
+	ns.udpMu.Lock()
+	if _, ok := ns.udpSockets[addr.Port]; ok {
+		ns.udpMu.Unlock()
 		return nil, fmt.Errorf("udp port %d already in use", addr.Port)
 	}
+	ns.udpSockets[addr.Port] = ep
+	ns.udpMu.Unlock()
 
-	return ep.(*udpEndpointConn), nil
+	return ep, nil
 }
 
-// UDPCallback is a function type for handling UDP packets
+// UDPCallback is a function type for handling UDP packets. The data and addr
+// are borrowed for the duration of the callback; copy anything retained after
+// the callback returns.
 type UDPCallback func(ep *udpCallbackEndpoint, data []byte, addr net.UDPAddr)
 
 type udpCallbackEndpoint struct {
@@ -3094,7 +3105,9 @@ func (ep *udpCallbackEndpoint) Close() error {
 	}
 	ep.closed.Store(true)
 
-	ep.stack.udpSockets.Delete(ep.port)
+	ep.stack.udpMu.Lock()
+	delete(ep.stack.udpSockets, ep.port)
+	ep.stack.udpMu.Unlock()
 	return nil
 }
 
@@ -3109,10 +3122,14 @@ func (ns *NetStack) BindUDPCallback(address string, callback UDPCallback) error 
 		return err
 	}
 
-	_, loaded := ns.udpSockets.LoadOrStore(addr.Port, newUDPCallbackEndpoint(ns, addr.Port, callback))
-	if loaded {
+	ep := newUDPCallbackEndpoint(ns, addr.Port, callback)
+	ns.udpMu.Lock()
+	if _, ok := ns.udpSockets[addr.Port]; ok {
+		ns.udpMu.Unlock()
 		return fmt.Errorf("udp port %d already in use", addr.Port)
 	}
+	ns.udpSockets[addr.Port] = ep
+	ns.udpMu.Unlock()
 
 	return nil
 }
@@ -3549,12 +3566,11 @@ func (ns *NetStack) collectDebugStatus() debugStatus {
 	}
 	ns.tcpMu.Unlock()
 
-	ns.udpSockets.Range(func(key, value any) bool {
-		if port, ok := key.(uint16); ok {
-			status.UDPSockets = append(status.UDPSockets, port)
-		}
-		return true
-	})
+	ns.udpMu.RLock()
+	for port := range ns.udpSockets {
+		status.UDPSockets = append(status.UDPSockets, port)
+	}
+	ns.udpMu.RUnlock()
 
 	sort.Slice(status.TCPListeners, func(i, j int) bool { return status.TCPListeners[i] < status.TCPListeners[j] })
 	sort.Strings(status.TCPConnections)

--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -2464,6 +2464,9 @@ func (c *tcpConn) Read(b []byte) (int, error) {
 // buffer before the kernel write.
 func (c *tcpConn) WriteTo(w io.Writer) (int64, error) {
 	var written int64
+	batch := getProxyCopyBuffer(64 * 1024)
+	defer releaseProxyCopyBuffer(batch)
+
 	for {
 		data, owned, err := c.nextReadPayload()
 		if err != nil {
@@ -2472,23 +2475,76 @@ func (c *tcpConn) WriteTo(w io.Writer) (int64, error) {
 			}
 			return written, err
 		}
-		remaining := data
-		for len(remaining) > 0 {
-			n, writeErr := w.Write(remaining)
-			if n > 0 {
-				written += int64(n)
-				remaining = remaining[n:]
+		if len(data) >= cap(batch) {
+			n, err := writeFull(w, data)
+			written += n
+			releasePayload(owned)
+			if err != nil {
+				return written, err
 			}
-			if writeErr != nil {
-				releasePayload(owned)
-				return written, writeErr
+			continue
+		}
+
+		batch = batch[:0]
+		eofAfterBatch := false
+		for {
+			if len(data) > cap(batch)-len(batch) {
+				n, err := writeFull(w, batch)
+				written += n
+				if err != nil {
+					releasePayload(owned)
+					return written, err
+				}
+				batch = batch[:0]
 			}
-			if n == 0 {
+			batch = append(batch, data...)
+			releasePayload(owned)
+
+			var ok bool
+			data, owned, ok, err = c.tryNextReadPayload()
+			if err != nil {
+				if err == io.EOF {
+					eofAfterBatch = true
+					break
+				}
+				n, writeErr := writeFull(w, batch)
+				written += n
+				if writeErr != nil {
+					return written, writeErr
+				}
+				return written, err
+			}
+			if !ok {
+				break
+			}
+			if len(data) >= cap(batch) && len(batch) > 0 {
+				n, err := writeFull(w, batch)
+				written += n
+				if err != nil {
+					releasePayload(owned)
+					return written, err
+				}
+				batch = batch[:0]
+			}
+			if len(data) >= cap(batch) {
+				n, err := writeFull(w, data)
+				written += n
 				releasePayload(owned)
-				return written, io.ErrShortWrite
+				if err != nil {
+					return written, err
+				}
+				break
 			}
 		}
-		releasePayload(owned)
+
+		n, err := writeFull(w, batch)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		if eofAfterBatch {
+			return written, nil
+		}
 	}
 }
 
@@ -2536,6 +2592,51 @@ func (c *tcpConn) nextReadPayload() ([]byte, []byte, error) {
 	case <-timeout:
 		return nil, nil, &net.OpError{Op: "read", Net: "tcp", Err: tcpTimeoutError{}}
 	}
+}
+
+func (c *tcpConn) tryNextReadPayload() ([]byte, []byte, bool, error) {
+	c.mu.Lock()
+	if len(c.readPending) > 0 {
+		data := c.readPending
+		owned := c.readPendingBuf
+		c.readPending = nil
+		c.readPendingBuf = nil
+		c.mu.Unlock()
+		return data, owned, true, nil
+	}
+	buf := c.recvBuf
+	c.mu.Unlock()
+
+	select {
+	case data, ok := <-buf:
+		if !ok {
+			return nil, nil, false, net.ErrClosed
+		}
+		if data == nil {
+			return nil, nil, false, io.EOF
+		}
+		return data, data, true, nil
+	default:
+		return nil, nil, false, nil
+	}
+}
+
+func writeFull(w io.Writer, data []byte) (int64, error) {
+	var written int64
+	for len(data) > 0 {
+		n, err := w.Write(data)
+		if n > 0 {
+			written += int64(n)
+			data = data[n:]
+		}
+		if err != nil {
+			return written, err
+		}
+		if n == 0 {
+			return written, io.ErrShortWrite
+		}
+	}
+	return written, nil
 }
 
 // Write transmits payload to the guest.
@@ -3122,6 +3223,7 @@ func (ns *NetStack) startServiceProxy(conn *tcpConn) {
 			_ = conn.Close()
 			return
 		}
+		tuneProxyTCPConn(outbound)
 		defer outbound.Close()
 		defer conn.Close()
 
@@ -3152,6 +3254,9 @@ func (ns *NetStack) startOutboundTCPProxy(conn *tcpConn) {
 			_ = conn.Close()
 			return
 		}
+		if tcpConn, ok := outbound.(*net.TCPConn); ok {
+			tuneProxyTCPConn(tcpConn)
+		}
 		defer outbound.Close()
 		defer conn.Close()
 
@@ -3161,6 +3266,15 @@ func (ns *NetStack) startOutboundTCPProxy(conn *tcpConn) {
 			slog.Error("raw: outbound proxy", "err", err)
 		}
 	}()
+}
+
+func tuneProxyTCPConn(conn *net.TCPConn) {
+	if conn == nil {
+		return
+	}
+	_ = conn.SetNoDelay(true)
+	_ = conn.SetReadBuffer(4 * 1024 * 1024)
+	_ = conn.SetWriteBuffer(4 * 1024 * 1024)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -265,6 +265,9 @@ type NetStack struct {
 	udpMu      sync.RWMutex
 	udpSockets map[uint16]udpEndpoint
 
+	udpProxyMu        sync.Mutex
+	udpServiceProxies map[udpProxyKey]*udpServiceProxyConn
+
 	// Embedded DNS server (optional).
 	dnsServer *dnsServer
 
@@ -297,6 +300,7 @@ func New(l *slog.Logger) *NetStack {
 		tcpListen:           make(map[uint16]*tcpListener),
 		tcpConns:            make(map[tcpFourTuple]*tcpConn),
 		udpSockets:          make(map[uint16]udpEndpoint),
+		udpServiceProxies:   make(map[udpProxyKey]*udpServiceProxyConn),
 		randSource:          rand.New(rand.NewSource(now)),
 	}
 	stack.tcpDial = stack.defaultOutboundTCPDial
@@ -415,6 +419,21 @@ func (ns *NetStack) Close() error {
 
 		for _, ep := range udpEndpoints {
 			_ = ep.Close()
+		}
+
+		var udpProxies []*udpServiceProxyConn
+		ns.udpProxyMu.Lock()
+		if ns.udpServiceProxies != nil {
+			udpProxies = make([]*udpServiceProxyConn, 0, len(ns.udpServiceProxies))
+			for _, proxy := range ns.udpServiceProxies {
+				udpProxies = append(udpProxies, proxy)
+			}
+			ns.udpServiceProxies = make(map[udpProxyKey]*udpServiceProxyConn)
+		}
+		ns.udpProxyMu.Unlock()
+		for _, proxy := range udpProxies {
+			_ = proxy.conn.Close()
+			<-proxy.done
 		}
 
 		// Stop packet capture.
@@ -1208,6 +1227,22 @@ type udpPacket struct {
 	addr    net.UDPAddr
 }
 
+type udpProxyKey struct {
+	srcIP   [4]byte
+	srcPort uint16
+	dstPort uint16
+}
+
+type udpServiceProxyConn struct {
+	stack    *NetStack
+	key      udpProxyKey
+	conn     *net.UDPConn
+	done     chan struct{}
+	lastUsed atomic.Int64
+}
+
+const udpServiceProxyIdleTimeout = 30 * time.Second
+
 // handleUDP parses the UDP header and enqueues payloads to bound endpoints.
 func (ns *NetStack) handleUDP(h ipv4Header, payload []byte) error {
 	return ns.handleUDPWithReuse(h, payload, false)
@@ -1244,6 +1279,15 @@ func (ns *NetStack) handleUDPWithReuse(h ipv4Header, payload []byte, releaseUnsa
 		tracef("netstack.udpEndpointConn", "src=%s:%d dst=%s:%d dataLen=%d releaseUnsafe=%t", h.src.String(), srcPort, h.dst.String(), dstPort, len(data), releaseUnsafe)
 	}
 
+	dstIP := h.dst.To4()
+	if ns.shouldProxyService(dstIP) {
+		if !ns.serviceProxyEnabled || !ns.serviceProxyAllowed(dstIP, dstPort) {
+			tracef("netstack.handleUDP service proxy disabled", "src=%s:%d dst=%s:%d", h.src.String(), srcPort, h.dst.String(), dstPort)
+			return nil
+		}
+		return ns.proxyServiceUDP(h.src.To4(), srcPort, dstPort, data)
+	}
+
 	ns.udpMu.RLock()
 	ep, ok := ns.udpSockets[dstPort]
 	ns.udpMu.RUnlock()
@@ -1274,6 +1318,111 @@ func (ns *NetStack) handleUDPWithReuse(h ipv4Header, payload []byte, releaseUnsa
 	return nil
 }
 
+func (ns *NetStack) proxyServiceUDP(srcIP net.IP, srcPort, dstPort uint16, payload []byte) error {
+	if srcIP == nil {
+		return fmt.Errorf("udp service proxy source ip is not ipv4")
+	}
+	var key udpProxyKey
+	copy(key.srcIP[:], srcIP)
+	key.srcPort = srcPort
+	key.dstPort = dstPort
+
+	proxy, err := ns.getUDPServiceProxy(key)
+	if err != nil {
+		return err
+	}
+	proxy.lastUsed.Store(time.Now().UnixNano())
+	if _, err := proxy.conn.Write(payload); err != nil {
+		return err
+	}
+	ns.udpRxPackets.Add(1)
+	return nil
+}
+
+func (ns *NetStack) getUDPServiceProxy(key udpProxyKey) (*udpServiceProxyConn, error) {
+	ns.udpProxyMu.Lock()
+	if proxy, ok := ns.udpServiceProxies[key]; ok {
+		ns.udpProxyMu.Unlock()
+		return proxy, nil
+	}
+	ns.udpProxyMu.Unlock()
+
+	addr := &net.UDPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: int(key.dstPort),
+	}
+	conn, err := net.DialUDP("udp", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+	proxy := &udpServiceProxyConn{
+		stack: ns,
+		key:   key,
+		conn:  conn,
+		done:  make(chan struct{}),
+	}
+	proxy.lastUsed.Store(time.Now().UnixNano())
+
+	ns.udpProxyMu.Lock()
+	if existing, ok := ns.udpServiceProxies[key]; ok {
+		ns.udpProxyMu.Unlock()
+		_ = conn.Close()
+		return existing, nil
+	}
+	ns.udpServiceProxies[key] = proxy
+	ns.udpProxyMu.Unlock()
+
+	go proxy.readLoop()
+	return proxy, nil
+}
+
+func (p *udpServiceProxyConn) readLoop() {
+	defer func() {
+		p.stack.udpProxyMu.Lock()
+		if p.stack.udpServiceProxies[p.key] == p {
+			delete(p.stack.udpServiceProxies, p.key)
+		}
+		p.stack.udpProxyMu.Unlock()
+		_ = p.conn.Close()
+		close(p.done)
+	}()
+
+	buf := make([]byte, maxEthernetFramePoolLen)
+	for {
+		if err := p.conn.SetReadDeadline(time.Now().Add(udpServiceProxyIdleTimeout)); err != nil {
+			return
+		}
+		n, err := p.conn.Read(buf)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				if time.Since(time.Unix(0, p.lastUsed.Load())) < udpServiceProxyIdleTimeout {
+					continue
+				}
+				return
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			slog.Debug("raw: udp service proxy read failed", "port", p.key.dstPort, "err", err)
+			return
+		}
+
+		frameLen := ethernetHeaderLen + ipv4HeaderLen + udpHeaderLen + n
+		frame := getEthernetFrameBuffer(frameLen)
+		copy(frame[ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen:], buf[:n])
+		dstIP := net.IP(p.key.srcIP[:])
+		err = p.stack.sendUDP(frame, p.key.dstPort, p.key.srcPort, net.IP(p.stack.serviceIPv4[:]), dstIP, n)
+		putEthernetFrameBuffer(frame)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			slog.Debug("raw: udp service proxy send failed", "port", p.key.dstPort, "err", err)
+			return
+		}
+	}
+}
+
 // sendUDP crafts and transmits a UDP packet to the guest.
 func (ns *NetStack) sendUDP(
 	buf []byte,
@@ -1288,13 +1437,15 @@ func (ns *NetStack) sendUDP(
 	tracef("netstack.sendUDPPacket", "src=%s:%d dst=%s:%d payloadLen=%d", srcIP.String(), srcPort, dstIP.String(), dstPort, payloadLen)
 
 	totalLen := 8 + payloadLen
-	packet := buf[ethernetHeaderLen+ipv4HeaderLen:]
+	packet := buf[ethernetHeaderLen+ipv4HeaderLen : ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen+payloadLen]
 	binary.BigEndian.PutUint16(packet[0:2], srcPort)
 	binary.BigEndian.PutUint16(packet[2:4], dstPort)
 	binary.BigEndian.PutUint16(packet[4:6], uint16(totalLen))
 	copy(packet[8:], buf[ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen:])
 
 	zeroOut := packet[6:8]
+	zeroOut[0] = 0
+	zeroOut[1] = 0
 	check := udpChecksum(srcIP, dstIP, packet)
 	binary.BigEndian.PutUint16(zeroOut, check)
 

--- a/internal/netstack/netstack_test.go
+++ b/internal/netstack/netstack_test.go
@@ -2,8 +2,10 @@ package netstack
 
 import (
 	"bytes"
+	"encoding/binary"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestAttachNetworkInterfaceGeneratesUnicastHostMAC(t *testing.T) {
@@ -50,4 +52,100 @@ func TestSetHostMACRejectsMulticast(t *testing.T) {
 	if err := ns.SetHostMAC(net.HardwareAddr{0x03, 0x42, 0x0a, 0x2a, 0x00, 0x01}); err == nil {
 		t.Fatal("SetHostMAC accepted multicast MAC")
 	}
+}
+
+func TestServiceProxyBridgesUDP(t *testing.T) {
+	host, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer host.Close()
+	hostPort := host.LocalAddr().(*net.UDPAddr).Port
+
+	hostPayloads := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 2048)
+		n, addr, err := host.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		hostPayloads <- append([]byte(nil), buf[:n]...)
+		_, _ = host.WriteTo([]byte("pong"), addr)
+	}()
+
+	h := newBenchmarkHarness(t)
+	guestFrames := make(chan []byte, 1)
+	h.nic.AttachVirtioBackend(func(frame []byte) error {
+		guestFrames <- append([]byte(nil), frame...)
+		return nil
+	})
+
+	guestPort := uint16(40200)
+	serviceIP := net.IP(h.stack.serviceIPv4[:])
+	frame := buildBenchmarkUDPFrameTo(guestPort, uint16(hostPort), serviceIP, []byte("ping"))
+	if err := h.nic.DeliverGuestPacket(frame, true); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-hostPayloads:
+		if !bytes.Equal(got, []byte("ping")) {
+			t.Fatalf("host udp payload = %q, want ping", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("host did not receive proxied UDP payload")
+	}
+
+	select {
+	case reply := <-guestFrames:
+		srcIP, dstIP, srcPort, dstPort, payload, ok := parseTestUDPFrame(reply)
+		if !ok {
+			t.Fatalf("reply frame is not UDP: %x", reply)
+		}
+		if !srcIP.Equal(serviceIP) {
+			t.Fatalf("reply src ip = %s, want %s", srcIP, serviceIP)
+		}
+		if !dstIP.Equal(benchmarkGuestIP) {
+			t.Fatalf("reply dst ip = %s, want %s", dstIP, benchmarkGuestIP)
+		}
+		if srcPort != uint16(hostPort) || dstPort != guestPort {
+			t.Fatalf("reply ports = %d -> %d, want %d -> %d", srcPort, dstPort, hostPort, guestPort)
+		}
+		udp := reply[ethernetHeaderLen+ipv4HeaderLen : ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen+len(payload)]
+		if got := udpChecksum(srcIP, dstIP, udp); got != 0 {
+			t.Fatalf("reply udp checksum = 0x%04x, want 0", got)
+		}
+		if !bytes.Equal(payload, []byte("pong")) {
+			t.Fatalf("reply payload = %q, want pong", payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("guest did not receive UDP service proxy reply")
+	}
+}
+
+func parseTestUDPFrame(frame []byte) (srcIP, dstIP net.IP, srcPort, dstPort uint16, payload []byte, ok bool) {
+	if len(frame) < ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen {
+		return nil, nil, 0, 0, nil, false
+	}
+	if etherType(binary.BigEndian.Uint16(frame[12:14])) != etherTypeIPv4 {
+		return nil, nil, 0, 0, nil, false
+	}
+	ip := frame[ethernetHeaderLen:]
+	if protocolNumber(ip[9]) != udpProtocolNumber {
+		return nil, nil, 0, 0, nil, false
+	}
+	ihl := int(ip[0]&0x0f) * 4
+	if len(ip) < ihl+udpHeaderLen {
+		return nil, nil, 0, 0, nil, false
+	}
+	udp := ip[ihl:]
+	length := int(binary.BigEndian.Uint16(udp[4:6]))
+	if length < udpHeaderLen || len(udp) < length {
+		return nil, nil, 0, 0, nil, false
+	}
+	return net.IP(ip[12:16]), net.IP(ip[16:20]),
+		binary.BigEndian.Uint16(udp[0:2]),
+		binary.BigEndian.Uint16(udp[2:4]),
+		udp[udpHeaderLen:length],
+		true
 }

--- a/internal/virtio/net.go
+++ b/internal/virtio/net.go
@@ -17,7 +17,9 @@ const (
 
 	netQueueSize = 256
 
+	netFeatureCSUM          = uint64(1) << 0
 	netFeatureMAC           = uint64(1) << 5
+	netFeatureHostTSO4      = uint64(1) << 11
 	netFeatureStatus        = uint64(1) << 16
 	netFeatureMergeRX       = uint64(1) << 15
 	netHdrFlagNeedsChecksum = 1
@@ -90,27 +92,28 @@ type Net struct {
 	MAC        net.HardwareAddr
 	LegacyMMIO bool
 
-	DisableMergeRX   bool
-	HeaderLength     int
-	mu               sync.Mutex
-	mem              GuestMemory
-	irq              IRQController
-	backend          NetBackend
-	deviceFeatureSel uint32
-	driverFeatureSel uint32
-	driverFeatures   uint64
-	queueSel         uint32
-	status           uint32
-	interruptStatus  uint32
-	irqHigh          bool
-	configGeneration uint32
-	queues           [2]queue
-	pendingRx        [][]byte
-	legacy           bool
-	scratch2         [2]byte
-	scratch4         [4]byte
-	scratch8         [8]byte
-	scratch16        [16]byte
+	DisableMergeRX     bool
+	CompleteTXChecksum bool
+	HeaderLength       int
+	mu                 sync.Mutex
+	mem                GuestMemory
+	irq                IRQController
+	backend            NetBackend
+	deviceFeatureSel   uint32
+	driverFeatureSel   uint32
+	driverFeatures     uint64
+	queueSel           uint32
+	status             uint32
+	interruptStatus    uint32
+	irqHigh            bool
+	configGeneration   uint32
+	queues             [2]queue
+	pendingRx          [][]byte
+	legacy             bool
+	scratch2           [2]byte
+	scratch4           [4]byte
+	scratch8           [8]byte
+	scratch16          [16]byte
 }
 
 type netTXPacket struct {
@@ -120,11 +123,12 @@ type netTXPacket struct {
 
 func NewNet(base, size uint64, irq uint32, mac net.HardwareAddr, backend NetBackend) *Net {
 	n := &Net{
-		Base:    base,
-		Size:    size,
-		IRQ:     irq,
-		MAC:     append(net.HardwareAddr(nil), mac...),
-		backend: backend,
+		Base:               base,
+		Size:               size,
+		IRQ:                irq,
+		MAC:                append(net.HardwareAddr(nil), mac...),
+		backend:            backend,
+		CompleteTXChecksum: true,
 	}
 	if len(n.MAC) != 6 {
 		n.MAC = net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}
@@ -591,10 +595,12 @@ func (n *Net) processTXLocked(packets []netTXPacket) ([]netTXPacket, error) {
 		}
 		releaseData := data
 		if len(data) >= headerLen {
-			if err := fixTXChecksum(data, headerLen); err != nil {
-				releaseNetPacketBuffer(releaseData)
-				releaseNetTXPackets(packets)
-				return nil, err
+			if n.CompleteTXChecksum {
+				if err := fixTXChecksum(data, headerLen); err != nil {
+					releaseNetPacketBuffer(releaseData)
+					releaseNetTXPackets(packets)
+					return nil, err
+				}
 			}
 			packet := data[headerLen:]
 			if n.backend != nil {
@@ -947,7 +953,7 @@ func (n *Net) legacyFeaturesLocked() uint64 {
 }
 
 func (n *Net) deviceFeaturesLocked() uint64 {
-	features := featureVersion1 | netFeatureMAC | netFeatureStatus
+	features := featureVersion1 | netFeatureCSUM | netFeatureMAC | netFeatureHostTSO4 | netFeatureStatus
 	if !n.DisableMergeRX {
 		features |= netFeatureMergeRX
 	}

--- a/internal/virtio/net.go
+++ b/internal/virtio/net.go
@@ -26,13 +26,52 @@ const (
 	netHeaderLen         = 10
 	netHeaderLenMergeRX  = 12
 	maxNetPacketPoolSize = 256 * 1024
+	netPacketPoolDepth   = 256
 )
 
-var netPacketPool = sync.Pool{
-	New: func() any {
-		return make([]byte, 0, 2048)
-	},
+type netByteSlicePool struct {
+	ch         chan []byte
+	defaultCap int
+	maxCap     int
 }
+
+func newNetByteSlicePool(defaultCap, maxCap int) *netByteSlicePool {
+	return &netByteSlicePool{
+		ch:         make(chan []byte, netPacketPoolDepth),
+		defaultCap: defaultCap,
+		maxCap:     maxCap,
+	}
+}
+
+func (p *netByteSlicePool) get(size int) []byte {
+	if size > p.maxCap {
+		return make([]byte, size)
+	}
+	select {
+	case buf := <-p.ch:
+		if cap(buf) >= size {
+			return buf[:size]
+		}
+	default:
+	}
+	capacity := p.defaultCap
+	if capacity < size {
+		capacity = size
+	}
+	return make([]byte, size, capacity)
+}
+
+func (p *netByteSlicePool) put(buf []byte) {
+	if buf == nil || cap(buf) > p.maxCap {
+		return
+	}
+	select {
+	case p.ch <- buf[:0]:
+	default:
+	}
+}
+
+var netPacketPool = newNetByteSlicePool(2048, maxNetPacketPoolSize)
 
 var netTXPacketBatchPool = sync.Pool{
 	New: func() any {
@@ -68,6 +107,10 @@ type Net struct {
 	queues           [2]queue
 	pendingRx        [][]byte
 	legacy           bool
+	scratch2         [2]byte
+	scratch4         [4]byte
+	scratch8         [8]byte
+	scratch16        [16]byte
 }
 
 type netTXPacket struct {
@@ -211,6 +254,7 @@ func (n *Net) Write(addr uint64, size int, value uint64) error {
 			if value == 0 {
 				q.lastAvailIdx = 0
 				q.usedIdx = 0
+				q.clearCache()
 			} else if n.queueSel == netQueueRX {
 				if err := n.processRXLocked(); err != nil {
 					n.mu.Unlock()
@@ -231,6 +275,7 @@ func (n *Net) Write(addr uint64, size int, value uint64) error {
 					q.descAddr = 0
 					q.availAddr = 0
 					q.usedAddr = 0
+					q.clearCache()
 					n.mu.Unlock()
 					return nil
 				}
@@ -246,26 +291,32 @@ func (n *Net) Write(addr uint64, size int, value uint64) error {
 	case regQueueDescLow:
 		if q := n.selectedQueueLocked(); q != nil {
 			n.setQueueAddr(&q.descAddr, uint32(value), true)
+			q.clearCache()
 		}
 	case regQueueDescHigh:
 		if q := n.selectedQueueLocked(); q != nil {
 			n.setQueueAddr(&q.descAddr, uint32(value), false)
+			q.clearCache()
 		}
 	case regQueueAvailLow:
 		if q := n.selectedQueueLocked(); q != nil {
 			n.setQueueAddr(&q.availAddr, uint32(value), true)
+			q.clearCache()
 		}
 	case regQueueAvailHigh:
 		if q := n.selectedQueueLocked(); q != nil {
 			n.setQueueAddr(&q.availAddr, uint32(value), false)
+			q.clearCache()
 		}
 	case regQueueUsedLow:
 		if q := n.selectedQueueLocked(); q != nil {
 			n.setQueueAddr(&q.usedAddr, uint32(value), true)
+			q.clearCache()
 		}
 	case regQueueUsedHigh:
 		if q := n.selectedQueueLocked(); q != nil {
 			n.setQueueAddr(&q.usedAddr, uint32(value), false)
+			q.clearCache()
 		}
 	case regInterruptAck:
 		n.interruptStatus &^= uint32(value)
@@ -285,11 +336,11 @@ func (n *Net) Write(addr uint64, size int, value uint64) error {
 			n.mu.Unlock()
 			if err != nil {
 				releaseNetTXPackets(packets)
-				releaseNetTXPacketBatch(packetBatch)
+				releaseNetTXPacketBatch(packetBatch, len(packets))
 				return err
 			}
 			err = n.deliverTXPackets(packets)
-			releaseNetTXPacketBatch(packetBatch)
+			releaseNetTXPacketBatch(packetBatch, len(packets))
 			return err
 		case netQueueRX:
 			err := n.processRXLocked()
@@ -353,6 +404,7 @@ func (n *Net) WriteLegacy(offset uint16, size int, value uint64) error {
 				q.descAddr = 0
 				q.availAddr = 0
 				q.usedAddr = 0
+				q.clearCache()
 				n.mu.Unlock()
 				return nil
 			}
@@ -374,11 +426,11 @@ func (n *Net) WriteLegacy(offset uint16, size int, value uint64) error {
 			n.mu.Unlock()
 			if err != nil {
 				releaseNetTXPackets(packets)
-				releaseNetTXPacketBatch(packetBatch)
+				releaseNetTXPacketBatch(packetBatch, len(packets))
 				return err
 			}
 			err = n.deliverTXPackets(packets)
-			releaseNetTXPacketBatch(packetBatch)
+			releaseNetTXPacketBatch(packetBatch, len(packets))
 			return err
 		case netQueueRX:
 			err := n.processRXLocked()
@@ -407,6 +459,15 @@ func (n *Net) EnqueueRxPacketOwned(packet []byte) error {
 func (n *Net) enqueueRxPacket(packet []byte, owned bool) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if len(n.pendingRx) == 0 {
+		delivered, err := n.processOneRXPacketLocked(packet)
+		if err != nil {
+			return err
+		}
+		if delivered {
+			return nil
+		}
+	}
 	if !owned {
 		packet = append([]byte(nil), packet...)
 	}
@@ -415,25 +476,22 @@ func (n *Net) enqueueRxPacket(packet []byte, owned bool) error {
 }
 
 func getNetPacketBuffer() []byte {
-	return netPacketPool.Get().([]byte)[:0]
+	return netPacketPool.get(0)
 }
 
 func releaseNetPacketBuffer(buf []byte) {
-	if buf == nil || cap(buf) > maxNetPacketPoolSize {
-		return
-	}
-	netPacketPool.Put(buf[:0])
+	netPacketPool.put(buf)
 }
 
 func getNetTXPacketBatch() *[netQueueSize]netTXPacket {
 	return netTXPacketBatchPool.Get().(*[netQueueSize]netTXPacket)
 }
 
-func releaseNetTXPacketBatch(batch *[netQueueSize]netTXPacket) {
+func releaseNetTXPacketBatch(batch *[netQueueSize]netTXPacket, used int) {
 	if batch == nil {
 		return
 	}
-	clear(batch[:])
+	clear(batch[:used])
 	netTXPacketBatchPool.Put(batch)
 }
 
@@ -449,31 +507,89 @@ func readGuestMemoryInto(mem GuestMemory, addr uint64, dst []byte) error {
 	return nil
 }
 
+func (n *Net) readIPAInto(addr uint64, dst []byte) error {
+	return readGuestMemoryInto(n.mem, addr, dst)
+}
+
+func (n *Net) ensureQueueCacheLocked(q *queue) error {
+	if q.size == 0 || q.descAddr == 0 || q.availAddr == 0 || q.usedAddr == 0 {
+		return nil
+	}
+	if q.descMem != nil && q.availMem != nil && q.usedMem != nil {
+		return nil
+	}
+	slicer, ok := n.mem.(guestMemorySlicer)
+	if !ok {
+		return nil
+	}
+	descLen := int(q.size) * 16
+	availLen := 4 + int(q.size)*2 + 2
+	usedLen := 4 + int(q.size)*8 + 2
+	descMem, err := slicer.SliceIPA(q.descAddr, descLen)
+	if err != nil {
+		return err
+	}
+	availMem, err := slicer.SliceIPA(q.availAddr, availLen)
+	if err != nil {
+		return err
+	}
+	usedMem, err := slicer.SliceIPA(q.usedAddr, usedLen)
+	if err != nil {
+		return err
+	}
+	q.descMem = descMem
+	q.availMem = availMem
+	q.usedMem = usedMem
+	return nil
+}
+
+func (n *Net) readAvailHeaderLocked(q *queue) (flags uint16, idx uint16, err error) {
+	if err := n.ensureQueueCacheLocked(q); err != nil {
+		return 0, 0, err
+	}
+	if len(q.availMem) >= 4 {
+		return binary.LittleEndian.Uint16(q.availMem[0:2]), binary.LittleEndian.Uint16(q.availMem[2:4]), nil
+	}
+	if err := n.readIPAInto(q.availAddr, n.scratch4[:]); err != nil {
+		return 0, 0, err
+	}
+	return binary.LittleEndian.Uint16(n.scratch4[0:2]), binary.LittleEndian.Uint16(n.scratch4[2:4]), nil
+}
+
+func (n *Net) readAvailRingEntryLocked(q *queue, slot uint16) (uint16, error) {
+	offset := 4 + int(slot)*2
+	if len(q.availMem) >= offset+2 {
+		return binary.LittleEndian.Uint16(q.availMem[offset : offset+2]), nil
+	}
+	if err := n.readIPAInto(q.availAddr+uint64(offset), n.scratch2[:]); err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint16(n.scratch2[:]), nil
+}
+
 func (n *Net) processTXLocked(packets []netTXPacket) ([]netTXPacket, error) {
 	q := &n.queues[netQueueTX]
 	if !q.ready || q.size == 0 || n.mem == nil {
 		return nil, nil
 	}
-	header, err := n.mem.ReadIPA(q.availAddr, 4)
+	_, availIdx, err := n.readAvailHeaderLocked(q)
 	if err != nil {
 		return nil, err
 	}
-	availIdx := binary.LittleEndian.Uint16(header[2:4])
+	headerLen := n.netHeaderLenLocked()
 	for q.lastAvailIdx != availIdx {
 		slot := q.lastAvailIdx % q.size
-		entry, err := n.mem.ReadIPA(q.availAddr+4+uint64(slot)*2, 2)
+		head, err := n.readAvailRingEntryLocked(q, slot)
 		if err != nil {
 			releaseNetTXPackets(packets)
 			return nil, err
 		}
-		head := binary.LittleEndian.Uint16(entry)
 		data, err := n.readChainLocked(q, head, false)
 		if err != nil {
 			releaseNetTXPackets(packets)
 			return nil, err
 		}
 		releaseData := data
-		headerLen := n.netHeaderLenLocked()
 		if len(data) >= headerLen {
 			if err := fixTXChecksum(data, headerLen); err != nil {
 				releaseNetPacketBuffer(releaseData)
@@ -535,19 +651,17 @@ func (n *Net) processRXLocked() error {
 	if !q.ready || q.size == 0 || n.mem == nil || len(n.pendingRx) == 0 {
 		return nil
 	}
-	header, err := n.mem.ReadIPA(q.availAddr, 4)
+	_, availIdx, err := n.readAvailHeaderLocked(q)
 	if err != nil {
 		return err
 	}
-	availIdx := binary.LittleEndian.Uint16(header[2:4])
 	processed := false
 	for q.lastAvailIdx != availIdx && len(n.pendingRx) > 0 {
 		slot := q.lastAvailIdx % q.size
-		entry, err := n.mem.ReadIPA(q.availAddr+4+uint64(slot)*2, 2)
+		head, err := n.readAvailRingEntryLocked(q, slot)
 		if err != nil {
 			return err
 		}
-		head := binary.LittleEndian.Uint16(entry)
 		packet := n.pendingRx[0]
 		written, err := n.writeRXPacketLocked(q, head, packet)
 		if err != nil {
@@ -565,6 +679,35 @@ func (n *Net) processRXLocked() error {
 		return n.updateIRQLocked()
 	}
 	return nil
+}
+
+func (n *Net) processOneRXPacketLocked(packet []byte) (bool, error) {
+	q := &n.queues[netQueueRX]
+	if !q.ready || q.size == 0 || n.mem == nil {
+		return false, nil
+	}
+	_, availIdx, err := n.readAvailHeaderLocked(q)
+	if err != nil {
+		return false, err
+	}
+	if q.lastAvailIdx == availIdx {
+		return false, nil
+	}
+	slot := q.lastAvailIdx % q.size
+	head, err := n.readAvailRingEntryLocked(q, slot)
+	if err != nil {
+		return false, err
+	}
+	written, err := n.writeRXPacketLocked(q, head, packet)
+	if err != nil {
+		return false, err
+	}
+	if err := n.writeUsedLocked(q, head, written); err != nil {
+		return false, err
+	}
+	q.lastAvailIdx++
+	n.interruptStatus |= intVring
+	return true, n.updateIRQLocked()
 }
 
 func (n *Net) readChainLocked(q *queue, head uint16, writable bool) ([]byte, error) {
@@ -603,7 +746,8 @@ func (n *Net) readChainLocked(q *queue, head uint16, writable bool) ([]byte, err
 
 func (n *Net) writeRXPacketLocked(q *queue, head uint16, packet []byte) (uint32, error) {
 	headerLen := n.netHeaderLenLocked()
-	var hdr [netHeaderLenMergeRX]byte
+	hdr := n.scratch16[:netHeaderLenMergeRX]
+	clear(hdr)
 	if headerLen == netHeaderLenMergeRX {
 		binary.LittleEndian.PutUint16(hdr[10:12], 1)
 	}
@@ -673,9 +817,18 @@ func (n *Net) readDescriptorLocked(q *queue, index uint16) (descriptor, error) {
 	if index >= q.size {
 		return descriptor{}, fmt.Errorf("descriptor index %d out of range", index)
 	}
-	buf, err := n.mem.ReadIPA(q.descAddr+uint64(index)*16, 16)
-	if err != nil {
+	if err := n.ensureQueueCacheLocked(q); err != nil {
 		return descriptor{}, err
+	}
+	offset := int(index) * 16
+	var buf []byte
+	if len(q.descMem) >= offset+16 {
+		buf = q.descMem[offset : offset+16]
+	} else {
+		if err := n.readIPAInto(q.descAddr+uint64(offset), n.scratch16[:]); err != nil {
+			return descriptor{}, err
+		}
+		buf = n.scratch16[:]
 	}
 	return descriptor{
 		addr:   binary.LittleEndian.Uint64(buf[0:8]),
@@ -687,16 +840,27 @@ func (n *Net) readDescriptorLocked(q *queue, index uint16) (descriptor, error) {
 
 func (n *Net) writeUsedLocked(q *queue, head uint16, usedLen uint32) error {
 	slot := q.usedIdx % q.size
-	var elem [8]byte
-	binary.LittleEndian.PutUint32(elem[0:4], uint32(head))
-	binary.LittleEndian.PutUint32(elem[4:8], usedLen)
-	if err := n.mem.WriteIPA(q.usedAddr+4+uint64(slot)*8, elem[:]); err != nil {
+	if err := n.ensureQueueCacheLocked(q); err != nil {
 		return err
 	}
+	offset := 4 + int(slot)*8
+	if len(q.usedMem) >= offset+8 {
+		binary.LittleEndian.PutUint32(q.usedMem[offset:offset+4], uint32(head))
+		binary.LittleEndian.PutUint32(q.usedMem[offset+4:offset+8], usedLen)
+	} else {
+		binary.LittleEndian.PutUint32(n.scratch8[0:4], uint32(head))
+		binary.LittleEndian.PutUint32(n.scratch8[4:8], usedLen)
+		if err := n.mem.WriteIPA(q.usedAddr+4+uint64(slot)*8, n.scratch8[:]); err != nil {
+			return err
+		}
+	}
 	q.usedIdx++
-	var idx [2]byte
-	binary.LittleEndian.PutUint16(idx[:], q.usedIdx)
-	return n.mem.WriteIPA(q.usedAddr+2, idx[:])
+	if len(q.usedMem) >= 4 {
+		binary.LittleEndian.PutUint16(q.usedMem[2:4], q.usedIdx)
+		return nil
+	}
+	binary.LittleEndian.PutUint16(n.scratch2[:], q.usedIdx)
+	return n.mem.WriteIPA(q.usedAddr+2, n.scratch2[:])
 }
 
 func (n *Net) selectedQueueLocked() *queue {
@@ -715,6 +879,7 @@ func (n *Net) setQueueAddr(target *uint64, value uint32, low bool) {
 }
 
 func (n *Net) configureLegacyQueueLocked(q *queue, pfn uint32) {
+	q.clearCache()
 	if q.size == 0 {
 		q.size = netQueueSize
 	}

--- a/internal/virtio/net_benchmark_test.go
+++ b/internal/virtio/net_benchmark_test.go
@@ -1,0 +1,119 @@
+package virtio
+
+import (
+	"encoding/binary"
+	"net"
+	"strconv"
+	"testing"
+)
+
+const (
+	benchNetQueuePFN = 0x10
+	benchNetQueue    = benchNetQueuePFN * 4096
+	benchNetBufBase  = 0x20000
+)
+
+type benchNetBackend struct {
+	packets int
+	bytes   int
+}
+
+func (b *benchNetBackend) HandleTxPacket(packet []byte) error {
+	b.packets++
+	b.bytes += len(packet)
+	return nil
+}
+
+func BenchmarkNetLegacyTXNotify(b *testing.B) {
+	for _, size := range []int{64, 512, 1400} {
+		b.Run(benchNetPayloadName(size), func(b *testing.B) {
+			mem := make(testGuestMemory, 0x120000)
+			backend := &benchNetBackend{}
+			dev := NewNet(0, 0x1000, 11, net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}, backend)
+			dev.DisableMergeRX = true
+			dev.Attach(mem, &testIRQ{})
+			configureLegacyNetQueue(b, dev, netQueueTX)
+
+			payload := benchNetPayload(size)
+			for i := 0; i < netQueueSize; i++ {
+				buf := uint64(benchNetBufBase + i*2048)
+				copy(mem[buf+netHeaderLen:], payload)
+				writeDesc(mem, benchNetQueue+uint64(i)*16, buf, uint32(netHeaderLen+len(payload)), 0, 0)
+				binary.LittleEndian.PutUint16(mem[benchNetQueue+16*netQueueSize+4+uint64(i)*2:], uint16(i))
+			}
+
+			availIdx := uint16(0)
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				availIdx++
+				binary.LittleEndian.PutUint16(mem[benchNetQueue+16*netQueueSize+2:], availIdx)
+				if err := dev.WriteLegacy(16, 2, netQueueTX); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			if backend.packets != b.N {
+				b.Fatalf("packets = %d, want %d", backend.packets, b.N)
+			}
+		})
+	}
+}
+
+func BenchmarkNetLegacyRXEnqueue(b *testing.B) {
+	for _, size := range []int{64, 512, 1400} {
+		b.Run(benchNetPayloadName(size), func(b *testing.B) {
+			mem := make(testGuestMemory, 0x120000)
+			dev := NewNet(0, 0x1000, 11, nil, nil)
+			dev.DisableMergeRX = true
+			dev.Attach(mem, &testIRQ{})
+			configureLegacyNetQueue(b, dev, netQueueRX)
+
+			for i := 0; i < netQueueSize; i++ {
+				buf := uint64(benchNetBufBase + i*2048)
+				writeDesc(mem, benchNetQueue+uint64(i)*16, buf, 2048, descFWrite, 0)
+				binary.LittleEndian.PutUint16(mem[benchNetQueue+16*netQueueSize+4+uint64(i)*2:], uint16(i))
+			}
+
+			packet := benchNetPayload(size)
+			availIdx := uint16(0)
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				availIdx++
+				binary.LittleEndian.PutUint16(mem[benchNetQueue+16*netQueueSize+2:], availIdx)
+				if err := dev.EnqueueRxPacketOwned(packet); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			if got := binary.LittleEndian.Uint16(mem[benchNetQueue+16*netQueueSize+4096+2:]); got != uint16(b.N) {
+				b.Fatalf("used idx = %d, want %d", got, uint16(b.N))
+			}
+		})
+	}
+}
+
+func configureLegacyNetQueue(b *testing.B, dev *Net, queue uint64) {
+	b.Helper()
+	if err := dev.WriteLegacy(14, 2, queue); err != nil {
+		b.Fatal(err)
+	}
+	if err := dev.WriteLegacy(8, 4, benchNetQueuePFN); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func benchNetPayload(size int) []byte {
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	return payload
+}
+
+func benchNetPayloadName(size int) string {
+	return strconv.Itoa(size) + "B"
+}

--- a/internal/virtio/test_helpers_test.go
+++ b/internal/virtio/test_helpers_test.go
@@ -10,9 +10,18 @@ func (m testGuestMemory) ReadIPA(addr uint64, size int) ([]byte, error) {
 	return out, nil
 }
 
+func (m testGuestMemory) ReadIPAInto(addr uint64, dst []byte) error {
+	copy(dst, m[addr:addr+uint64(len(dst))])
+	return nil
+}
+
 func (m testGuestMemory) WriteIPA(addr uint64, data []byte) error {
 	copy(m[addr:addr+uint64(len(data))], data)
 	return nil
+}
+
+func (m testGuestMemory) SliceIPA(addr uint64, size int) ([]byte, error) {
+	return m[addr : addr+uint64(size)], nil
 }
 
 type testIRQ struct {

--- a/internal/vm/network_common.go
+++ b/internal/vm/network_common.go
@@ -126,6 +126,7 @@ func newNetworkRuntime(cfg networkDeviceConfig) (_ *networkRuntime, retErr error
 		txHook: cfg.TXHook,
 	}
 	dev := virtio.NewNet(cfg.Base, cfg.Size, cfg.IRQ, cfg.MAC, &netstackVirtioBackend{runtime: runtime})
+	dev.CompleteTXChecksum = false
 	runtime.dev = dev
 	rxHook := cfg.RXHook
 	if rxHook == nil {

--- a/internal/vm/network_darwin_arm64.go
+++ b/internal/vm/network_darwin_arm64.go
@@ -3,6 +3,7 @@
 package vm
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -14,6 +15,8 @@ import (
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
 )
+
+var defaultGatewayMACBytes = []byte{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x01}
 
 type darwinNetworkRuntime struct {
 	*networkRuntime
@@ -93,6 +96,9 @@ func newDarwinRemoteNetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRun
 			Size:   arm64vm.NetSize,
 			IRQ:    arm64vm.NetIRQ,
 			TXHook: func(packet []byte) {
+				if frameTargetsDefaultGateway(packet) {
+					return
+				}
 				_ = codec.Send(virtio.NetPacket{
 					Kind:     virtio.NetPacketTX,
 					VMID:     DefaultInstanceID,
@@ -118,6 +124,7 @@ func newDarwinRemoteNetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRun
 		}, nil
 	}
 	dev := virtio.NewNet(arm64vm.NetBase, arm64vm.NetSize, arm64vm.NetIRQ, mac, virtio.NewNetRemoteBackend(codec, DefaultInstanceID, "eth0"))
+	dev.CompleteTXChecksum = false
 	go func() {
 		_ = virtio.ReceiveNetRXPackets(context.Background(), codec, dev)
 	}()
@@ -126,6 +133,13 @@ func newDarwinRemoteNetworkRuntime(cfg *client.NetworkConfig) (*darwinNetworkRun
 		mac: mac,
 		dev: dev,
 	}, closeFn: codec.Close}, nil
+}
+
+func frameTargetsDefaultGateway(frame []byte) bool {
+	if len(frame) < 6 {
+		return false
+	}
+	return bytes.Equal(frame[:6], defaultGatewayMACBytes)
 }
 
 func (n *darwinNetworkRuntime) Close() error {

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -293,7 +293,17 @@ func serveSidecarFS(cacheDir string, backend sidecarRootFS) (sidecarStartResourc
 }
 
 func prepareSidecarNetResources(cacheDir, id string, cfg *client.NetworkConfig) (sidecarStartResources, error) {
-	return prepareSidecarNetResourcesWithMode(cacheDir, id, cfg, "")
+	mode := ""
+	if cfg != nil {
+		switch strings.ToLower(strings.TrimSpace(cfg.Mode)) {
+		case "", "remote":
+		case "bridge":
+			mode = "bridge"
+		default:
+			return sidecarStartResources{}, fmt.Errorf("unsupported sidecar network mode %q", cfg.Mode)
+		}
+	}
+	return prepareSidecarNetResourcesWithMode(cacheDir, id, cfg, mode)
 }
 
 func prepareSidecarNetResourcesWithMode(cacheDir, id string, cfg *client.NetworkConfig, mode string) (sidecarStartResources, error) {

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -296,9 +296,11 @@ func prepareSidecarNetResources(cacheDir, id string, cfg *client.NetworkConfig) 
 	mode := ""
 	if cfg != nil {
 		switch strings.ToLower(strings.TrimSpace(cfg.Mode)) {
-		case "", "remote":
+		case "":
+			mode = "bridge"
 		case "bridge":
 			mode = "bridge"
+		case "remote":
 		default:
 			return sidecarStartResources{}, fmt.Errorf("unsupported sidecar network mode %q", cfg.Mode)
 		}


### PR DESCRIPTION
## Summary

Closes #28.
Closes #29.

Adds focused benchmarks and hot-path optimizations for virtio-net, the managed netstack host path, and end-to-end guest networking. This PR now includes TCP/UDP host-path benchmarks, UDP service bridging, opt-in checksum validation, virtio TSO/checksum offload support, and high-throughput sidecar bridge networking as the default data path.

## Changes

### Virtio-net device path

- Add TX notify and RX enqueue benchmarks covering descriptor/avail/used-ring behavior.
- Cache queue descriptor/avail/used memory using direct guest-memory slices when available, falling back to scratch-buffer reads.
- Avoid per-packet packet-buffer pool allocation churn.
- Clear only the used TX batch entries instead of all 256 slots on every notify.
- Complete ready RX descriptors directly when no packets are pending, avoiding pending-queue allocation churn.
- Use device scratch space for RX virtio-net headers and small ring reads/writes.
- Advertise checksum and IPv4 TCP segmentation offload support to the guest.
- Let managed netstack backends consume offloaded TX frames without recomputing checksums in the virtio device.

### Netstack host path

- Add host-path TCP/UDP benchmarks over full Ethernet/IPv4 frames through DeliverGuestPacket.
- Add GSO-sized TCP ingress and WriteTo benchmarks for iperf-style payloads.
- Make inbound checksum validation opt-in and disabled by default.
- Avoid disabled trace formatting and callback address copies on the UDP hot path.
- Replace hot byte-slice sync.Pool paths and the UDP socket sync.Map with lower-overhead structures.
- Bridge UDP packets addressed to the service IP to 127.0.0.1:<port>, preserving per-flow reply routing back to the guest.
- Fix UDP transmit checksum construction so replies are accepted by the guest kernel.
- Batch queued guest TCP payloads in tcpConn.WriteTo before writing to host sockets.
- Increase proxy copy buffers to 256 KiB and tune TCP proxy socket buffers/NoDelay.

### Darwin sidecar path

- Add sidecar network mode selection through network.mode, documented in the OpenAPI schema.
- Default sidecar networking to bridge mode for worker-local netstack handling.
- Keep the previous coordinator-backed remote mode available with network.mode=remote.
- In bridge mode, avoid forwarding gateway-bound frames over the coordinator packet socket so service-proxy and egress traffic stay on the fast worker-local path.

## Results

### Virtio-net device path

Baseline:

- TX 512B: ~154-155 ns/op, 64 B/op, 6 allocs/op
- RX 512B: ~87-98 ns/op, 72 B/op, 7 allocs/op

After:

- TX 64B: ~56-57 ns/op, 0 B/op, 0 allocs/op
- TX 512B: ~63 ns/op, 0 B/op, 0 allocs/op
- TX 1400B: ~76-78 ns/op, 0 B/op, 0 allocs/op
- RX 64B: ~23-26 ns/op, 0 B/op, 0 allocs/op
- RX 512B: ~30-33 ns/op, 0 B/op, 0 allocs/op
- RX 1400B: ~44 ns/op, 0 B/op, 0 allocs/op

### Netstack host path

Earlier focused run:

- UDPCallback/512B: ~41-43 ns/op, 0 B/op, 0 allocs/op
- UDPReadFrom/512B: ~256-285 ns/op, 80 B/op, 1 alloc/op
- TCPIngress/512B: ~499-591 ns/op, 0 allocs/op
- TCPIngress/1400B: ~765-838 ns/op, 0 allocs/op

Latest TCP WriteTo batching run:

- TCPWriteTo/1400B: ~190-219 ns/op, ~6.4-7.4 GB/s, ~0.0054 writes/pkt, 0 allocs/op
- TCPWriteTo/16KiB: ~477-614 ns/op, ~26.7-34.3 GB/s, ~0.0625 writes/pkt, 0 allocs/op
- TCPWriteTo/64KiB: ~2.08-2.45 us/op, ~26.8-31.6 GB/s, ~0.25 writes/pkt, 0 allocs/op

### Guest iperf3 through service proxy

Baseline before this PR:

- TCP guest -> host: ~627 Mbit/s, 0 retransmits.
- UDP guest -> host at 100M target: ~85.5 Mbit/s delivered, 0% loss.
- UDP host -> guest reverse at 750M target: ~750 Mbit/s delivered, 0% loss.
- UDP host -> guest reverse at 1G target: ~964.5 Mbit/s received with ~3.5% loss.

TCP after TSO/checksum offload in remote sidecar mode:

- TCP guest -> host, -P1: ~1.13 Gbit/s.
- TCP guest -> host, -P4: ~1.36 Gbit/s.

TCP after bridge mode, gateway-frame filtering, and larger TCP batching:

- TCP guest -> host, -P1: 2.443 Gbit/s, 0 retransmits.
- TCP guest -> host, -P2, 5s: 10.600 Gbit/s received, 0 retransmits.
- TCP guest -> host, -P2, 10s: 10.410 Gbit/s received, 0 retransmits.
- TCP guest -> host, -P3: 6.262 Gbit/s received, 0 retransmits.

## Notes

- Sidecar bridge mode is now the default; network.mode=remote preserves the previous coordinator-backed sidecar packet path.
- The highest-throughput iperf result used a host iperf3 listener, guest traffic to 10.42.0.100, default bridge networking, and iperf3 -P2.
- Larger future work: batching guest notifications across more packets and interrupt moderation/event-index negotiation.

## Validation

- go test -count=1 ./internal/virtio ./internal/netstack ./client
- go test -count=1 ./internal/vm
- go test ./internal/netstack -run '^$' -bench '^BenchmarkHostPathTCPWriteTo/(1400B|16384B|65536B)' -benchmem -count=3
- Guest iperf3 runs against a host iperf3 listener through 10.42.0.100, including the 10.410 Gbit/s 10-second -P2 bridge-mode run.