### PR TITLE
[codex] Add Windows arm64 WHP runtime

### DIFF
--- a/internal/arm64vm/boot.go
+++ b/internal/arm64vm/boot.go
@@ -10,13 +10,15 @@ import (
 )
 
 type BootConfig struct {
-	MemoryMB    uint64
-	NumCPUs     int
-	GICVersion  bootarm64.GICVersion
-	Dmesg       bool
-	DisableUART bool
-	ExtraNodes  []fdt.Node
-	RecordTime  func(name string, duration time.Duration)
+	MemoryMB             uint64
+	NumCPUs              int
+	GICVersion           bootarm64.GICVersion
+	Dmesg                bool
+	DisableUART          bool
+	DisableSerialConsole bool
+	HyperVTimer          bool
+	ExtraNodes           []fdt.Node
+	RecordTime           func(name string, duration time.Duration)
 }
 
 func MemorySizeBytes(memoryMB uint64) uint64 {
@@ -46,6 +48,8 @@ func BootCommandLine(dmesg bool, serialConsole bool) string {
 }
 
 func PrepareBoot(memory []byte, kernel []byte, initrd []byte, cfg BootConfig) (*bootarm64.BootPlan, error) {
+	serialConsole := !cfg.DisableUART && !cfg.DisableSerialConsole
+	cmdline := BootCommandLine(cfg.Dmesg, serialConsole)
 	return bootarm64.PrepareBoot(memory, kernel, bootarm64.BootOptions{
 		MemoryBase:  MemoryBase,
 		MemorySize:  MemorySizeBytes(cfg.MemoryMB),
@@ -53,9 +57,10 @@ func PrepareBoot(memory []byte, kernel []byte, initrd []byte, cfg BootConfig) (*
 		GICVersion:  cfg.GICVersion,
 		Initrd:      initrd,
 		DisableUART: cfg.DisableUART,
-		Console:     !cfg.DisableUART,
+		Console:     serialConsole,
+		HyperVTimer: cfg.HyperVTimer,
 		ExtraNodes:  append([]fdt.Node(nil), cfg.ExtraNodes...),
 		RecordTime:  cfg.RecordTime,
-		Cmdline:     BootCommandLine(cfg.Dmesg, !cfg.DisableUART),
+		Cmdline:     cmdline,
 	})
 }

--- a/internal/arm64vm/layout.go
+++ b/internal/arm64vm/layout.go
@@ -53,6 +53,9 @@ const (
 	SnapshotBase = 0x0a106000
 	SnapshotSize = 0x1000
 
+	RTCBase = 0x0a107000
+	RTCSize = 0x1000
+
 	PCIConfigBase = 0x20000000
 	PCIConfigSize = 0x01000000
 	PCIMMIOBase   = 0x21000000

--- a/internal/arm64vm/pl031.go
+++ b/internal/arm64vm/pl031.go
@@ -1,0 +1,110 @@
+package arm64vm
+
+import (
+	"fmt"
+	"time"
+
+	"j5.nz/cc/internal/fdt"
+)
+
+const (
+	pl031DR  = 0x00
+	pl031LR  = 0x08
+	pl031CR  = 0x0c
+	pl031RIS = 0x14
+	pl031MIS = 0x18
+
+	pl031CRStart = 1
+)
+
+type PL031 struct {
+	Base      uint64
+	Size      uint64
+	start     time.Time
+	baseUnix  int64
+	control   uint32
+	interrupt uint32
+}
+
+func NewPL031(base, size uint64, now time.Time) *PL031 {
+	if size == 0 {
+		size = RTCSize
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return &PL031{
+		Base:     base,
+		Size:     size,
+		start:    now,
+		baseUnix: now.Unix(),
+		control:  pl031CRStart,
+	}
+}
+
+func (r *PL031) Contains(addr uint64, size int) bool {
+	if r == nil || size <= 0 {
+		return false
+	}
+	return addr >= r.Base && addr+uint64(size) <= r.Base+r.Size
+}
+
+func (r *PL031) Read(addr uint64, size int) (uint64, error) {
+	if r == nil {
+		return 0, nil
+	}
+	switch addr - r.Base {
+	case pl031DR:
+		return truncatePL031(uint64(r.currentUnix()), size), nil
+	case pl031LR:
+		return truncatePL031(uint64(r.baseUnix), size), nil
+	case pl031CR:
+		return truncatePL031(uint64(r.control), size), nil
+	case pl031RIS, pl031MIS:
+		return truncatePL031(uint64(r.interrupt), size), nil
+	default:
+		return 0, nil
+	}
+}
+
+func (r *PL031) Write(addr uint64, size int, value uint64) error {
+	if r == nil {
+		return nil
+	}
+	switch addr - r.Base {
+	case pl031LR:
+		r.baseUnix = int64(uint32(value))
+		r.start = time.Now()
+	case pl031CR:
+		r.control = uint32(value) & pl031CRStart
+	}
+	return nil
+}
+
+func (r *PL031) DeviceTreeNode() fdt.Node {
+	return fdt.Node{
+		Name: fmt.Sprintf("rtc@%x", r.Base),
+		Properties: map[string]fdt.Property{
+			"compatible": {Strings: []string{"arm,pl031"}},
+			"reg":        {U64: []uint64{r.Base, r.Size}},
+			"status":     {Strings: []string{"okay"}},
+		},
+	}
+}
+
+func (r *PL031) currentUnix() int64 {
+	if r.control&pl031CRStart == 0 {
+		return r.baseUnix
+	}
+	return r.baseUnix + int64(time.Since(r.start)/time.Second)
+}
+
+func truncatePL031(value uint64, size int) uint64 {
+	if size >= 8 {
+		return value
+	}
+	if size <= 0 {
+		return 0
+	}
+	return value & ((uint64(1) << (uint(size) * 8)) - 1)
+}

--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -2456,12 +2456,25 @@ func managedExecExitCode(waitErr error, state *os.ProcessState) (int, error) {
 	if waitErr != nil && errors.Is(waitErr, exec.ErrWaitDelay) {
 		waitErr = nil
 	}
+	if state != nil {
+		status, ok := state.Sys().(syscall.WaitStatus)
+		if !ok {
+			return 126, fmt.Errorf("process state did not include wait status")
+		}
+		if status.Signaled() {
+			return 128 + int(status.Signal()), nil
+		}
+		if status.Exited() {
+			return status.ExitStatus(), nil
+		}
+		return 126, fmt.Errorf("process did not exit normally")
+	}
 	if waitErr == nil {
 		return 0, nil
 	}
 	var exitErr *exec.ExitError
 	if errors.As(waitErr, &exitErr) {
-		return guestagent.ProcessExitCode(state, exitErr.ExitCode()), nil
+		return exitErr.ExitCode(), nil
 	}
 	return 126, waitErr
 }
@@ -2484,16 +2497,17 @@ type managedExecWaitResult struct {
 }
 
 func waitManagedExecProcess(cmd *exec.Cmd, execStart time.Time) managedExecWaitResult {
-	waitErr := cmd.Wait()
-	usage := guestagent.UsageFromProcessState(cmd.ProcessState, time.Since(execStart))
-	exitCode, exitErr := managedExecExitCode(waitErr, cmd.ProcessState)
+	state, waitErr := cmd.Process.Wait()
+	cmd.ProcessState = state
+	usage := guestagent.UsageFromProcessState(state, time.Since(execStart))
+	exitCode, exitErr := managedExecExitCode(waitErr, state)
 	var usagePayload string
 	if usage != nil {
 		usagePayload = guestagent.EncodeExecUsage(usage)
 	}
 	return managedExecWaitResult{
 		WaitErr:      waitErr,
-		ProcessState: cmd.ProcessState,
+		ProcessState: state,
 		Usage:        usagePayload,
 		ExitCode:     exitCode,
 		ExitErr:      exitErr,
@@ -2576,6 +2590,25 @@ func copyManagedExecStdinToPTY(done chan<- struct{}, stdin io.ReadCloser, pty io
 	}
 }
 
+func copyManagedExecStdinToPipe(done chan<- struct{}, stdin io.ReadCloser, childStdin io.WriteCloser) {
+	defer func() { done <- struct{}{} }()
+	defer stdin.Close()
+	defer childStdin.Close()
+	_, _ = io.Copy(childStdin, stdin)
+}
+
+func closeManagedExecStdinPipe(stdin io.ReadCloser, childStdin io.WriteCloser, done <-chan struct{}) {
+	if childStdin != nil {
+		_ = childStdin.Close()
+	}
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
 func runManagedExec(cfg config, control io.Writer, id string, argv []string, env []string, rootDir string, workDir string, user string, stdin io.ReadCloser, managed *managedExec, tty bool, controlFD bool, cols int, rows int, waitReady func() error, cleanup func()) {
 	defer cleanup()
 	execStart := time.Now()
@@ -2633,8 +2666,10 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 	cmd, useExecPivot := managedExecCommand(argv, env, rootDir, workDir, execCred, tty)
 	var (
 		done       chan struct{}
-		stdoutW    *io.PipeWriter
-		stderrW    *io.PipeWriter
+		stdoutR    io.ReadCloser
+		stderrR    io.ReadCloser
+		stdinW     io.WriteCloser
+		stdinDone  chan struct{}
 		controlR   *os.File
 		controlW   *os.File
 		ptyMaster  *os.File
@@ -2698,8 +2733,15 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 		}
 	} else {
 		if stdin != nil {
-			defer stdin.Close()
-			cmd.Stdin = stdin
+			var err error
+			stdinW, err = cmd.StdinPipe()
+			if err != nil {
+				closeManagedExecStdinPipe(stdin, nil, nil)
+				writeKernel("ccx3-init: open stdin pipe: " + err.Error())
+				writeExecStderr(cfg, control, id, "ccx3-init: open stdin pipe: "+err.Error()+"\n")
+				reporter.Exit(126)
+				return
+			}
 		} else {
 			devNull, err := os.Open("/dev/null")
 			if err == nil {
@@ -2708,12 +2750,24 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 			}
 		}
 
-		stdoutR, stdoutPipeW := io.Pipe()
-		stderrR, stderrPipeW := io.Pipe()
-		stdoutW = stdoutPipeW
-		stderrW = stderrPipeW
-		cmd.Stdout = stdoutW
-		cmd.Stderr = stderrW
+		var err error
+		stdoutR, err = cmd.StdoutPipe()
+		if err != nil {
+			closeManagedExecStdinPipe(stdin, stdinW, nil)
+			writeKernel("ccx3-init: open stdout pipe: " + err.Error())
+			writeExecStderr(cfg, control, id, "ccx3-init: open stdout pipe: "+err.Error()+"\n")
+			reporter.Exit(126)
+			return
+		}
+		stderrR, err = cmd.StderrPipe()
+		if err != nil {
+			_ = stdoutR.Close()
+			closeManagedExecStdinPipe(stdin, stdinW, nil)
+			writeKernel("ccx3-init: open stderr pipe: " + err.Error())
+			writeExecStderr(cfg, control, id, "ccx3-init: open stderr pipe: "+err.Error()+"\n")
+			reporter.Exit(126)
+			return
+		}
 
 		done = make(chan struct{}, managedExecStreamCount(false, stdin != nil, controlR != nil))
 		var stdoutEmit func([]byte)
@@ -2736,6 +2790,7 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 	startErr := startManagedExecProcess(cmd, &controlW)
 	if startErr != nil {
 		_ = managed.closeStdin()
+		closeManagedExecStdinPipe(stdin, stdinW, stdinDone)
 		if ptySlave != nil {
 			_ = ptySlave.Close()
 			ptySlave = nil
@@ -2744,11 +2799,11 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 			_ = ptyMaster.Close()
 			ptyMaster = nil
 		}
-		if stdoutW != nil {
-			_ = stdoutW.Close()
+		if stdoutR != nil {
+			_ = stdoutR.Close()
 		}
-		if stderrW != nil {
-			_ = stderrW.Close()
+		if stderrR != nil {
+			_ = stderrR.Close()
 		}
 		waitManagedExecStreams(done, cap(done))
 		writeKernel("ccx3-init: exec error: " + startErr.Error())
@@ -2757,6 +2812,10 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 		return
 	}
 	reporter.Timing(managedExecTimingStarted)
+	if stdinW != nil {
+		stdinDone = make(chan struct{}, 1)
+		go copyManagedExecStdinToPipe(stdinDone, stdin, stdinW)
+	}
 	managed.setProcess(cmd.Process, signalGroup)
 	if ptySlave != nil {
 		_ = ptySlave.Close()
@@ -2764,19 +2823,23 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 	}
 
 	reporter.Timing(managedExecTimingWaitBegin)
-	waitResult := waitManagedExecProcess(cmd, execStart)
+	var waitResult managedExecWaitResult
+	if !tty {
+		waitManagedExecStreams(done, cap(done))
+		reporter.Timing(managedExecTimingStreamsDone)
+	}
+	waitResult = waitManagedExecProcess(cmd, execStart)
 	reporter.Timing(managedExecTimingWaitDone)
 	if tty {
 		_ = managed.closeStdin()
 	}
-	if stdoutW != nil {
-		_ = stdoutW.Close()
+	if !tty {
+		closeManagedExecStdinPipe(stdin, stdinW, stdinDone)
 	}
-	if stderrW != nil {
-		_ = stderrW.Close()
+	if tty {
+		waitManagedExecStreams(done, cap(done))
+		reporter.Timing(managedExecTimingStreamsDone)
 	}
-	waitManagedExecStreams(done, cap(done))
-	reporter.Timing(managedExecTimingStreamsDone)
 
 	if waitResult.ExitErr != nil {
 		writeKernel("ccx3-init: exec error: " + waitResult.ExitErr.Error())

--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -2528,6 +2528,13 @@ func managedExecStreamCount(tty bool, hasStdin bool, hasControl bool) int {
 	return streams
 }
 
+func managedExecDoneStreamCount(tty bool, hasStdin bool, hasControl bool) int {
+	if !tty {
+		hasStdin = false
+	}
+	return managedExecStreamCount(tty, hasStdin, hasControl)
+}
+
 func waitManagedExecStreams(done <-chan struct{}, count int) {
 	for i := 0; i < count; i++ {
 		<-done
@@ -2722,7 +2729,7 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 			Setctty: true,
 			Ctty:    0,
 		}
-		done = make(chan struct{}, managedExecStreamCount(true, stdin != nil, controlR != nil))
+		done = make(chan struct{}, managedExecDoneStreamCount(true, stdin != nil, controlR != nil))
 		var ptyEmit func([]byte)
 		if cfg.OutputMarkerPref != "" {
 			ptyEmit = reporter.Stdout
@@ -2769,7 +2776,7 @@ func runManagedExec(cfg config, control io.Writer, id string, argv []string, env
 			return
 		}
 
-		done = make(chan struct{}, managedExecStreamCount(false, stdin != nil, controlR != nil))
+		done = make(chan struct{}, managedExecDoneStreamCount(false, stdin != nil, controlR != nil))
 		var stdoutEmit func([]byte)
 		if cfg.OutputMarkerPref != "" {
 			stdoutEmit = reporter.Stdout

--- a/internal/cmd/init/main_test.go
+++ b/internal/cmd/init/main_test.go
@@ -444,7 +444,7 @@ func TestWaitManagedExecProcess(t *testing.T) {
 		t.Fatalf("start exit 7: %v", err)
 	}
 	result = waitManagedExecProcess(failed, time.Now())
-	if result.WaitErr == nil || result.ExitErr != nil || result.ExitCode != 7 || result.ProcessState == nil || len(result.Usage) == 0 {
+	if result.WaitErr != nil || result.ExitErr != nil || result.ExitCode != 7 || result.ProcessState == nil || len(result.Usage) == 0 {
 		t.Fatalf("exit 7 result = %+v", result)
 	}
 }
@@ -579,6 +579,23 @@ func TestCopyManagedExecStdinToPTYWritesEOTOnEOF(t *testing.T) {
 	}
 }
 
+func TestCopyManagedExecStdinToPipeClosesBothEnds(t *testing.T) {
+	done := make(chan struct{}, 1)
+	stdin := &trackingReadCloser{Buffer: bytes.NewBufferString("input")}
+	childStdin := &trackingWriteCloser{}
+	copyManagedExecStdinToPipe(done, stdin, childStdin)
+	<-done
+	if got := childStdin.String(); got != "input" {
+		t.Fatalf("child stdin = %q, want input", got)
+	}
+	if !stdin.closed {
+		t.Fatalf("stdin was not closed")
+	}
+	if !childStdin.closed {
+		t.Fatalf("child stdin was not closed")
+	}
+}
+
 func TestManagedExecTimingPhaseSelection(t *testing.T) {
 	if begin, done, ok := managedExecGuestReadyTimingPhases(nil); ok || begin != "" || done != "" {
 		t.Fatalf("nil wait ready phases = (%q, %q, %v), want disabled", begin, done, ok)
@@ -679,5 +696,15 @@ type trackingReadCloser struct {
 
 func (r *trackingReadCloser) Close() error {
 	r.closed = true
+	return nil
+}
+
+type trackingWriteCloser struct {
+	bytes.Buffer
+	closed bool
+}
+
+func (w *trackingWriteCloser) Close() error {
+	w.closed = true
 	return nil
 }

--- a/internal/cmd/init/main_test.go
+++ b/internal/cmd/init/main_test.go
@@ -612,6 +612,29 @@ func TestManagedExecTimingPhaseSelection(t *testing.T) {
 	}
 }
 
+func TestManagedExecDoneStreamCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		tty        bool
+		hasStdin   bool
+		hasControl bool
+		want       int
+	}{
+		{name: "non_tty", want: 2},
+		{name: "non_tty_stdin", hasStdin: true, want: 2},
+		{name: "non_tty_control_stdin", hasStdin: true, hasControl: true, want: 3},
+		{name: "tty_stdin", tty: true, hasStdin: true, want: 2},
+		{name: "tty_control_stdin", tty: true, hasStdin: true, hasControl: true, want: 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := managedExecDoneStreamCount(tc.tty, tc.hasStdin, tc.hasControl); got != tc.want {
+				t.Fatalf("managedExecDoneStreamCount(%t, %t, %t) = %d, want %d", tc.tty, tc.hasStdin, tc.hasControl, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHandleInitControlRequest(t *testing.T) {
 	var control bytes.Buffer
 	active := guestagent.NewActiveExecSet()

--- a/internal/freebsd/guestinit/guestinit.go
+++ b/internal/freebsd/guestinit/guestinit.go
@@ -36,7 +36,7 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 	}
 	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 	out := filepath.Join(cacheDir, "guest-init-freebsd-"+arch)
-	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", out, "./internal/cmd/freebsd-init")
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-ldflags", "-s -w", "-o", out, "./internal/cmd/freebsd-init")
 	cmd.Env = append(os.Environ(), "GOOS=freebsd", "GOARCH="+arch, "CGO_ENABLED=0")
 	cmd.Dir = moduleRoot
 	data, err := cmd.CombinedOutput()

--- a/internal/hv/hv_other.go
+++ b/internal/hv/hv_other.go
@@ -1,4 +1,4 @@
-//go:build (!darwin || !arm64) && (!linux || (!arm64 && !amd64)) && (!windows || !amd64)
+//go:build (!darwin || !arm64) && (!linux || (!arm64 && !amd64)) && (!windows || (!amd64 && !arm64))
 
 package hv
 

--- a/internal/hv/hv_windows_arm64.go
+++ b/internal/hv/hv_windows_arm64.go
@@ -1,0 +1,13 @@
+//go:build windows && arm64
+
+package hv
+
+import "j5.nz/cc/internal/hv/whp"
+
+func Supports() error {
+	return whp.Supports()
+}
+
+func NestedVirtualizationSupported() (bool, error) {
+	return false, nil
+}

--- a/internal/hv/hvf/managed_session_darwin_arm64.go
+++ b/internal/hv/hvf/managed_session_darwin_arm64.go
@@ -42,6 +42,11 @@ func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (clie
 	if err := s.sendExecStart(id, req); err != nil {
 		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
 	}
+	if len(req.Stdin) == 0 {
+		if err := s.sendStdinClose(id); err != nil {
+			return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+		}
+	}
 	segment, err := s.waitForTranscript(ctx, start, func(text string) bool {
 		_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, s.dmesg)
 		return ok

--- a/internal/hv/hvf/managed_session_darwin_arm64_test.go
+++ b/internal/hv/hvf/managed_session_darwin_arm64_test.go
@@ -1,0 +1,86 @@
+//go:build darwin && arm64
+
+package hvf
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/managed/protocol"
+)
+
+func TestManagedSessionExecClosesEmptyStdin(t *testing.T) {
+	transcript := newSerialTranscript()
+	control := &recordingManagedControl{transcript: transcript}
+	session := &ManagedSession{
+		control:    control,
+		transcript: transcript,
+		serialOut:  newSerialTranscript(),
+		done:       newManagedSessionDone(),
+	}
+
+	resp, err := session.Exec(t.Context(), client.ExecRequest{Command: []string{"true"}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if resp.ExitCode != 0 {
+		t.Fatalf("Exec exit code = %d", resp.ExitCode)
+	}
+	if got := control.kinds(); len(got) != 2 || got[0] != "exec" || got[1] != "stdin_close" {
+		t.Fatalf("control request kinds = %v", got)
+	}
+}
+
+type recordingManagedControl struct {
+	mu         sync.Mutex
+	buf        bytes.Buffer
+	requests   []protocol.ManagedExecRequest
+	transcript io.Writer
+}
+
+func (c *recordingManagedControl) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (c *recordingManagedControl) Write(data []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n, _ := c.buf.Write(data)
+	for {
+		line, err := c.buf.ReadBytes('\n')
+		if err != nil {
+			c.buf.Write(line)
+			return n, nil
+		}
+		var req protocol.ManagedExecRequest
+		if err := json.Unmarshal(bytes.TrimSpace(line), &req); err != nil {
+			return n, err
+		}
+		if req.Kind == "" {
+			req.Kind = "exec"
+		}
+		c.requests = append(c.requests, req)
+		if req.Kind == "stdin_close" {
+			_, _ = c.transcript.Write([]byte(protocol.BeginMarkerPrefix + req.ID + "\n"))
+			_, _ = c.transcript.Write([]byte(protocol.ExitMarkerPrefix + req.ID + ":0\n"))
+		}
+	}
+}
+
+func (c *recordingManagedControl) Close() error {
+	return nil
+}
+
+func (c *recordingManagedControl) kinds() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.requests))
+	for i, req := range c.requests {
+		out[i] = req.Kind
+	}
+	return out
+}

--- a/internal/hv/whp/bindings_windows_arm64.go
+++ b/internal/hv/whp/bindings_windows_arm64.go
@@ -1,0 +1,423 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	winhvplatform = syscall.NewLazyDLL("winhvplatform.dll")
+	kernel32      = syscall.NewLazyDLL("kernel32.dll")
+
+	procWHvGetCapability                = winhvplatform.NewProc("WHvGetCapability")
+	procWHvCreatePartition              = winhvplatform.NewProc("WHvCreatePartition")
+	procWHvSetupPartition               = winhvplatform.NewProc("WHvSetupPartition")
+	procWHvDeletePartition              = winhvplatform.NewProc("WHvDeletePartition")
+	procWHvSetPartitionProperty         = winhvplatform.NewProc("WHvSetPartitionProperty")
+	procWHvMapGpaRange                  = winhvplatform.NewProc("WHvMapGpaRange")
+	procWHvUnmapGpaRange                = winhvplatform.NewProc("WHvUnmapGpaRange")
+	procWHvCreateVirtualProcessor       = winhvplatform.NewProc("WHvCreateVirtualProcessor")
+	procWHvDeleteVirtualProcessor       = winhvplatform.NewProc("WHvDeleteVirtualProcessor")
+	procWHvRunVirtualProcessor          = winhvplatform.NewProc("WHvRunVirtualProcessor")
+	procWHvGetVirtualProcessorRegisters = winhvplatform.NewProc("WHvGetVirtualProcessorRegisters")
+	procWHvSetVirtualProcessorRegisters = winhvplatform.NewProc("WHvSetVirtualProcessorRegisters")
+	procWHvCancelRunVirtualProcessor    = winhvplatform.NewProc("WHvCancelRunVirtualProcessor")
+	procWHvRequestInterrupt             = winhvplatform.NewProc("WHvRequestInterrupt")
+	procVirtualAlloc                    = kernel32.NewProc("VirtualAlloc")
+	procVirtualFree                     = kernel32.NewProc("VirtualFree")
+)
+
+type hresult int32
+
+func (hr hresult) Err() error {
+	if hr >= 0 {
+		return nil
+	}
+	return fmt.Errorf("HRESULT 0x%08x: %s", uint32(hr), syscall.Errno(hr))
+}
+
+func callHRESULT(proc *syscall.LazyProc, args ...uintptr) error {
+	r1, _, callErr := proc.Call(args...)
+	if callErr != syscall.Errno(0) && r1 == 0 {
+		return callErr
+	}
+	return hresult(int32(r1)).Err()
+}
+
+type partitionHandle syscall.Handle
+type guestPhysicalAddress uint64
+
+type capabilityCode uint32
+
+const (
+	capabilityCodeHypervisorPresent capabilityCode = 0
+	capabilityCodeFeatures          capabilityCode = 0x00000001
+	capabilityCodeGicLpiIntIDBits   capabilityCode = 0x00002011
+)
+
+type capabilityFeatures struct {
+	AsUint64 uint64
+}
+
+func (f capabilityFeatures) arm64Support() bool {
+	return f.AsUint64&(1<<11) != 0
+}
+
+type partitionPropertyCode uint32
+
+const (
+	partitionPropertyCodeArm64ICParameters partitionPropertyCode = 0x00001012
+	partitionPropertyCodeProcessorCount    partitionPropertyCode = 0x00001fff
+)
+
+type arm64ICEmulationMode uint32
+
+const arm64ICEmulationModeGICV3 arm64ICEmulationMode = 1
+
+type arm64ICGICV3Parameters struct {
+	GICDBaseAddress           guestPhysicalAddress
+	GITSTranslaterBaseAddress guestPhysicalAddress
+	Reserved                  uint32
+	GICLPIIntIDBits           uint32
+	GICPPIOverflowFromCNTV    uint32
+	GICPPIPerformanceMonitors uint32
+	Reserved1                 [6]uint32
+}
+
+type arm64ICParameters struct {
+	EmulationMode   arm64ICEmulationMode
+	Reserved        uint32
+	GICV3Parameters arm64ICGICV3Parameters
+}
+
+type mapGPARangeFlags uint32
+
+const (
+	mapGPARangeFlagRead    mapGPARangeFlags = 0x1
+	mapGPARangeFlagWrite   mapGPARangeFlags = 0x2
+	mapGPARangeFlagExecute mapGPARangeFlags = 0x4
+)
+
+type registerName uint32
+
+const (
+	registerX0     registerName = 0x00020000
+	registerX1     registerName = 0x00020001
+	registerX2     registerName = 0x00020002
+	registerX3     registerName = 0x00020003
+	registerX28    registerName = 0x0002001c
+	registerFP     registerName = 0x0002001d
+	registerLR     registerName = 0x0002001e
+	registerSP     registerName = 0x0002001f
+	registerSPEL0  registerName = 0x00020020
+	registerSPEL1  registerName = 0x00020021
+	registerPC     registerName = 0x00020022
+	registerPSTATE registerName = 0x00020023
+	registerGICR   registerName = 0x00063000
+)
+
+func registerX(index int) registerName {
+	if index >= 0 && index <= 28 {
+		return registerName(uint32(registerX0) + uint32(index))
+	}
+	if index == 29 {
+		return registerFP
+	}
+	return registerLR
+}
+
+type uint128 struct {
+	Low64  uint64
+	High64 uint64
+}
+
+type registerValue struct {
+	raw uint128
+}
+
+func uint64RegisterValue(v uint64) registerValue {
+	var out registerValue
+	*(*uint64)(unsafe.Pointer(&out)) = v
+	return out
+}
+
+func (v *registerValue) uint64() uint64 {
+	return *(*uint64)(unsafe.Pointer(v))
+}
+
+type runVPExitReason uint32
+
+const (
+	runVPExitReasonUnmappedGPA            runVPExitReason = 0x80000000
+	runVPExitReasonGPAIntercept           runVPExitReason = 0x80000001
+	runVPExitReasonUnrecoverableException runVPExitReason = 0x80000021
+	runVPExitReasonInvalidVPRegisterValue runVPExitReason = 0x80000020
+	runVPExitReasonUnsupportedFeature     runVPExitReason = 0x80000022
+	runVPExitReasonRegisterIntercept      runVPExitReason = 0x80010006
+	runVPExitReasonArm64Reset             runVPExitReason = 0x8001000c
+	runVPExitReasonCanceled               runVPExitReason = 0xffffffff
+)
+
+func (r runVPExitReason) String() string {
+	switch r {
+	case runVPExitReasonUnmappedGPA:
+		return "UnmappedGpa"
+	case runVPExitReasonGPAIntercept:
+		return "GpaIntercept"
+	case runVPExitReasonUnrecoverableException:
+		return "UnrecoverableException"
+	case runVPExitReasonInvalidVPRegisterValue:
+		return "InvalidVpRegisterValue"
+	case runVPExitReasonUnsupportedFeature:
+		return "UnsupportedFeature"
+	case runVPExitReasonRegisterIntercept:
+		return "RegisterIntercept"
+	case runVPExitReasonArm64Reset:
+		return "Arm64Reset"
+	case runVPExitReasonCanceled:
+		return "Canceled"
+	default:
+		return fmt.Sprintf("Unknown(%#x)", uint32(r))
+	}
+}
+
+type vpExecutionState struct {
+	AsUint16 uint16
+}
+
+type interceptMessageHeader struct {
+	VPIndex             uint32
+	InstructionLength   uint8
+	InterceptAccessType uint8
+	ExecutionState      vpExecutionState
+	PC                  uint64
+	CPSR                uint64
+}
+
+type memoryAccessInfo struct {
+	AsUint8 uint8
+}
+
+type memoryAccessContext struct {
+	Header               interceptMessageHeader
+	Reserved0            uint32
+	InstructionByteCount uint8
+	AccessInfo           memoryAccessInfo
+	Reserved1            uint16
+	InstructionBytes     [4]uint8
+	Reserved2            uint32
+	GVA                  uint64
+	GPA                  uint64
+	Syndrome             uint64
+}
+
+func (m memoryAccessContext) isWrite() bool {
+	return m.Syndrome&(1<<6) != 0
+}
+
+func (m memoryAccessContext) accessSize() uint32 {
+	if m.Syndrome&(1<<24) == 0 {
+		return 0
+	}
+	return 1 << ((m.Syndrome >> 22) & 0x3)
+}
+
+func (m memoryAccessContext) registerIndex() int {
+	return int((m.Syndrome >> 16) & 0x1f)
+}
+
+func (m memoryAccessContext) signExtend() bool {
+	return m.Syndrome&(1<<21) != 0
+}
+
+func (m memoryAccessContext) sf() bool {
+	return m.Syndrome&(1<<15) != 0
+}
+
+type runVPExitContext struct {
+	ExitReason runVPExitReason
+	Reserved   uint32
+	Reserved1  uint64
+	Payload    [256]byte
+}
+
+func (c *runVPExitContext) memoryAccess() *memoryAccessContext {
+	return (*memoryAccessContext)(unsafe.Pointer(&c.Payload[0]))
+}
+
+type allocation struct {
+	addr uintptr
+	size uintptr
+}
+
+func virtualAlloc(size uintptr) (*allocation, error) {
+	const (
+		memCommit            = 0x1000
+		memReserve           = 0x2000
+		pageExecuteReadWrite = 0x40
+	)
+	ptr, _, err := procVirtualAlloc.Call(0, size, memCommit|memReserve, pageExecuteReadWrite)
+	if ptr == 0 {
+		if err == syscall.Errno(0) {
+			err = syscall.GetLastError()
+		}
+		return nil, err
+	}
+	return &allocation{addr: ptr, size: size}, nil
+}
+
+func (a *allocation) bytes() []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(a.addr)), int(a.size))
+}
+
+func (a *allocation) free() error {
+	if a == nil || a.addr == 0 {
+		return nil
+	}
+	const memRelease = 0x8000
+	r1, _, err := procVirtualFree.Call(a.addr, 0, memRelease)
+	if r1 == 0 {
+		if err == syscall.Errno(0) {
+			err = syscall.GetLastError()
+		}
+		return err
+	}
+	a.addr = 0
+	a.size = 0
+	return nil
+}
+
+func isHypervisorPresent() (bool, error) {
+	var present uint32
+	var written uint32
+	err := callHRESULT(procWHvGetCapability, uintptr(capabilityCodeHypervisorPresent), uintptr(unsafe.Pointer(&present)), unsafe.Sizeof(present), uintptr(unsafe.Pointer(&written)))
+	if err != nil {
+		return false, err
+	}
+	return present != 0, nil
+}
+
+func getCapability[T any](code capabilityCode) (T, error) {
+	var value T
+	var written uint32
+	err := callHRESULT(procWHvGetCapability, uintptr(code), uintptr(unsafe.Pointer(&value)), unsafe.Sizeof(value), uintptr(unsafe.Pointer(&written)))
+	return value, err
+}
+
+func createPartition() (partitionHandle, error) {
+	var part partitionHandle
+	err := callHRESULT(procWHvCreatePartition, uintptr(unsafe.Pointer(&part)))
+	return part, err
+}
+
+func setPartitionProperty[T any](part partitionHandle, code partitionPropertyCode, value T) error {
+	return callHRESULT(procWHvSetPartitionProperty, uintptr(part), uintptr(code), uintptr(unsafe.Pointer(&value)), unsafe.Sizeof(value))
+}
+
+func setupPartition(part partitionHandle) error {
+	return callHRESULT(procWHvSetupPartition, uintptr(part))
+}
+
+func deletePartition(part partitionHandle) error {
+	return callHRESULT(procWHvDeletePartition, uintptr(part))
+}
+
+func mapGPARange(part partitionHandle, source unsafe.Pointer, guestAddress uint64, size uint64, flags mapGPARangeFlags) error {
+	return callHRESULT(procWHvMapGpaRange, uintptr(part), uintptr(source), uintptr(guestPhysicalAddress(guestAddress)), uintptr(size), uintptr(flags))
+}
+
+func unmapGPARange(part partitionHandle, guestAddress uint64, size uint64) error {
+	return callHRESULT(procWHvUnmapGpaRange, uintptr(part), uintptr(guestPhysicalAddress(guestAddress)), uintptr(size))
+}
+
+func createVirtualProcessor(part partitionHandle, vpIndex uint32) error {
+	return callHRESULT(procWHvCreateVirtualProcessor, uintptr(part), uintptr(vpIndex), 0)
+}
+
+func deleteVirtualProcessor(part partitionHandle, vpIndex uint32) error {
+	return callHRESULT(procWHvDeleteVirtualProcessor, uintptr(part), uintptr(vpIndex))
+}
+
+func runVirtualProcessor(part partitionHandle, vpIndex uint32, exit *runVPExitContext) error {
+	return callHRESULT(procWHvRunVirtualProcessor, uintptr(part), uintptr(vpIndex), uintptr(unsafe.Pointer(exit)), unsafe.Sizeof(*exit))
+}
+
+func getVirtualProcessorRegisters(part partitionHandle, vpIndex uint32, names []registerName, values []registerValue) error {
+	if len(values) < len(names) {
+		return fmt.Errorf("register values slice too small")
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	aligned, backing := alignedRegisterValues(len(names))
+	err := callHRESULT(procWHvGetVirtualProcessorRegisters, uintptr(part), uintptr(vpIndex), uintptr(unsafe.Pointer(&names[0])), uintptr(len(names)), uintptr(unsafe.Pointer(&aligned[0])))
+	if err == nil {
+		copy(values, aligned)
+	}
+	runtime.KeepAlive(names)
+	runtime.KeepAlive(values)
+	runtime.KeepAlive(backing)
+	return err
+}
+
+func setVirtualProcessorRegisters(part partitionHandle, vpIndex uint32, names []registerName, values []registerValue) error {
+	if len(values) < len(names) {
+		return fmt.Errorf("register values slice too small")
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	aligned, backing := alignedRegisterValues(len(names))
+	copy(aligned, values[:len(names)])
+	err := callHRESULT(procWHvSetVirtualProcessorRegisters, uintptr(part), uintptr(vpIndex), uintptr(unsafe.Pointer(&names[0])), uintptr(len(names)), uintptr(unsafe.Pointer(&aligned[0])))
+	runtime.KeepAlive(names)
+	runtime.KeepAlive(values)
+	runtime.KeepAlive(backing)
+	return err
+}
+
+func alignedRegisterValues(count int) ([]registerValue, []byte) {
+	const registerValueAlign = uintptr(16)
+	if count == 0 {
+		return nil, nil
+	}
+	size := unsafe.Sizeof(registerValue{})
+	backing := make([]byte, uintptr(count)*size+registerValueAlign-1)
+	addr := uintptr(unsafe.Pointer(&backing[0]))
+	aligned := (addr + registerValueAlign - 1) &^ (registerValueAlign - 1)
+	return unsafe.Slice((*registerValue)(unsafe.Pointer(aligned)), count), backing
+}
+
+func cancelRunVirtualProcessor(part partitionHandle, vpIndex uint32) error {
+	return callHRESULT(procWHvCancelRunVirtualProcessor, uintptr(part), uintptr(vpIndex), 0)
+}
+
+type interruptControl2 struct {
+	AsUint64 uint64
+}
+
+type interruptControl struct {
+	TargetPartition    uint64
+	InterruptControl   interruptControl2
+	DestinationAddress uint64
+	RequestedVector    uint32
+	TargetVTL          uint8
+	ReservedZ0         uint8
+	ReservedZ1         uint16
+}
+
+func requestInterrupt(part partitionHandle, vector uint32, asserted bool) error {
+	var assertedBit uint64
+	if asserted {
+		assertedBit = 1 << 34
+	}
+	control := interruptControl{
+		InterruptControl: interruptControl2{AsUint64: assertedBit},
+		RequestedVector:  vector,
+	}
+	return callHRESULT(procWHvRequestInterrupt, uintptr(part), uintptr(unsafe.Pointer(&control)), unsafe.Sizeof(control))
+}

--- a/internal/hv/whp/bindings_windows_arm64.go
+++ b/internal/hv/whp/bindings_windows_arm64.go
@@ -27,6 +27,7 @@ var (
 	procWHvSetVirtualProcessorRegisters = winhvplatform.NewProc("WHvSetVirtualProcessorRegisters")
 	procWHvCancelRunVirtualProcessor    = winhvplatform.NewProc("WHvCancelRunVirtualProcessor")
 	procWHvRequestInterrupt             = winhvplatform.NewProc("WHvRequestInterrupt")
+	procWHvAdviseGpaRange               = winhvplatform.NewProc("WHvAdviseGpaRange")
 	procVirtualAlloc                    = kernel32.NewProc("VirtualAlloc")
 	procVirtualFree                     = kernel32.NewProc("VirtualFree")
 )
@@ -101,6 +102,37 @@ const (
 	mapGPARangeFlagWrite   mapGPARangeFlags = 0x2
 	mapGPARangeFlagExecute mapGPARangeFlags = 0x4
 )
+
+type memoryRangeEntry struct {
+	GuestAddress guestPhysicalAddress
+	SizeInBytes  uint64
+}
+
+type adviseGPARangeCode uint32
+
+const (
+	adviseGPARangeCodePopulate adviseGPARangeCode = 0
+)
+
+type memoryAccessType uint32
+
+const (
+	memoryAccessRead    memoryAccessType = 0
+	memoryAccessWrite   memoryAccessType = 1
+	memoryAccessExecute memoryAccessType = 2
+)
+
+type adviseGPARangePopulateFlags uint32
+
+const (
+	adviseGPARangePopulateFlagPrefetch        adviseGPARangePopulateFlags = 0x1
+	adviseGPARangePopulateFlagAvoidHardFaults adviseGPARangePopulateFlags = 0x2
+)
+
+type adviseGPARangePopulateOptions struct {
+	Flags      adviseGPARangePopulateFlags
+	AccessType memoryAccessType
+}
 
 type registerName uint32
 
@@ -332,6 +364,26 @@ func mapGPARange(part partitionHandle, source unsafe.Pointer, guestAddress uint6
 
 func unmapGPARange(part partitionHandle, guestAddress uint64, size uint64) error {
 	return callHRESULT(procWHvUnmapGpaRange, uintptr(part), uintptr(guestPhysicalAddress(guestAddress)), uintptr(size))
+}
+
+func adviseGPARangePopulate(part partitionHandle, guestAddress uint64, size uint64, access memoryAccessType, flags adviseGPARangePopulateFlags) error {
+	ranges := []memoryRangeEntry{{
+		GuestAddress: guestPhysicalAddress(guestAddress),
+		SizeInBytes:  size,
+	}}
+	populate := adviseGPARangePopulateOptions{
+		Flags:      flags,
+		AccessType: access,
+	}
+	return callHRESULT(
+		procWHvAdviseGpaRange,
+		uintptr(part),
+		uintptr(unsafe.Pointer(&ranges[0])),
+		uintptr(len(ranges)),
+		uintptr(adviseGPARangeCodePopulate),
+		uintptr(unsafe.Pointer(&populate)),
+		unsafe.Sizeof(populate),
+	)
 }
 
 func createVirtualProcessor(part partitionHandle, vpIndex uint32) error {

--- a/internal/hv/whp/boot_status_windows_arm64.go
+++ b/internal/hv/whp/boot_status_windows_arm64.go
@@ -1,0 +1,12 @@
+//go:build windows && arm64
+
+package whp
+
+import "j5.nz/cc/client"
+
+func emitManagedBootStatus(onEvent func(client.BootEvent) error, message string) error {
+	if onEvent == nil {
+		return nil
+	}
+	return onEvent(client.BootEvent{Kind: "status", Message: message})
+}

--- a/internal/hv/whp/boot_windows_arm64.go
+++ b/internal/hv/whp/boot_windows_arm64.go
@@ -5,8 +5,10 @@ package whp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -16,6 +18,8 @@ import (
 	"j5.nz/cc/internal/serial"
 	"j5.nz/cc/internal/virtio"
 )
+
+const linuxWHPCNTVOverflowInterrupt = 20
 
 func BootKernelToSerial(ctx context.Context, kernel []byte, memoryMB uint64, dmesg bool) (string, error) {
 	return bootToCondition(ctx, kernel, nil, memoryMB, dmesg, nil, nil, nil, nil, func(serial string) bool {
@@ -42,7 +46,7 @@ func BootInitramfsToMarkerWithFSAndNet(ctx context.Context, kernel []byte, initr
 }
 
 func bootToCondition(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, done func(string) bool) (string, error) {
-	vm, uart, serialOut, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, rng, netdev, nil)
+	vm, uart, serialOut, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, true, fsdevs, vsock, rng, netdev, nil)
 	if err != nil {
 		return "", err
 	}
@@ -51,6 +55,7 @@ func bootToCondition(ctx context.Context, kernel []byte, initrd []byte, memoryMB
 	if vsock != nil {
 		defer vsock.Close()
 	}
+	var stats arm64RunStats
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			if done(serialOut.String()) {
@@ -65,14 +70,16 @@ func bootToCondition(ctx context.Context, kernel []byte, initrd []byte, memoryMB
 		if done(serialOut.String()) {
 			return serialOut.String(), nil
 		}
-		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit); err != nil {
+		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit, &stats); err != nil {
 			return serialOut.String(), err
 		}
 	}
 }
 
-func prepareArm64VM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialWriter io.Writer) (*VM, *serial.UART8250, fmt.Stringer, error) {
-	vm, err := NewVM(arm64vm.MemorySizeBytes(memoryMB), arm64vm.MemoryBase)
+func prepareArm64VM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, serialConsole bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialWriter io.Writer) (*VM, *serial.UART8250, fmt.Stringer, error) {
+	vm, err := NewVMWithOptions(arm64vm.MemorySizeBytes(memoryMB), arm64vm.MemoryBase, VMOptions{
+		CNTVOverflowInterrupt: linuxWHPCNTVOverflowInterrupt,
+	})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -104,10 +111,12 @@ func prepareArm64VM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, f
 		nodes = append(nodes, netdev.DeviceTreeNode())
 	}
 	plan, err := arm64vm.PrepareBoot(mem, kernel, initrd, arm64vm.BootConfig{
-		MemoryMB:   memoryMB,
-		GICVersion: arm64vm.GICVersionV3,
-		Dmesg:      dmesg,
-		ExtraNodes: nodes,
+		MemoryMB:             memoryMB,
+		GICVersion:           arm64vm.GICVersionV3,
+		Dmesg:                dmesg,
+		DisableSerialConsole: !serialConsole,
+		HyperVTimer:          true,
+		ExtraNodes:           nodes,
 	})
 	if err != nil {
 		_ = vm.Close()
@@ -144,10 +153,19 @@ func setupBootRegisters(vm *VM, plan *bootarm64.BootPlan) error {
 	return nil
 }
 
-func handleArm64Exit(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, exit Exit) error {
+type arm64RunStats struct {
+	uart  uint64
+	fs    uint64
+	vsock uint64
+	rng   uint64
+	net   uint64
+	gic   uint64
+}
+
+func handleArm64Exit(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, exit Exit, stats *arm64RunStats) error {
 	switch exit.Reason {
 	case runVPExitReasonUnmappedGPA, runVPExitReasonGPAIntercept:
-		return handleBootMMIO(vm, uart, fsdevs, vsock, rng, netdev, exit.MMIO)
+		return handleBootMMIO(vm, uart, fsdevs, vsock, rng, netdev, exit.MMIO, stats)
 	case runVPExitReasonCanceled:
 		return nil
 	case runVPExitReasonArm64Reset:
@@ -158,8 +176,11 @@ func handleArm64Exit(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *
 	}
 }
 
-func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, mmio MMIOExit) error {
+func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, mmio MMIOExit, stats *arm64RunStats) error {
 	if uart.Contains(mmio.Addr, int(mmio.Len)) {
+		if stats != nil {
+			stats.uart++
+		}
 		if mmio.Write {
 			if err := uart.Write(mmio.Addr, mmio.Data[:mmio.Len]); err != nil {
 				return err
@@ -176,6 +197,9 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 		if fsdev == nil || !fsdev.Contains(mmio.Addr, int(mmio.Len)) {
 			continue
 		}
+		if stats != nil {
+			stats.fs++
+		}
 		if mmio.Write {
 			if err := fsdev.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
 				return err
@@ -189,6 +213,9 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 		return vm.CompleteMMIORead(mmio, value)
 	}
 	if vsock != nil && vsock.Contains(mmio.Addr, int(mmio.Len)) {
+		if stats != nil {
+			stats.vsock++
+		}
 		if mmio.Write {
 			if err := vsock.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
 				return err
@@ -202,6 +229,9 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 		return vm.CompleteMMIORead(mmio, value)
 	}
 	if rng != nil && rng.Contains(mmio.Addr, int(mmio.Len)) {
+		if stats != nil {
+			stats.rng++
+		}
 		if mmio.Write {
 			if err := rng.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
 				return err
@@ -215,6 +245,9 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 		return vm.CompleteMMIORead(mmio, value)
 	}
 	if netdev != nil && netdev.Contains(mmio.Addr, int(mmio.Len)) {
+		if stats != nil {
+			stats.net++
+		}
 		if mmio.Write {
 			if err := netdev.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
 				return err
@@ -228,12 +261,18 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 		return vm.CompleteMMIORead(mmio, value)
 	}
 	if inRange(mmio.Addr, arm64vm.GICDistributorMin, arm64vm.GICDistributorMax) {
+		if stats != nil {
+			stats.gic++
+		}
 		if mmio.Write {
 			return vm.CompleteMMIOWrite(mmio)
 		}
 		return vm.CompleteMMIORead(mmio, readBootGICDistributor(mmio.Addr-arm64vm.GICDistributorMin))
 	}
 	if inRange(mmio.Addr, arm64vm.GICRedistributorMin, arm64vm.GICRedistributorMax) {
+		if stats != nil {
+			stats.gic++
+		}
 		if mmio.Write {
 			return vm.CompleteMMIOWrite(mmio)
 		}
@@ -242,13 +281,69 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 	return fmt.Errorf("unhandled mmio addr=%#x len=%d write=%v", mmio.Addr, mmio.Len, mmio.Write)
 }
 
-func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut fmt.Stringer) error {
+func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut fmt.Stringer, sampler *whpPCSampler) error {
+	if sampler != nil {
+		defer sampler.dump("final")
+	}
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != "" || os.Getenv("CC_WHP_BSD_TIMING") != ""
+	traceStart := time.Now()
+	nextTrace := traceStart.Add(5 * time.Second)
+	var nextSample time.Time
+	if sampler != nil {
+		nextSample = traceStart.Add(sampler.interval)
+	}
+	var exits, mmioExits, canceledExits uint64
+	var stats arm64RunStats
 	for step := 0; ; step++ {
 		var exit Exit
-		if err := vm.RunInterruptible(ctx, &exit); err != nil {
+		runCtx := ctx
+		var cancel context.CancelFunc
+		if sampler != nil {
+			timeout := time.Until(nextSample)
+			if timeout <= 0 {
+				timeout = time.Nanosecond
+			}
+			runCtx, cancel = context.WithTimeout(ctx, timeout)
+		}
+		err := vm.RunInterruptible(runCtx, &exit)
+		now := time.Now()
+		if cancel != nil {
+			cancel()
+		}
+		if err != nil {
+			if sampler != nil && errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				sampler.recordCurrentPC(vm, now)
+				nextSample = sampler.nextAfter(nextSample, now)
+				continue
+			}
 			return fmt.Errorf("run step %d: %w", step, err)
 		}
-		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit); err != nil {
+		if sampler != nil && !now.Before(nextSample) {
+			lr, _ := vm.getRegister(registerX(30))
+			if exit.PC != 0 {
+				sampler.record(exit.PC, lr, now)
+			} else {
+				sampler.recordCurrentPC(vm, now)
+			}
+			nextSample = sampler.nextAfter(nextSample, now)
+		}
+		exits++
+		switch exit.Reason {
+		case runVPExitReasonUnmappedGPA, runVPExitReasonGPAIntercept:
+			mmioExits++
+		case runVPExitReasonCanceled:
+			canceledExits++
+		}
+		if trace {
+			if !now.Before(nextTrace) {
+				_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux run +%s: exits=%d mmio=%d canceled=%d serial=%d uart=%d fs=%d vsock=%d rng=%d net=%d gic=%d\n",
+					now.Sub(traceStart).Round(time.Millisecond), exits, mmioExits, canceledExits, len(serialOut.String()), stats.uart, stats.fs, stats.vsock, stats.rng, stats.net, stats.gic)
+				for !nextTrace.After(now) {
+					nextTrace = nextTrace.Add(5 * time.Second)
+				}
+			}
+		}
+		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit, &stats); err != nil {
 			return err
 		}
 	}

--- a/internal/hv/whp/boot_windows_arm64.go
+++ b/internal/hv/whp/boot_windows_arm64.go
@@ -1,0 +1,314 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/fdt"
+	bootarm64 "j5.nz/cc/internal/linux/boot/arm64"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+)
+
+func BootKernelToSerial(ctx context.Context, kernel []byte, memoryMB uint64, dmesg bool) (string, error) {
+	return bootToCondition(ctx, kernel, nil, memoryMB, dmesg, nil, nil, nil, nil, func(serial string) bool {
+		return serial != ""
+	})
+}
+
+func BootInitramfsToMarker(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, marker string) (string, error) {
+	if strings.TrimSpace(marker) == "" {
+		return "", fmt.Errorf("boot marker is required")
+	}
+	return bootToCondition(ctx, kernel, initrd, memoryMB, dmesg, nil, nil, nil, nil, func(serial string) bool {
+		return strings.Contains(serial, marker)
+	})
+}
+
+func BootInitramfsToMarkerWithFSAndNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, marker string, fsdevs []*virtio.FS, netdev *virtio.Net) (string, error) {
+	if strings.TrimSpace(marker) == "" {
+		return "", fmt.Errorf("boot marker is required")
+	}
+	return bootToCondition(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, nil, netdev, func(serial string) bool {
+		return strings.Contains(serial, marker)
+	})
+}
+
+func bootToCondition(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, done func(string) bool) (string, error) {
+	vm, uart, serialOut, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, rng, netdev, nil)
+	if err != nil {
+		return "", err
+	}
+	defer vm.Close()
+	defer closeFSDevices(fsdevs)
+	if vsock != nil {
+		defer vsock.Close()
+	}
+	for step := 0; ; step++ {
+		if err := ctx.Err(); err != nil {
+			if done(serialOut.String()) {
+				return serialOut.String(), nil
+			}
+			return serialOut.String(), err
+		}
+		var exit Exit
+		if err := vm.RunInterruptible(ctx, &exit); err != nil {
+			return serialOut.String(), fmt.Errorf("run step %d: %w", step, err)
+		}
+		if done(serialOut.String()) {
+			return serialOut.String(), nil
+		}
+		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit); err != nil {
+			return serialOut.String(), err
+		}
+	}
+}
+
+func prepareArm64VM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialWriter io.Writer) (*VM, *serial.UART8250, fmt.Stringer, error) {
+	vm, err := NewVM(arm64vm.MemorySizeBytes(memoryMB), arm64vm.MemoryBase)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	mem := vm.Memory()
+	var out bytes.Buffer
+	if serialWriter == nil {
+		serialWriter = &out
+	}
+	uart := serial.NewUART8250(arm64vm.DefaultUARTBase, arm64vm.DefaultUARTRegShift, serialWriter)
+	uart.AttachIRQ(vm, arm64vm.UARTSPI)
+
+	nodes := make([]fdt.Node, 0, len(fsdevs)+3)
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			fsdev.Attach(vm, vm)
+			nodes = append(nodes, fsdev.DeviceTreeNode())
+		}
+	}
+	if vsock != nil {
+		vsock.Attach(vm, vm)
+		nodes = append(nodes, vsock.DeviceTreeNode())
+	}
+	if rng != nil {
+		rng.Attach(vm, vm)
+		nodes = append(nodes, rng.DeviceTreeNode())
+	}
+	if netdev != nil {
+		netdev.Attach(vm, vm)
+		nodes = append(nodes, netdev.DeviceTreeNode())
+	}
+	plan, err := arm64vm.PrepareBoot(mem, kernel, initrd, arm64vm.BootConfig{
+		MemoryMB:   memoryMB,
+		GICVersion: arm64vm.GICVersionV3,
+		Dmesg:      dmesg,
+		ExtraNodes: nodes,
+	})
+	if err != nil {
+		_ = vm.Close()
+		return nil, nil, nil, fmt.Errorf("prepare boot: %w", err)
+	}
+	if err := setupBootRegisters(vm, plan); err != nil {
+		_ = vm.Close()
+		return nil, nil, nil, err
+	}
+	if stringer, ok := serialWriter.(fmt.Stringer); ok {
+		return vm, uart, stringer, nil
+	}
+	return vm, uart, &out, nil
+}
+
+func setupBootRegisters(vm *VM, plan *bootarm64.BootPlan) error {
+	if err := vm.SetPC(plan.EntryGPA); err != nil {
+		return fmt.Errorf("set PC: %w", err)
+	}
+	if err := vm.SetPState(arm64vm.DefaultPStateBits); err != nil {
+		return fmt.Errorf("set PSTATE: %w", err)
+	}
+	if err := vm.SetSpEl1(plan.StackTopGPA); err != nil {
+		return fmt.Errorf("set SP_EL1: %w", err)
+	}
+	if err := vm.SetX(0, plan.DeviceTreeGPA); err != nil {
+		return fmt.Errorf("set X0: %w", err)
+	}
+	for reg := 1; reg <= 3; reg++ {
+		if err := vm.SetX(reg, 0); err != nil {
+			return fmt.Errorf("set X%d: %w", reg, err)
+		}
+	}
+	return nil
+}
+
+func handleArm64Exit(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, exit Exit) error {
+	switch exit.Reason {
+	case runVPExitReasonUnmappedGPA, runVPExitReasonGPAIntercept:
+		return handleBootMMIO(vm, uart, fsdevs, vsock, rng, netdev, exit.MMIO)
+	case runVPExitReasonCanceled:
+		return nil
+	case runVPExitReasonArm64Reset:
+		return fmt.Errorf("guest requested arm64 reset")
+	default:
+		pc, _ := vm.GetPC()
+		return fmt.Errorf("unexpected exit %s at pc=%#x", exit.Reason, pc)
+	}
+}
+
+func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, mmio MMIOExit) error {
+	if uart.Contains(mmio.Addr, int(mmio.Len)) {
+		if mmio.Write {
+			if err := uart.Write(mmio.Addr, mmio.Data[:mmio.Len]); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := uart.ReadValue(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev == nil || !fsdev.Contains(mmio.Addr, int(mmio.Len)) {
+			continue
+		}
+		if mmio.Write {
+			if err := fsdev.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := fsdev.Read(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	if vsock != nil && vsock.Contains(mmio.Addr, int(mmio.Len)) {
+		if mmio.Write {
+			if err := vsock.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := vsock.Read(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	if rng != nil && rng.Contains(mmio.Addr, int(mmio.Len)) {
+		if mmio.Write {
+			if err := rng.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := rng.Read(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	if netdev != nil && netdev.Contains(mmio.Addr, int(mmio.Len)) {
+		if mmio.Write {
+			if err := netdev.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := netdev.Read(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	if inRange(mmio.Addr, arm64vm.GICDistributorMin, arm64vm.GICDistributorMax) {
+		if mmio.Write {
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		return vm.CompleteMMIORead(mmio, readBootGICDistributor(mmio.Addr-arm64vm.GICDistributorMin))
+	}
+	if inRange(mmio.Addr, arm64vm.GICRedistributorMin, arm64vm.GICRedistributorMax) {
+		if mmio.Write {
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		return vm.CompleteMMIORead(mmio, readBootGICRedistributor(mmio.Addr-arm64vm.GICRedistributorMin))
+	}
+	return fmt.Errorf("unhandled mmio addr=%#x len=%d write=%v", mmio.Addr, mmio.Len, mmio.Write)
+}
+
+func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut fmt.Stringer) error {
+	for step := 0; ; step++ {
+		var exit Exit
+		if err := vm.RunInterruptible(ctx, &exit); err != nil {
+			return fmt.Errorf("run step %d: %w", step, err)
+		}
+		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit); err != nil {
+			return err
+		}
+	}
+}
+
+func closeFSDevices(fsdevs []*virtio.FS) {
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			_ = fsdev.Close()
+		}
+	}
+}
+
+func mmioValue(mmio MMIOExit) uint64 {
+	switch mmio.Len {
+	case 1:
+		return uint64(mmio.Data[0])
+	case 2:
+		return uint64(mmio.Data[0]) | uint64(mmio.Data[1])<<8
+	case 4:
+		return uint64(mmio.Data[0]) | uint64(mmio.Data[1])<<8 | uint64(mmio.Data[2])<<16 | uint64(mmio.Data[3])<<24
+	default:
+		var value uint64
+		for i := uint32(0); i < mmio.Len && i < 8; i++ {
+			value |= uint64(mmio.Data[i]) << (8 * i)
+		}
+		return value
+	}
+}
+
+func readBootGICDistributor(offset uint64) uint64 {
+	switch offset {
+	case 0xffe8:
+		return 0x30
+	default:
+		return 0
+	}
+}
+
+func readBootGICRedistributor(offset uint64) uint64 {
+	switch offset {
+	case 0x0:
+		return 0
+	case 0x8:
+		return 1 << 4
+	case 0x14:
+		return 0
+	case 0xffe8:
+		return 0x30
+	default:
+		return 0
+	}
+}
+
+func inRange(addr, start, end uint64) bool {
+	return addr >= start && addr < end
+}
+
+func BootKernelToSerialWithTimeout(kernel []byte, memoryMB uint64, dmesg bool, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return BootKernelToSerial(ctx, kernel, memoryMB, dmesg)
+}

--- a/internal/hv/whp/bsd_session_windows_arm64.go
+++ b/internal/hv/whp/bsd_session_windows_arm64.go
@@ -1,0 +1,913 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"bytes"
+	"context"
+	"debug/elf"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/fdt"
+	freebsdarm64 "j5.nz/cc/internal/freebsd/boot/arm64"
+	netbsdarm64 "j5.nz/cc/internal/netbsd/boot/arm64"
+	"j5.nz/cc/internal/netstack"
+	"j5.nz/cc/internal/nvme"
+	openbsdarm64 "j5.nz/cc/internal/openbsd/boot/arm64"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const bsdControlPort = 10777
+
+const (
+	openBSDWHPCNTVOverflowInterrupt = 20
+	openBSDWHPVirtualTimerPPI       = 4
+	openBSDWHPGICLPIIntIDBits       = 1
+	openBSDWHPMINGICMSILPIBits      = 14
+)
+
+type OpenBSDManagedConfig struct {
+	Kernel    []byte
+	Root      virtio.BlockBackend
+	MemoryMB  uint64
+	Dmesg     bool
+	GuestIPv4 net.IP
+	GuestMAC  net.HardwareAddr
+	NetDevice *virtio.Net
+	NetStack  *netstack.NetStack
+}
+
+type FreeBSDManagedConfig struct {
+	Kernel    []byte
+	Root      virtio.BlockBackend
+	MemoryMB  uint64
+	Dmesg     bool
+	GuestIPv4 net.IP
+	GuestMAC  net.HardwareAddr
+	NetDevice *virtio.Net
+	NetStack  *netstack.NetStack
+}
+
+type NetBSDManagedConfig struct {
+	Kernel    []byte
+	Root      virtio.BlockBackend
+	MemoryMB  uint64
+	Dmesg     bool
+	GuestIPv4 net.IP
+	GuestMAC  net.HardwareAddr
+	NetDevice *virtio.Net
+	NetStack  *netstack.NetStack
+}
+
+type bsdARM64SessionConfig struct {
+	GuestName           string
+	Kernel              []byte
+	Root                virtio.BlockBackend
+	MemoryMB            uint64
+	Dmesg               bool
+	NetDevice           *virtio.Net
+	NetStack            *netstack.NetStack
+	OwnNetStack         bool
+	BootKind            string
+	MemoryBase          uint64
+	BootArgs            string
+	FreeBSDVirtioQuirks bool
+	NetBSDVirtioQuirks  bool
+}
+
+func StartOpenBSDManagedSession(ctx context.Context, cfg OpenBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if len(cfg.Kernel) == 0 {
+		return nil, fmt.Errorf("OpenBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return nil, fmt.Errorf("OpenBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 768
+	}
+	netdev, stack, ownStack := openBSDManagedNet(cfg.NetDevice, cfg.NetStack, cfg.GuestIPv4, cfg.GuestMAC)
+	return startBSDARM64ManagedSession(ctx, bsdARM64SessionConfig{
+		GuestName:   "OpenBSD",
+		Kernel:      cfg.Kernel,
+		Root:        cfg.Root,
+		MemoryMB:    cfg.MemoryMB,
+		Dmesg:       cfg.Dmesg,
+		NetDevice:   netdev,
+		NetStack:    stack,
+		OwnNetStack: ownStack,
+		BootKind:    "openbsd",
+		MemoryBase:  arm64vm.MemoryBase,
+	}, onEvent)
+}
+
+func StartFreeBSDManagedSession(ctx context.Context, cfg FreeBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if len(cfg.Kernel) == 0 {
+		return nil, fmt.Errorf("FreeBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return nil, fmt.Errorf("FreeBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 1024
+	}
+	netdev, stack, ownStack := freeBSDManagedNet(cfg.NetDevice, cfg.NetStack, cfg.GuestIPv4, cfg.GuestMAC)
+	return startBSDARM64ManagedSession(ctx, bsdARM64SessionConfig{
+		GuestName:           "FreeBSD",
+		Kernel:              cfg.Kernel,
+		Root:                cfg.Root,
+		MemoryMB:            cfg.MemoryMB,
+		Dmesg:               cfg.Dmesg,
+		NetDevice:           netdev,
+		NetStack:            stack,
+		OwnNetStack:         ownStack,
+		BootKind:            "freebsd",
+		MemoryBase:          arm64vm.MemoryBase,
+		FreeBSDVirtioQuirks: true,
+	}, onEvent)
+}
+
+func StartNetBSDManagedSession(ctx context.Context, cfg NetBSDManagedConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if len(cfg.Kernel) == 0 {
+		return nil, fmt.Errorf("NetBSD kernel is required")
+	}
+	if cfg.Root == nil {
+		return nil, fmt.Errorf("NetBSD root filesystem is required")
+	}
+	if cfg.MemoryMB == 0 {
+		cfg.MemoryMB = 1024
+	}
+	netdev, stack, ownStack := netBSDManagedNet(cfg.NetDevice, cfg.NetStack, cfg.GuestIPv4, cfg.GuestMAC)
+	return startBSDARM64ManagedSession(ctx, bsdARM64SessionConfig{
+		GuestName:          "NetBSD",
+		Kernel:             cfg.Kernel,
+		Root:               cfg.Root,
+		MemoryMB:           cfg.MemoryMB,
+		Dmesg:              cfg.Dmesg,
+		NetDevice:          netdev,
+		NetStack:           stack,
+		OwnNetStack:        ownStack,
+		BootKind:           "netbsd",
+		MemoryBase:         netBSDArm64MemoryBase,
+		NetBSDVirtioQuirks: true,
+	}, onEvent)
+}
+
+const netBSDArm64MemoryBase = 0x40000000
+
+func startBSDARM64ManagedSession(ctx context.Context, cfg bsdARM64SessionConfig, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	traceStart := time.Now()
+	trace := os.Getenv("CC_WHP_BSD_TIMING") != ""
+	tracef := func(format string, args ...any) {
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-bsd %s +%s: %s\n", cfg.GuestName, time.Since(traceStart).Round(time.Millisecond), fmt.Sprintf(format, args...))
+		}
+	}
+	if cfg.NetDevice == nil || cfg.NetStack == nil {
+		return nil, fmt.Errorf("%s network device and stack are required", cfg.GuestName)
+	}
+	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
+		return nil, err
+	}
+	ln, err := cfg.NetStack.ListenInternal("tcp", fmt.Sprintf(":%d", bsdControlPort))
+	if err != nil {
+		if cfg.OwnNetStack {
+			cfg.NetStack.Close()
+		}
+		return nil, fmt.Errorf("listen %s control tcp: %w", cfg.GuestName, err)
+	}
+
+	var (
+		vm         *VM
+		bootWriter *vmruntime.BootEventWriter
+	)
+	cleanupStartup := func() {
+		_ = ln.Close()
+		if cfg.OwnNetStack && cfg.NetStack != nil {
+			cfg.NetStack.Close()
+		}
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		if vm != nil {
+			_ = vm.Close()
+		}
+	}
+
+	connCh := make(chan net.Conn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go acceptBSDControlConnection(ln, controlTranscript, connCh, acceptErrCh)
+
+	memorySize := arm64vm.MemorySizeBytes(cfg.MemoryMB)
+	memoryBase := cfg.MemoryBase
+	if memoryBase == 0 {
+		memoryBase = arm64vm.MemoryBase
+	}
+	vmOpts := VMOptions{}
+	enableOpenBSDMSI := false
+	if cfg.BootKind == "openbsd" {
+		vmOpts.CNTVOverflowInterrupt = openBSDWHPCNTVOverflowInterrupt
+		lpiBits, err := getCapability[uint32](capabilityCodeGicLpiIntIDBits)
+		if err == nil && lpiBits >= openBSDWHPMINGICMSILPIBits {
+			vmOpts.GICLPIIntIDBits = lpiBits
+			enableOpenBSDMSI = true
+		} else {
+			vmOpts.GICLPIIntIDBits = openBSDWHPGICLPIIntIDBits
+		}
+		tracef("openbsd lpiBits=%d enableMSI=%t", vmOpts.GICLPIIntIDBits, enableOpenBSDMSI)
+	}
+	vm, err = NewVMWithOptions(memorySize, memoryBase, vmOpts)
+	if err != nil {
+		cleanupStartup()
+		return nil, err
+	}
+	tracef("vm created")
+	mem := vm.Memory()
+
+	serialOut := vmruntime.NewSerialTranscript()
+	var serialWriter io.Writer = serialOut
+	if os.Getenv("CC_WHP_BSD_SERIAL") != "" {
+		serialWriter = io.MultiWriter(serialWriter, os.Stderr)
+	}
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = io.MultiWriter(serialOut, bootWriter)
+		if os.Getenv("CC_WHP_BSD_SERIAL") != "" {
+			serialWriter = io.MultiWriter(serialWriter, os.Stderr)
+		}
+	}
+	uart := serial.NewUART8250(arm64vm.DefaultUARTBase, arm64vm.DefaultUARTRegShift, serialWriter)
+	uart.AttachIRQ(vm, arm64vm.UARTSPI)
+
+	nvmeBlock := nvme.NewController(cfg.Root)
+	nvmeBlock.Attach(vm, vm)
+	nvmePCI := newArm64NVMePCIDevice(1, arm64vm.NVMeBase, arm64vm.NVMeIRQ, nvmeBlock)
+	pci := newArm64PCIHost(nvmePCI)
+	if enableOpenBSDMSI {
+		nvmePCI.MSI = true
+		pci.msiParent = openbsdarm64.DefaultGICITSPhandle
+	}
+
+	if cfg.FreeBSDVirtioQuirks {
+		cfg.NetDevice.DisableMergeRX = true
+		cfg.NetDevice.HeaderLength = 12
+	}
+	if cfg.NetBSDVirtioQuirks {
+		cfg.NetDevice.DisableMergeRX = true
+		cfg.NetDevice.LegacyMMIO = true
+	}
+	if cfg.BootKind == "openbsd" {
+		cfg.NetDevice.NoTXIRQ = true
+		cfg.NetDevice.NoTXUsed = true
+	}
+	cfg.NetDevice.AsyncTX = true
+	cfg.NetDevice.AsyncTXDelay = 10 * time.Millisecond
+	cfg.NetDevice.Attach(vm, vm)
+	rng := virtio.NewRNG(arm64vm.RNGBase, arm64vm.RNGSize, arm64vm.RNGIRQ)
+	rng.LegacyMMIO = cfg.NetBSDVirtioQuirks
+	rng.Attach(vm, vm)
+	rtc := arm64vm.NewPL031(arm64vm.RTCBase, arm64vm.RTCSize, time.Now())
+	rootNodes := []fdt.Node{pci.DeviceTreeNode(), rtc.DeviceTreeNode()}
+
+	switch cfg.BootKind {
+	case "openbsd":
+		plan, err := openbsdarm64.PrepareBoot(mem, cfg.Kernel, openbsdarm64.BootOptions{
+			MemoryBase:                      memoryBase,
+			MemorySize:                      memorySize,
+			NumCPUs:                         1,
+			GICVersion:                      openbsdarm64.GICVersionV3,
+			Console:                         true,
+			VirtualTimerPPI:                 openBSDWHPVirtualTimerPPI,
+			EnableGICITS:                    enableOpenBSDMSI,
+			UsePMRShiftForInterruptPriority: true,
+			DisableNVMeINTxMasking:          true,
+			ExtraNodes:                      append(rootNodes, cfg.NetDevice.DeviceTreeNode(), rng.DeviceTreeNode()),
+		})
+		if err != nil {
+			cleanupStartup()
+			return nil, fmt.Errorf("prepare OpenBSD boot: %w", err)
+		}
+		if err := setupOpenBSDBootState(vm, plan); err != nil {
+			cleanupStartup()
+			return nil, err
+		}
+		tracef("boot state prepared")
+	case "freebsd":
+		plan, err := freebsdarm64.PrepareBoot(mem, cfg.Kernel, freebsdarm64.BootOptions{
+			MemoryBase: memoryBase,
+			MemorySize: memorySize,
+			NumCPUs:    1,
+			GICVersion: freebsdarm64.GICVersionV3,
+			Console:    true,
+			ExtraNodes: append(rootNodes, cfg.NetDevice.DeviceTreeNode(), rng.DeviceTreeNode()),
+		})
+		if err != nil {
+			cleanupStartup()
+			return nil, fmt.Errorf("prepare FreeBSD boot: %w", err)
+		}
+		if err := setupFreeBSDBootState(vm, plan); err != nil {
+			cleanupStartup()
+			return nil, err
+		}
+		tracef("boot state prepared")
+	case "netbsd":
+		bootArgs := cfg.BootArgs
+		if bootArgs == "" {
+			bootArgs = "root=ld4a"
+		}
+		plan, err := netbsdarm64.PrepareBoot(mem, cfg.Kernel, netbsdarm64.BootOptions{
+			MemoryBase: memoryBase,
+			MemorySize: memorySize,
+			NumCPUs:    1,
+			GICVersion: netbsdarm64.GICVersionV3,
+			Console:    true,
+			BootArgs:   bootArgs,
+			ExtraNodes: append(rootNodes, cfg.NetDevice.DeviceTreeNode(), rng.DeviceTreeNode()),
+		})
+		if err != nil {
+			cleanupStartup()
+			return nil, fmt.Errorf("prepare NetBSD boot: %w", err)
+		}
+		if err := setupNetBSDBootState(vm, plan); err != nil {
+			cleanupStartup()
+			return nil, err
+		}
+		tracef("boot state prepared")
+	default:
+		cleanupStartup()
+		return nil, fmt.Errorf("unsupported BSD boot kind %q", cfg.BootKind)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error, 1)
+	vmForRun := vm
+	vm = nil
+	go func() {
+		err := runBSDARM64ManagedVM(runCtx, cfg.GuestName, vmForRun, uart, pci, cfg.NetDevice, rng, rtc, serialOut, newWHPPCSampler(cfg.GuestName, cfg.Kernel))
+		err = errors.Join(err, vmForRun.Close())
+		doneCh <- err
+	}()
+	tracef("vm run loop started")
+
+	stopStartedVM := func() {
+		cancel()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		select {
+		case <-doneCh:
+		case <-time.After(time.Second):
+		}
+		if cfg.OwnNetStack && cfg.NetStack != nil {
+			cfg.NetStack.Close()
+		}
+	}
+
+	var control net.Conn
+	select {
+	case err := <-acceptErrCh:
+		stopStartedVM()
+		return nil, bsdStartupError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+		tracef("control connected")
+	case err := <-doneCh:
+		cancel()
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		if cfg.OwnNetStack && cfg.NetStack != nil {
+			cfg.NetStack.Close()
+		}
+		return nil, bsdStartupError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		err := fmt.Errorf("%s guest did not connect to control TCP port %d before startup deadline: %w", cfg.GuestName, bsdControlPort, ctx.Err())
+		cancel()
+		select {
+		case runErr := <-doneCh:
+			if runErr != nil {
+				err = fmt.Errorf("%w; VM run result: %v", err, runErr)
+			}
+		case <-time.After(time.Second):
+		}
+		_ = ln.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		if cfg.OwnNetStack && cfg.NetStack != nil {
+			cfg.NetStack.Close()
+		}
+		return nil, bsdStartupError(err, serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, containsReadyOrFatal); err != nil {
+		_ = control.Close()
+		stopStartedVM()
+		err = fmt.Errorf("%s control connection did not report ready marker %q: %w", cfg.GuestName, vmruntime.InstanceReadyMarker, err)
+		return nil, bsdStartupError(err, serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		_ = control.Close()
+		stopStartedVM()
+		return nil, bsdStartupError(fmt.Errorf("%s guest reported boot failure", cfg.GuestName), serialOut.String(), controlTranscript.String())
+	}
+	tracef("ready marker received")
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		_ = control.Close()
+		stopStartedVM()
+		return nil, err
+	}
+
+	var cleanup func()
+	if cfg.OwnNetStack && cfg.NetStack != nil {
+		cleanup = func() {
+			_ = cfg.NetStack.Close()
+		}
+	}
+	return &ManagedSession{
+		cancel:     cancel,
+		doneCh:     doneCh,
+		control:    control,
+		listener:   ln,
+		bootWriter: bootWriter,
+		transcript: controlTranscript,
+		serialOut:  serialOut,
+		cleanup:    cleanup,
+		dmesg:      cfg.Dmesg,
+	}, nil
+}
+
+func openBSDManagedNet(netdev *virtio.Net, stack *netstack.NetStack, guestIPv4 net.IP, mac net.HardwareAddr) (*virtio.Net, *netstack.NetStack, bool) {
+	return newBSDManagedNet(netdev, stack, guestIPv4, mac, false, 0, false, 50*time.Millisecond)
+}
+
+func freeBSDManagedNet(netdev *virtio.Net, stack *netstack.NetStack, guestIPv4 net.IP, mac net.HardwareAddr) (*virtio.Net, *netstack.NetStack, bool) {
+	return newBSDManagedNet(netdev, stack, guestIPv4, mac, true, 12, false, 0)
+}
+
+func netBSDManagedNet(netdev *virtio.Net, stack *netstack.NetStack, guestIPv4 net.IP, mac net.HardwareAddr) (*virtio.Net, *netstack.NetStack, bool) {
+	return newBSDManagedNet(netdev, stack, guestIPv4, mac, true, 0, true, 0)
+}
+
+func acceptBSDControlConnection(ln net.Listener, transcript *vmruntime.SerialTranscript, connCh chan<- net.Conn, errCh chan<- error) {
+	const candidateReadyTimeout = time.Second
+	buf := make([]byte, 32*1024)
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		start := transcript.Len()
+		_ = conn.SetReadDeadline(time.Now().Add(candidateReadyTimeout))
+
+		for {
+			n, readErr := conn.Read(buf)
+			if n > 0 {
+				_, _ = transcript.Write(buf[:n])
+				text := transcript.String()
+				if start <= len(text) && containsReadyOrFatal(text[start:]) {
+					_ = conn.SetReadDeadline(time.Time{})
+					connCh <- conn
+					for readErr == nil {
+						n, readErr = conn.Read(buf)
+						if n > 0 {
+							_, _ = transcript.Write(buf[:n])
+						}
+					}
+					return
+				}
+			}
+			if readErr != nil {
+				_ = conn.Close()
+				break
+			}
+		}
+	}
+}
+
+type bsdManagedNetBackend struct {
+	iface *netstack.NetworkInterface
+}
+
+func (b bsdManagedNetBackend) HandleTxPacket(packet []byte) error {
+	return b.iface.DeliverGuestPacket(packet, true)
+}
+
+func newBSDManagedNet(netdev *virtio.Net, stack *netstack.NetStack, guestIPv4 net.IP, mac net.HardwareAddr, disableMergeRX bool, headerLength int, legacyMMIO bool, rxDelay time.Duration) (*virtio.Net, *netstack.NetStack, bool) {
+	if netdev != nil && stack != nil {
+		return netdev, stack, false
+	}
+	if guestIPv4 == nil {
+		guestIPv4 = net.IPv4(10, 42, 0, 2)
+	}
+	if mac == nil {
+		mac = net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}
+	}
+	stack = netstack.New(slog.Default())
+	_ = stack.SetGuestMAC(mac)
+	_ = stack.SetGuestIPv4(guestIPv4)
+	iface, _ := stack.AttachNetworkInterface()
+	netdev = virtio.NewNet(arm64vm.NetBase, arm64vm.NetSize, arm64vm.NetIRQ, mac, bsdManagedNetBackend{iface: iface})
+	netdev.DisableMergeRX = disableMergeRX
+	netdev.HeaderLength = headerLength
+	netdev.LegacyMMIO = legacyMMIO
+	iface.AttachVirtioBackend(func(frame []byte) error {
+		copied := append([]byte(nil), frame...)
+		go func() {
+			if rxDelay > 0 {
+				time.Sleep(rxDelay)
+			}
+			if err := netdev.EnqueueRxPacketOwned(copied); err != nil {
+				slog.Warn("enqueue BSD RX packet", "error", err)
+			}
+		}()
+		return nil
+	})
+	return netdev, stack, true
+}
+
+func setupOpenBSDBootState(vm *VM, plan *openbsdarm64.BootPlan) error {
+	if err := vm.SetPC(plan.EntryGPA); err != nil {
+		return fmt.Errorf("set PC: %w", err)
+	}
+	if err := vm.SetPState(arm64vm.DefaultPStateBits); err != nil {
+		return fmt.Errorf("set PSTATE: %w", err)
+	}
+	if err := vm.SetX(0, plan.KernelEndGPA); err != nil {
+		return fmt.Errorf("set X0: %w", err)
+	}
+	if err := vm.SetX(1, 0); err != nil {
+		return fmt.Errorf("set X1: %w", err)
+	}
+	if err := vm.SetX(2, plan.DeviceTreeGPA); err != nil {
+		return fmt.Errorf("set X2: %w", err)
+	}
+	return nil
+}
+
+func setupFreeBSDBootState(vm *VM, plan *freebsdarm64.BootPlan) error {
+	if err := vm.SetPC(plan.EntryGPA); err != nil {
+		return fmt.Errorf("set PC: %w", err)
+	}
+	if err := vm.SetPState(arm64vm.DefaultPStateBits); err != nil {
+		return fmt.Errorf("set PSTATE: %w", err)
+	}
+	if err := vm.SetX(0, plan.DeviceTreeGPA); err != nil {
+		return fmt.Errorf("set X0: %w", err)
+	}
+	for reg := 1; reg <= 3; reg++ {
+		if err := vm.SetX(reg, 0); err != nil {
+			return fmt.Errorf("clear X%d: %w", reg, err)
+		}
+	}
+	return nil
+}
+
+func setupNetBSDBootState(vm *VM, plan *netbsdarm64.BootPlan) error {
+	if err := vm.SetPC(plan.EntryGPA); err != nil {
+		return fmt.Errorf("set PC: %w", err)
+	}
+	if err := vm.SetPState(0x40000000 | arm64vm.DefaultPStateBits); err != nil {
+		return fmt.Errorf("set PSTATE: %w", err)
+	}
+	if err := vm.SetX(0, plan.DeviceTreeGPA); err != nil {
+		return fmt.Errorf("set X0: %w", err)
+	}
+	for reg := 1; reg <= 3; reg++ {
+		if err := vm.SetX(reg, 0); err != nil {
+			return fmt.Errorf("clear X%d: %w", reg, err)
+		}
+	}
+	return nil
+}
+
+func runBSDARM64ManagedVM(ctx context.Context, guestName string, vm *VM, uart *serial.UART8250, pci *arm64PCIHost, netdev *virtio.Net, rng *virtio.RNG, rtc *arm64vm.PL031, serialOut *vmruntime.SerialTranscript, sampler *whpPCSampler) error {
+	go answerBSDPrompts(ctx, guestName, uart, serialOut)
+	if sampler != nil {
+		defer sampler.dump("final")
+	}
+	trace := os.Getenv("CC_WHP_BSD_TIMING") != ""
+	traceStart := time.Now()
+	lastTrace := traceStart
+	var nextSample time.Time
+	if sampler != nil {
+		nextSample = traceStart.Add(sampler.interval)
+	}
+	var exits, mmioExits, canceledExits uint64
+	for step := 0; ; step++ {
+		if err := ctx.Err(); err != nil {
+			pc, _ := vm.GetPC()
+			return fmt.Errorf("%w at pc=%#x", err, pc)
+		}
+		var exit Exit
+		runCtx := ctx
+		var cancel context.CancelFunc
+		if sampler != nil {
+			timeout := time.Until(nextSample)
+			if timeout <= 0 {
+				timeout = time.Nanosecond
+			}
+			runCtx, cancel = context.WithTimeout(ctx, timeout)
+		}
+		err := vm.RunInterruptible(runCtx, &exit)
+		now := time.Now()
+		if cancel != nil {
+			cancel()
+		}
+		if err != nil {
+			if sampler != nil && errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				sampler.recordCurrentPC(vm, now)
+				nextSample = sampler.nextAfter(nextSample, now)
+				continue
+			}
+			if ctx.Err() != nil {
+				pc, _ := vm.GetPC()
+				return fmt.Errorf("%w at pc=%#x", ctx.Err(), pc)
+			}
+			return fmt.Errorf("run %s step %d: %w\nserial:\n%s", guestName, step, err, serialOut.String())
+		}
+		if sampler != nil && !now.Before(nextSample) {
+			lr, _ := vm.getRegister(registerX(30))
+			if exit.PC != 0 {
+				sampler.record(exit.PC, lr, now)
+			} else {
+				sampler.recordCurrentPC(vm, now)
+			}
+			nextSample = sampler.nextAfter(nextSample, now)
+		}
+		if trace {
+			exits++
+			if now.Sub(lastTrace) >= 5*time.Second {
+				_, _ = fmt.Fprintf(os.Stderr, "whp-bsd %s run +%s: exits=%d mmio=%d canceled=%d serial=%d\n",
+					guestName, now.Sub(traceStart).Round(time.Millisecond), exits, mmioExits, canceledExits, serialOut.Len())
+				lastTrace = now
+			}
+		}
+		switch exit.Reason {
+		case runVPExitReasonUnmappedGPA, runVPExitReasonGPAIntercept:
+			if trace {
+				mmioExits++
+			}
+			if err := handleBSDARM64MMIO(vm, uart, pci, netdev, rng, rtc, exit.MMIO); err != nil {
+				return fmt.Errorf("handle %s mmio addr=%#x len=%d write=%v pc=%#x: %w\nserial:\n%s",
+					guestName, exit.MMIO.Addr, exit.MMIO.Len, exit.MMIO.Write, exit.MMIO.PC, err, serialOut.String())
+			}
+		case runVPExitReasonCanceled:
+			if trace {
+				canceledExits++
+			}
+		case runVPExitReasonArm64Reset:
+			return fmt.Errorf("%s guest requested arm64 reset\nserial:\n%s", guestName, serialOut.String())
+		default:
+			pc, _ := vm.GetPC()
+			return fmt.Errorf("unexpected %s exit %s at pc=%#x\nserial:\n%s", guestName, exit.Reason, pc, serialOut.String())
+		}
+	}
+}
+
+type whpPCSampler struct {
+	guestName string
+	interval  time.Duration
+	start     time.Time
+	lastDump  time.Time
+	symbols   []whpPCSymbol
+	counts    map[string]uint64
+	callers   map[string]uint64
+	rawCounts map[uint64]uint64
+	total     uint64
+}
+
+type whpPCSymbol struct {
+	name string
+	addr uint64
+	size uint64
+}
+
+func newWHPPCSampler(guestName string, kernel []byte) *whpPCSampler {
+	if os.Getenv("CC_WHP_PC_SAMPLE") == "" {
+		return nil
+	}
+	now := time.Now()
+	return &whpPCSampler{
+		guestName: guestName,
+		interval:  100 * time.Millisecond,
+		start:     now,
+		lastDump:  now,
+		symbols:   whpKernelSymbols(kernel),
+		counts:    make(map[string]uint64),
+		callers:   make(map[string]uint64),
+		rawCounts: make(map[uint64]uint64),
+	}
+}
+
+func whpKernelSymbols(kernel []byte) []whpPCSymbol {
+	f, err := elf.NewFile(bytes.NewReader(kernel))
+	if err != nil {
+		return nil
+	}
+	raw, err := f.Symbols()
+	if err != nil {
+		return nil
+	}
+	symbols := make([]whpPCSymbol, 0, len(raw))
+	for _, sym := range raw {
+		if sym.Value == 0 || sym.Size == 0 || elf.ST_TYPE(sym.Info) != elf.STT_FUNC {
+			continue
+		}
+		symbols = append(symbols, whpPCSymbol{name: sym.Name, addr: sym.Value, size: sym.Size})
+	}
+	sort.Slice(symbols, func(i, j int) bool {
+		return symbols[i].addr < symbols[j].addr
+	})
+	return symbols
+}
+
+func (s *whpPCSampler) nextAfter(next, now time.Time) time.Time {
+	for !next.After(now) {
+		next = next.Add(s.interval)
+	}
+	return next
+}
+
+func (s *whpPCSampler) recordCurrentPC(vm *VM, now time.Time) {
+	if pc, err := vm.GetPC(); err == nil {
+		lr, _ := vm.getRegister(registerX(30))
+		s.record(pc, lr, now)
+	}
+}
+
+func (s *whpPCSampler) record(pc, lr uint64, now time.Time) {
+	if s == nil {
+		return
+	}
+	pcDesc := s.describe(pc)
+	s.total++
+	s.rawCounts[pc]++
+	s.counts[pcDesc]++
+	if lr != 0 {
+		s.callers[fmt.Sprintf("%s <- %s", pcDesc, s.describe(lr))]++
+	}
+	if now.Sub(s.lastDump) >= 5*time.Second {
+		s.dump("sample")
+		s.lastDump = now
+	}
+}
+
+func (s *whpPCSampler) describe(pc uint64) string {
+	if len(s.symbols) == 0 {
+		return fmt.Sprintf("%#x", pc)
+	}
+	i := sort.Search(len(s.symbols), func(i int) bool {
+		return s.symbols[i].addr > pc
+	})
+	if i == 0 {
+		return fmt.Sprintf("%#x", pc)
+	}
+	sym := s.symbols[i-1]
+	if pc >= sym.addr+sym.size {
+		return fmt.Sprintf("%#x", pc)
+	}
+	return fmt.Sprintf("%s+%#x", sym.name, pc-sym.addr)
+}
+
+func (s *whpPCSampler) dump(label string) {
+	if s == nil || s.total == 0 {
+		return
+	}
+	type entry struct {
+		name  string
+		count uint64
+	}
+	entries := make([]entry, 0, len(s.counts))
+	for name, count := range s.counts {
+		entries = append(entries, entry{name: name, count: count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count == entries[j].count {
+			return entries[i].name < entries[j].name
+		}
+		return entries[i].count > entries[j].count
+	})
+	limit := 12
+	if len(entries) < limit {
+		limit = len(entries)
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "whp-pc-sample %s %s +%s total=%d\n", s.guestName, label, time.Since(s.start).Round(time.Millisecond), s.total)
+	for i := 0; i < limit; i++ {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-pc-sample %s %5d %5.1f%% %s\n", s.guestName, entries[i].count, float64(entries[i].count)*100/float64(s.total), entries[i].name)
+	}
+	callerEntries := make([]entry, 0, len(s.callers))
+	for name, count := range s.callers {
+		callerEntries = append(callerEntries, entry{name: name, count: count})
+	}
+	sort.Slice(callerEntries, func(i, j int) bool {
+		if callerEntries[i].count == callerEntries[j].count {
+			return callerEntries[i].name < callerEntries[j].name
+		}
+		return callerEntries[i].count > callerEntries[j].count
+	})
+	if len(callerEntries) < limit {
+		limit = len(callerEntries)
+	}
+	for i := 0; i < limit; i++ {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-pc-sample %s caller %5d %5.1f%% %s\n", s.guestName, callerEntries[i].count, float64(callerEntries[i].count)*100/float64(s.total), callerEntries[i].name)
+	}
+}
+
+func handleBSDARM64MMIO(vm *VM, uart *serial.UART8250, pci *arm64PCIHost, netdev *virtio.Net, rng *virtio.RNG, rtc *arm64vm.PL031, mmio MMIOExit) error {
+	if pci != nil && pci.Contains(mmio.Addr, int(mmio.Len)) {
+		if mmio.Write {
+			if err := pci.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := pci.Read(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	if rtc != nil && rtc.Contains(mmio.Addr, int(mmio.Len)) {
+		if mmio.Write {
+			if err := rtc.Write(mmio.Addr, int(mmio.Len), mmioValue(mmio)); err != nil {
+				return err
+			}
+			return vm.CompleteMMIOWrite(mmio)
+		}
+		value, err := rtc.Read(mmio.Addr, int(mmio.Len))
+		if err != nil {
+			return err
+		}
+		return vm.CompleteMMIORead(mmio, value)
+	}
+	return handleBootMMIO(vm, uart, nil, nil, rng, netdev, mmio, nil)
+}
+
+func answerBSDPrompts(ctx context.Context, guestName string, uart *serial.UART8250, serialOut *vmruntime.SerialTranscript) {
+	var answeredRoot atomic.Bool
+	var answeredSwap atomic.Bool
+	var answeredMountroot atomic.Bool
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			serialText := serialOut.String()
+			if strings.EqualFold(guestName, "OpenBSD") {
+				if !answeredRoot.Load() && strings.Contains(serialText, "root device:") {
+					answeredRoot.Store(true)
+					_ = uart.InjectRXBytes([]byte("sd0a\n"))
+				}
+				if answeredRoot.Load() && !answeredSwap.Load() && strings.Contains(serialText, "swap device") {
+					answeredSwap.Store(true)
+					_ = uart.InjectRXBytes([]byte("\n"))
+				}
+				continue
+			}
+			if strings.EqualFold(guestName, "NetBSD") {
+				if !answeredRoot.Load() && strings.Contains(serialText, "root device:") {
+					answeredRoot.Store(true)
+					_ = uart.InjectRXBytes([]byte("ld4a\n"))
+				}
+				continue
+			}
+			if !answeredMountroot.Load() && strings.Contains(serialText, "mountroot>") {
+				answeredMountroot.Store(true)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(100 * time.Millisecond):
+				}
+				_ = uart.InjectRXBytes([]byte("ufs:/dev/nda0\n"))
+			}
+		}
+	}
+}
+
+func containsReadyOrFatal(text string) bool {
+	return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+}
+
+func bsdStartupError(err error, serialText, controlText string) error {
+	return transcriptError(err, serialText, controlText)
+}

--- a/internal/hv/whp/host_windows_arm64.go
+++ b/internal/hv/whp/host_windows_arm64.go
@@ -5,12 +5,14 @@ package whp
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"j5.nz/cc/client"
 	managedhost "j5.nz/cc/internal/managed/host"
 	"j5.nz/cc/internal/managed/machine"
 	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/netstack"
 	"j5.nz/cc/internal/virtio"
 )
 
@@ -29,10 +31,68 @@ type LinuxManagedAttachments struct {
 	NetDevice *virtio.Net
 }
 
+type BSDManagedAttachments struct {
+	GuestIPv4 net.IP
+	GuestMAC  net.HardwareAddr
+	NetDevice *virtio.Net
+	NetStack  *netstack.NetStack
+}
+
 func (Host) Start(ctx context.Context, req managedhost.StartRequest, onEvent func(client.BootEvent) error) (managedsession.Session, error) {
-	if managedGuestKind(req.Spec) != "linux" {
+	switch managedGuestKind(req.Spec) {
+	case "linux":
+		return Host{}.startLinux(ctx, req, onEvent)
+	case "openbsd":
+		attachments, err := bsdManagedAttachments(req.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		return StartOpenBSDManagedSession(ctx, OpenBSDManagedConfig{
+			Kernel:    req.Artifact.Kernel,
+			Root:      req.Artifact.RootBlock,
+			MemoryMB:  req.Spec.MemoryMB,
+			Dmesg:     req.Spec.Dmesg,
+			GuestIPv4: attachments.GuestIPv4,
+			GuestMAC:  attachments.GuestMAC,
+			NetDevice: attachments.NetDevice,
+			NetStack:  attachments.NetStack,
+		}, onEvent)
+	case "freebsd":
+		attachments, err := bsdManagedAttachments(req.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		return StartFreeBSDManagedSession(ctx, FreeBSDManagedConfig{
+			Kernel:    req.Artifact.Kernel,
+			Root:      req.Artifact.RootBlock,
+			MemoryMB:  req.Spec.MemoryMB,
+			Dmesg:     req.Spec.Dmesg,
+			GuestIPv4: attachments.GuestIPv4,
+			GuestMAC:  attachments.GuestMAC,
+			NetDevice: attachments.NetDevice,
+			NetStack:  attachments.NetStack,
+		}, onEvent)
+	case "netbsd":
+		attachments, err := bsdManagedAttachments(req.Attachments)
+		if err != nil {
+			return nil, err
+		}
+		return StartNetBSDManagedSession(ctx, NetBSDManagedConfig{
+			Kernel:    req.Artifact.Kernel,
+			Root:      req.Artifact.RootBlock,
+			MemoryMB:  req.Spec.MemoryMB,
+			Dmesg:     req.Spec.Dmesg,
+			GuestIPv4: attachments.GuestIPv4,
+			GuestMAC:  attachments.GuestMAC,
+			NetDevice: attachments.NetDevice,
+			NetStack:  attachments.NetStack,
+		}, onEvent)
+	default:
 		return nil, fmt.Errorf("whp arm64 host does not support managed guest %q boot %q", req.Spec.Guest, req.Spec.Boot.Kind)
 	}
+}
+
+func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEvent func(client.BootEvent) error) (managedsession.Session, error) {
 	var attachments LinuxManagedAttachments
 	switch value := req.Attachments.(type) {
 	case nil:
@@ -75,6 +135,20 @@ func normalizeLinuxManagedMachine(machine LinuxManagedMachine) LinuxManagedMachi
 	return machine
 }
 
+func bsdManagedAttachments(value any) (BSDManagedAttachments, error) {
+	switch attachments := value.(type) {
+	case BSDManagedAttachments:
+		return attachments, nil
+	case *BSDManagedAttachments:
+		if attachments == nil {
+			return BSDManagedAttachments{}, fmt.Errorf("whp bsd managed attachments are nil")
+		}
+		return *attachments, nil
+	default:
+		return BSDManagedAttachments{}, fmt.Errorf("whp bsd managed attachments have type %T", value)
+	}
+}
+
 func managedGuestKind(spec machine.Spec) string {
 	guest := strings.ToLower(strings.TrimSpace(spec.Guest))
 	boot := strings.ToLower(strings.TrimSpace(spec.Boot.Kind))
@@ -89,6 +163,11 @@ func managedGuestKind(spec machine.Spec) string {
 	}
 	if guest == "linux" && boot == "linux" {
 		return "linux"
+	}
+	for _, bsd := range []string{"openbsd", "freebsd", "netbsd"} {
+		if guest == bsd || boot == bsd {
+			return bsd
+		}
 	}
 	return guest
 }

--- a/internal/hv/whp/host_windows_arm64.go
+++ b/internal/hv/whp/host_windows_arm64.go
@@ -1,0 +1,94 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"j5.nz/cc/client"
+	managedhost "j5.nz/cc/internal/managed/host"
+	"j5.nz/cc/internal/managed/machine"
+	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/virtio"
+)
+
+type Host struct{}
+
+type LinuxManagedMachine struct {
+	Spec      machine.Spec
+	Kernel    []byte
+	Initrd    []byte
+	FSDevices []*virtio.FS
+	NetDevice *virtio.Net
+}
+
+type LinuxManagedAttachments struct {
+	FSDevices []*virtio.FS
+	NetDevice *virtio.Net
+}
+
+func (Host) Start(ctx context.Context, req managedhost.StartRequest, onEvent func(client.BootEvent) error) (managedsession.Session, error) {
+	if managedGuestKind(req.Spec) != "linux" {
+		return nil, fmt.Errorf("whp arm64 host does not support managed guest %q boot %q", req.Spec.Guest, req.Spec.Boot.Kind)
+	}
+	var attachments LinuxManagedAttachments
+	switch value := req.Attachments.(type) {
+	case nil:
+	case LinuxManagedAttachments:
+		attachments = value
+	case *LinuxManagedAttachments:
+		if value != nil {
+			attachments = *value
+		}
+	default:
+		return nil, fmt.Errorf("whp linux managed attachments have type %T", req.Attachments)
+	}
+	return Host{}.StartLinuxManaged(ctx, LinuxManagedMachine{
+		Spec:      req.Spec,
+		Kernel:    req.Artifact.Kernel,
+		Initrd:    req.Artifact.Initrd,
+		FSDevices: attachments.FSDevices,
+		NetDevice: attachments.NetDevice,
+	}, onEvent)
+}
+
+func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	machine = normalizeLinuxManagedMachine(machine)
+	return StartManagedSessionWithNet(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, onEvent)
+}
+
+func normalizeLinuxManagedMachine(machine LinuxManagedMachine) LinuxManagedMachine {
+	if machine.Spec.Guest == "" {
+		machine.Spec.Guest = "Linux"
+	}
+	if machine.Spec.Arch == "" {
+		machine.Spec.Arch = "arm64"
+	}
+	if machine.Spec.Boot.Kind == "" {
+		machine.Spec.Boot.Kind = "linux"
+	}
+	if machine.Spec.Control.Kind == "" {
+		machine.Spec.Control.Kind = "vsock"
+	}
+	return machine
+}
+
+func managedGuestKind(spec machine.Spec) string {
+	guest := strings.ToLower(strings.TrimSpace(spec.Guest))
+	boot := strings.ToLower(strings.TrimSpace(spec.Boot.Kind))
+	if guest == "" && boot == "" {
+		return "linux"
+	}
+	if guest == "" {
+		guest = boot
+	}
+	if boot == "" {
+		return guest
+	}
+	if guest == "linux" && boot == "linux" {
+		return "linux"
+	}
+	return guest
+}

--- a/internal/hv/whp/pci_windows_arm64.go
+++ b/internal/hv/whp/pci_windows_arm64.go
@@ -1,0 +1,343 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/fdt"
+	"j5.nz/cc/internal/nvme"
+)
+
+const (
+	arm64PCIVendorRedHat = 0x1b36
+	arm64PCINVMeDeviceID = 0x0010
+
+	arm64PCICapMSIOffset = 0x50
+)
+
+type arm64PCIHost struct {
+	configBase uint64
+	configSize uint64
+	mmioBase   uint64
+	mmioSize   uint64
+	msiParent  uint32
+	devices    []*arm64PCIDevice
+}
+
+type arm64PCIDevice struct {
+	Bus         uint8
+	Device      uint8
+	Function    uint8
+	VendorID    uint16
+	DeviceID    uint16
+	SubsystemID uint16
+	Class       uint8
+	Subclass    uint8
+	ProgIF      uint8
+	Revision    uint8
+	IRQLine     uint8
+	IRQPin      uint8
+	MMIOBAR     uint64
+	MMIOSize    uint64
+	Command     uint16
+	MSI         bool
+	MSIEnabled  bool
+	MSIAddress  uint64
+	MSIData     uint32
+	nvme        *nvme.Controller
+	mmio        interface {
+		ReadMMIO(offset uint64, size int) (uint64, error)
+		WriteMMIO(offset uint64, size int, value uint64) error
+	}
+	barProbeValue bool
+}
+
+func newArm64PCIHost(devices ...*arm64PCIDevice) *arm64PCIHost {
+	return &arm64PCIHost{
+		configBase: arm64vm.PCIConfigBase,
+		configSize: arm64vm.PCIConfigSize,
+		mmioBase:   arm64vm.PCIMMIOBase,
+		mmioSize:   arm64vm.PCIMMIOSize,
+		devices:    devices,
+	}
+}
+
+func newArm64NVMePCIDevice(dev uint8, mmioBase uint64, irq uint8, ctrl *nvme.Controller) *arm64PCIDevice {
+	if ctrl != nil {
+		ctrl.Base = mmioBase
+		ctrl.Size = nvme.MMIOSize
+		ctrl.IRQ = uint32(irq)
+	}
+	return &arm64PCIDevice{
+		Device:      dev,
+		VendorID:    arm64PCIVendorRedHat,
+		DeviceID:    arm64PCINVMeDeviceID,
+		SubsystemID: arm64PCINVMeDeviceID,
+		Class:       0x01,
+		Subclass:    0x08,
+		ProgIF:      0x02,
+		IRQLine:     irq,
+		IRQPin:      1,
+		MMIOBAR:     mmioBase,
+		MMIOSize:    nvme.MMIOSize,
+		nvme:        ctrl,
+		mmio:        ctrl,
+	}
+}
+
+func (h *arm64PCIHost) DeviceTreeNode() fdt.Node {
+	node := fdt.Node{
+		Name: fmt.Sprintf("pcie@%x", h.configBase),
+		Properties: map[string]fdt.Property{
+			"compatible":         {Strings: []string{"pci-host-ecam-generic"}},
+			"device_type":        {Strings: []string{"pci"}},
+			"#address-cells":     {U32: []uint32{3}},
+			"#size-cells":        {U32: []uint32{2}},
+			"#interrupt-cells":   {U32: []uint32{1}},
+			"bus-range":          {U32: []uint32{0, 0}},
+			"dma-coherent":       {Flag: true},
+			"linux,pci-domain":   {U32: []uint32{0}},
+			"reg":                {U64: []uint64{h.configBase, h.configSize}},
+			"ranges":             {U32: arm64PCIRanges(h.mmioBase, h.mmioBase, h.mmioSize)},
+			"interrupt-map-mask": {U32: []uint32{0x0000f800, 0, 0, 7}},
+			"interrupt-map":      {U32: h.interruptMap()},
+			"interrupt-parent":   {U32: []uint32{1}},
+			"status":             {Strings: []string{"okay"}},
+		},
+	}
+	if h.msiParent != 0 {
+		node.Properties["msi-parent"] = fdt.Property{U32: []uint32{h.msiParent}}
+	}
+	for _, dev := range h.devices {
+		if dev != nil {
+			node.Children = append(node.Children, dev.deviceTreeNode())
+		}
+	}
+	return node
+}
+
+func (h *arm64PCIHost) Contains(addr uint64, size int) bool {
+	if size <= 0 {
+		return false
+	}
+	end := addr + uint64(size)
+	return (addr >= h.configBase && end <= h.configBase+h.configSize) ||
+		(addr >= h.mmioBase && end <= h.mmioBase+h.mmioSize)
+}
+
+func (h *arm64PCIHost) Read(addr uint64, size int) (uint64, error) {
+	if addr >= h.configBase && addr+uint64(size) <= h.configBase+h.configSize {
+		return h.readConfig(addr-h.configBase, size), nil
+	}
+	for _, dev := range h.devices {
+		if dev == nil || dev.mmio == nil || dev.MMIOSize == 0 {
+			continue
+		}
+		if addr >= dev.MMIOBAR && addr+uint64(size) <= dev.MMIOBAR+dev.MMIOSize {
+			return dev.mmio.ReadMMIO(addr-dev.MMIOBAR, size)
+		}
+	}
+	return 0, fmt.Errorf("unhandled PCI read addr=%#x size=%d", addr, size)
+}
+
+func (h *arm64PCIHost) Write(addr uint64, size int, value uint64) error {
+	if addr >= h.configBase && addr+uint64(size) <= h.configBase+h.configSize {
+		h.writeConfig(addr-h.configBase, size, value)
+		return nil
+	}
+	for _, dev := range h.devices {
+		if dev == nil || dev.mmio == nil || dev.MMIOSize == 0 {
+			continue
+		}
+		if addr >= dev.MMIOBAR && addr+uint64(size) <= dev.MMIOBAR+dev.MMIOSize {
+			return dev.mmio.WriteMMIO(addr-dev.MMIOBAR, size, value)
+		}
+	}
+	return fmt.Errorf("unhandled PCI write addr=%#x size=%d value=%#x", addr, size, value)
+}
+
+func (h *arm64PCIHost) readConfig(offset uint64, size int) uint64 {
+	bus := uint8((offset >> 20) & 0xff)
+	device := uint8((offset >> 15) & 0x1f)
+	function := uint8((offset >> 12) & 0x07)
+	reg := uint16(offset & 0xfff)
+	dev := h.deviceAt(bus, device, function)
+	cfg := make([]byte, 4096)
+	for i := range cfg {
+		cfg[i] = 0xff
+	}
+	if dev != nil {
+		clear(cfg)
+		dev.buildConfig(cfg)
+	}
+	return readArm64PCIConfigValue(cfg[reg:], size)
+}
+
+func (h *arm64PCIHost) writeConfig(offset uint64, size int, value uint64) {
+	bus := uint8((offset >> 20) & 0xff)
+	device := uint8((offset >> 15) & 0x1f)
+	function := uint8((offset >> 12) & 0x07)
+	reg := uint16(offset & 0xfff)
+	dev := h.deviceAt(bus, device, function)
+	if dev == nil {
+		return
+	}
+	for i := 0; i < size; i++ {
+		dev.writeConfigByte(uint16(int(reg)+i), byte(value>>(8*i)))
+	}
+}
+
+func (h *arm64PCIHost) deviceAt(bus, device, function uint8) *arm64PCIDevice {
+	for _, dev := range h.devices {
+		if dev != nil && dev.Bus == bus && dev.Device == device && dev.Function == function {
+			return dev
+		}
+	}
+	return nil
+}
+
+func (h *arm64PCIHost) interruptMap() []uint32 {
+	var out []uint32
+	for _, dev := range h.devices {
+		if dev == nil || dev.IRQPin == 0 {
+			continue
+		}
+		devAddr := uint32(dev.Bus)<<16 | uint32(dev.Device)<<11 | uint32(dev.Function)<<8
+		out = append(out, devAddr, 0, 0, uint32(dev.IRQPin), 1, 0, 0, 0, uint32(dev.IRQLine), 4)
+	}
+	return out
+}
+
+func (d *arm64PCIDevice) buildConfig(cfg []byte) {
+	binary.LittleEndian.PutUint16(cfg[0x00:0x02], d.VendorID)
+	binary.LittleEndian.PutUint16(cfg[0x02:0x04], d.DeviceID)
+	binary.LittleEndian.PutUint16(cfg[0x04:0x06], d.Command)
+	cfg[0x08] = d.Revision
+	cfg[0x09] = d.ProgIF
+	cfg[0x0a] = d.Subclass
+	cfg[0x0b] = d.Class
+	cfg[0x0e] = 0
+	if d.barProbeValue {
+		binary.LittleEndian.PutUint32(cfg[0x10:0x14], uint32(^(d.MMIOSize-1)&0xfffffff0))
+	} else {
+		binary.LittleEndian.PutUint32(cfg[0x10:0x14], uint32(d.MMIOBAR&0xfffffff0))
+	}
+	binary.LittleEndian.PutUint16(cfg[0x2c:0x2e], d.VendorID)
+	binary.LittleEndian.PutUint16(cfg[0x2e:0x30], d.SubsystemID)
+	cfg[0x3c] = d.IRQLine
+	cfg[0x3d] = d.IRQPin
+	if d.MSI {
+		cfg[0x06] |= 0x10
+		cfg[0x34] = arm64PCICapMSIOffset
+		cfg[arm64PCICapMSIOffset] = 0x05
+		binary.LittleEndian.PutUint16(cfg[arm64PCICapMSIOffset+2:arm64PCICapMSIOffset+4], d.msiControl())
+		binary.LittleEndian.PutUint32(cfg[arm64PCICapMSIOffset+4:arm64PCICapMSIOffset+8], uint32(d.MSIAddress))
+		binary.LittleEndian.PutUint32(cfg[arm64PCICapMSIOffset+8:arm64PCICapMSIOffset+12], uint32(d.MSIAddress>>32))
+		binary.LittleEndian.PutUint16(cfg[arm64PCICapMSIOffset+12:arm64PCICapMSIOffset+14], uint16(d.MSIData))
+	}
+}
+
+func (d *arm64PCIDevice) deviceTreeNode() fdt.Node {
+	addr := uint32(d.Bus)<<16 | uint32(d.Device)<<11 | uint32(d.Function)<<8
+	return fdt.Node{
+		Name: fmt.Sprintf("nvme@%x,0", d.Device),
+		Properties: map[string]fdt.Property{
+			"reg":        {U32: []uint32{addr, 0, 0, 0, 0}},
+			"interrupts": {U32: []uint32{uint32(d.IRQPin)}},
+		},
+	}
+}
+
+func (d *arm64PCIDevice) writeConfigByte(offset uint16, value byte) {
+	switch offset {
+	case 0x04:
+		d.Command = (d.Command & 0xff00) | uint16(value)
+	case 0x05:
+		d.Command = (d.Command & 0x00ff) | uint16(value)<<8
+	case 0x10, 0x11, 0x12, 0x13:
+		if value == 0xff {
+			d.barProbeValue = true
+			return
+		}
+		d.barProbeValue = false
+		switch offset {
+		case 0x10:
+			d.MMIOBAR = (d.MMIOBAR & 0xffffffffffffff00) | uint64(value&0xf0)
+		case 0x11:
+			d.MMIOBAR = (d.MMIOBAR & 0xffffffffffff00ff) | uint64(value)<<8
+		case 0x12:
+			d.MMIOBAR = (d.MMIOBAR & 0xffffffffff00ffff) | uint64(value)<<16
+		case 0x13:
+			d.MMIOBAR = (d.MMIOBAR & 0xffffffff00ffffff) | uint64(value)<<24
+		}
+	case 0x3c:
+		d.IRQLine = value
+	case arm64PCICapMSIOffset + 2, arm64PCICapMSIOffset + 3:
+		if !d.MSI {
+			return
+		}
+		control := d.msiControl()
+		if offset == arm64PCICapMSIOffset+2 {
+			control = (control & 0xff00) | uint16(value)
+		} else {
+			control = (control & 0x00ff) | uint16(value)<<8
+		}
+		d.MSIEnabled = control&1 != 0
+		d.configureMSI()
+	case arm64PCICapMSIOffset + 4, arm64PCICapMSIOffset + 5, arm64PCICapMSIOffset + 6, arm64PCICapMSIOffset + 7,
+		arm64PCICapMSIOffset + 8, arm64PCICapMSIOffset + 9, arm64PCICapMSIOffset + 10, arm64PCICapMSIOffset + 11:
+		if !d.MSI {
+			return
+		}
+		shift := (offset - (arm64PCICapMSIOffset + 4)) * 8
+		d.MSIAddress = (d.MSIAddress &^ (uint64(0xff) << shift)) | uint64(value)<<shift
+		d.configureMSI()
+	case arm64PCICapMSIOffset + 12, arm64PCICapMSIOffset + 13:
+		if !d.MSI {
+			return
+		}
+		shift := (offset - (arm64PCICapMSIOffset + 12)) * 8
+		d.MSIData = (d.MSIData &^ (uint32(0xff) << shift)) | uint32(value)<<shift
+		d.configureMSI()
+	}
+}
+
+func (d *arm64PCIDevice) msiControl() uint16 {
+	control := uint16(1 << 7)
+	if d.MSIEnabled {
+		control |= 1
+	}
+	return control
+}
+
+func (d *arm64PCIDevice) configureMSI() {
+	if d.nvme != nil {
+		d.nvme.ConfigureMSI(d.MSIEnabled, d.MSIAddress, d.MSIData)
+	}
+}
+
+func arm64PCIRanges(cpuAddr, pciAddr, size uint64) []uint32 {
+	return []uint32{
+		0x02000000,
+		uint32(pciAddr >> 32),
+		uint32(pciAddr),
+		uint32(cpuAddr >> 32),
+		uint32(cpuAddr),
+		uint32(size >> 32),
+		uint32(size),
+	}
+}
+
+func readArm64PCIConfigValue(data []byte, size int) uint64 {
+	if size <= 0 {
+		return 0
+	}
+	var value uint64
+	for i := 0; i < size && i < len(data) && i < 8; i++ {
+		value |= uint64(data[i]) << (8 * i)
+	}
+	return value
+}

--- a/internal/hv/whp/pci_windows_arm64_test.go
+++ b/internal/hv/whp/pci_windows_arm64_test.go
@@ -1,0 +1,42 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestArm64PCIDeviceMSICapability(t *testing.T) {
+	dev := &arm64PCIDevice{
+		VendorID: 0x1b36,
+		DeviceID: 0x0010,
+		MSI:      true,
+	}
+	var cfg [4096]byte
+	dev.buildConfig(cfg[:])
+
+	if got := cfg[0x34]; got != arm64PCICapMSIOffset {
+		t.Fatalf("capability pointer = %#x, want %#x", got, arm64PCICapMSIOffset)
+	}
+	if got := cfg[arm64PCICapMSIOffset]; got != 0x05 {
+		t.Fatalf("capability ID = %#x, want %#x", got, byte(0x05))
+	}
+	if got := binary.LittleEndian.Uint16(cfg[arm64PCICapMSIOffset+2 : arm64PCICapMSIOffset+4]); got != 1<<7 {
+		t.Fatalf("MSI control = %#x, want %#x", got, uint16(1<<7))
+	}
+
+	dev.writeConfigByte(arm64PCICapMSIOffset+4, 0x00)
+	dev.writeConfigByte(arm64PCICapMSIOffset+5, 0x00)
+	dev.writeConfigByte(arm64PCICapMSIOffset+6, 0x08)
+	dev.writeConfigByte(arm64PCICapMSIOffset+7, 0x08)
+	dev.writeConfigByte(arm64PCICapMSIOffset+12, 0x03)
+	dev.writeConfigByte(arm64PCICapMSIOffset+2, 0x01)
+
+	if !dev.MSIEnabled {
+		t.Fatalf("MSIEnabled = false")
+	}
+	if dev.MSIAddress != 0x08080000 || dev.MSIData != 3 {
+		t.Fatalf("MSI address/data = %#x/%#x, want %#x/%#x", dev.MSIAddress, dev.MSIData, uint64(0x08080000), uint32(3))
+	}
+}

--- a/internal/hv/whp/session_windows_amd64.go
+++ b/internal/hv/whp/session_windows_amd64.go
@@ -104,7 +104,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	go func() {
 		err := runManagedExecVM(runCtx, vm, platform, serialOut)
 		platform.Close()
-		vm.Close()
+		err = errors.Join(err, vm.Close())
 		doneCh <- err
 	}()
 
@@ -379,6 +379,10 @@ func (s *ManagedSession) waitForExecExit(id string, start int, timeout time.Dura
 }
 
 func (s *ManagedSession) Wait() error {
+	return s.waitDone()
+}
+
+func (s *ManagedSession) waitDone() error {
 	if s == nil || s.doneCh == nil {
 		return nil
 	}
@@ -388,10 +392,32 @@ func (s *ManagedSession) Wait() error {
 	return s.waitErr
 }
 
+func (s *ManagedSession) waitDoneTimeout(timeout time.Duration) error {
+	if s == nil || s.doneCh == nil {
+		return nil
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.waitDone()
+	}()
+	select {
+	case err := <-errCh:
+		return err
+	case <-timer.C:
+		return fmt.Errorf("timed out waiting for managed session to stop")
+	}
+}
+
 func (s *ManagedSession) Close() error {
 	if s == nil {
 		return nil
 	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	waitErr := s.waitDoneTimeout(15 * time.Second)
 	if s.control != nil {
 		_ = s.control.Close()
 	}
@@ -404,11 +430,8 @@ func (s *ManagedSession) Close() error {
 	if s.bootWriter != nil {
 		_ = s.bootWriter.Close()
 	}
-	if s.cancel != nil {
-		s.cancel()
-	}
-	if err := s.Wait(); err != nil && !errors.Is(err, context.Canceled) {
-		return err
+	if waitErr != nil && !errors.Is(waitErr, context.Canceled) {
+		return waitErr
 	}
 	return nil
 }

--- a/internal/hv/whp/session_windows_arm64.go
+++ b/internal/hv/whp/session_windows_arm64.go
@@ -1,0 +1,296 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/arm64vm"
+	managedagent "j5.nz/cc/internal/managed/agent"
+	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const (
+	execTerminateGrace = 500 * time.Millisecond
+	execKillWait       = 2 * time.Second
+)
+
+type ManagedSession struct {
+	cancel     context.CancelFunc
+	doneCh     chan error
+	control    io.ReadWriteCloser
+	listener   io.Closer
+	vsock      *virtio.Vsock
+	bootWriter *vmruntime.BootEventWriter
+	transcript *vmruntime.SerialTranscript
+	serialOut  *vmruntime.SerialTranscript
+	sendMu     sync.Mutex
+	nextID     atomic.Uint64
+	dmesg      bool
+}
+
+func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithNet(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, onEvent)
+}
+
+func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
+		return nil, err
+	}
+	backend := virtio.NewSimpleVsockBackend()
+	listener, err := backend.Listen(vmruntime.ControlPort)
+	if err != nil {
+		return nil, fmt.Errorf("listen vsock control: %w", err)
+	}
+	vsock := virtio.NewVsock(arm64vm.VsockBase, arm64vm.VsockSize, arm64vm.VsockIRQ, vmruntime.GuestCID, backend)
+	rng := virtio.NewRNG(arm64vm.RNGBase, arm64vm.RNGSize, arm64vm.RNGIRQ)
+	connCh := make(chan virtio.VsockConn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+
+	serialOut := vmruntime.NewSerialTranscript()
+	var serialWriter io.Writer = serialOut
+	var bootWriter *vmruntime.BootEventWriter
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = io.MultiWriter(serialOut, bootWriter)
+	}
+	vm, uart, _, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, rng, netdev, serialWriter)
+	if err != nil {
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error, 1)
+	go func() {
+		defer vm.Close()
+		defer closeFSDevices(fsdevs)
+		doneCh <- runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
+	}()
+
+	var control virtio.VsockConn
+	select {
+	case err := <-acceptErrCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+	case err := <-doneCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(ctx.Err(), serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	return &ManagedSession{cancel: cancel, doneCh: doneCh, control: control, listener: listener, vsock: vsock, bootWriter: bootWriter, transcript: controlTranscript, serialOut: serialOut, dmesg: dmesg}, nil
+}
+
+func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {
+	if len(req.Command) == 0 {
+		return client.ExecResponse{}, fmt.Errorf("exec command is required")
+	}
+	id := strconv.FormatUint(s.nextID.Add(1), 10)
+	start := s.transcript.Len()
+	if err := s.sendExecMessage(managedagent.ExecRequest(id, req)); err != nil {
+		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+	}
+	segment, err := s.transcript.WaitFor(ctx, start, func(text string) bool {
+		_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, s.dmesg)
+		return ok
+	})
+	if err != nil {
+		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+	}
+	code, output, usage, ok := vmruntime.ExtractManagedExecResult(segment, id, s.dmesg)
+	if !ok {
+		return client.ExecResponse{}, transcriptError(fmt.Errorf("exec did not produce a complete result"), s.serialOut.String(), s.transcript.String())
+	}
+	if s.dmesg {
+		output = s.serialOut.String() + "\n[control]\n" + output
+	}
+	return client.ExecResponse{ExitCode: code, Output: output, Usage: usage}, nil
+}
+
+func (s *ManagedSession) ExecStream(ctx context.Context, req client.ExecRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	if (req.Kind == "" || req.Kind == "exec") && len(req.Command) == 0 {
+		return fmt.Errorf("exec command is required")
+	}
+	id := strconv.FormatUint(s.nextID.Add(1), 10)
+	start := s.transcript.Len()
+	if err := s.sendExecMessage(managedagent.ExecRequest(id, req)); err != nil {
+		return transcriptError(err, s.serialOut.String(), s.transcript.String())
+	}
+	if inputs != nil {
+		go managedagent.ForwardInputs(ctx, id, inputs, s.sendExecMessage)
+	} else if len(req.Stdin) == 0 && !req.TTY {
+		_ = s.sendExecMessage(managedagent.StdinCloseRequest(id))
+	}
+	return managedsession.StreamExecEvents(ctx, managedsession.StreamExecOptions{
+		Transcript: s.transcript,
+		Start:      start,
+		ID:         id,
+		OnEvent:    onEvent,
+		Wait: func(context.Context) error {
+			select {
+			case vmErr := <-s.doneCh:
+				select {
+				case s.doneCh <- vmErr:
+				default:
+				}
+				if vmErr != nil {
+					return vmErr
+				}
+				return fmt.Errorf("managed session exited")
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Millisecond):
+				return nil
+			}
+		},
+	})
+}
+
+func (s *ManagedSession) Flush(ctx context.Context) error {
+	id := strconv.FormatUint(s.nextID.Add(1), 10)
+	start := s.transcript.Len()
+	if err := s.sendExecMessage(managedagent.SyncRequest(id)); err != nil {
+		return transcriptError(err, s.serialOut.String(), s.transcript.String())
+	}
+	segment, err := s.transcript.WaitFor(ctx, start, func(text string) bool {
+		_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, s.dmesg)
+		return ok
+	})
+	if err != nil {
+		return transcriptError(err, s.serialOut.String(), s.transcript.String())
+	}
+	code, output, _, ok := vmruntime.ExtractManagedExecResult(segment, id, s.dmesg)
+	if !ok {
+		return transcriptError(fmt.Errorf("sync did not produce a complete result"), s.serialOut.String(), s.transcript.String())
+	}
+	if code != 0 {
+		return transcriptError(fmt.Errorf("sync exited with status %d: %s", code, output), s.serialOut.String(), s.transcript.String())
+	}
+	return nil
+}
+
+func (s *ManagedSession) ConsoleHistory(context.Context) (string, error) {
+	if s == nil || s.serialOut == nil {
+		return "", nil
+	}
+	return s.serialOut.String(), nil
+}
+
+func (s *ManagedSession) Wait() error {
+	if s == nil || s.doneCh == nil {
+		return nil
+	}
+	return <-s.doneCh
+}
+
+func (s *ManagedSession) Close() error {
+	if s == nil {
+		return nil
+	}
+	if s.control != nil {
+		_ = s.control.Close()
+	}
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+	if s.vsock != nil {
+		_ = s.vsock.Close()
+	}
+	if s.bootWriter != nil {
+		_ = s.bootWriter.Close()
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	return nil
+}
+
+func (s *ManagedSession) sendExecMessage(msg vmruntime.ManagedExecRequest) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	return managedagent.Send(s.control, msg)
+}
+
+func transcriptError(err error, serialText, controlText string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w\nserial:\n%s\ncontrol:\n%s", err, serialText, controlText)
+}

--- a/internal/hv/whp/session_windows_arm64.go
+++ b/internal/hv/whp/session_windows_arm64.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,6 +36,7 @@ type ManagedSession struct {
 	bootWriter *vmruntime.BootEventWriter
 	transcript *vmruntime.SerialTranscript
 	serialOut  *vmruntime.SerialTranscript
+	cleanup    func()
 	sendMu     sync.Mutex
 	nextID     atomic.Uint64
 	dmesg      bool
@@ -45,6 +47,11 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 }
 
 func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != "" || os.Getenv("CC_WHP_BSD_TIMING") != ""
+	startTime := time.Now()
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +0s: starting managed session\n")
+	}
 	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
 		return nil, err
 	}
@@ -75,7 +82,8 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = io.MultiWriter(serialOut, bootWriter)
 	}
-	vm, uart, _, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, rng, netdev, serialWriter)
+	prepareStart := time.Now()
+	vm, uart, _, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, dmesg, fsdevs, vsock, rng, netdev, serialWriter)
 	if err != nil {
 		_ = listener.Close()
 		vsock.Close()
@@ -84,15 +92,21 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		}
 		return nil, err
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: vm prepared took=%s\n", time.Since(startTime).Round(time.Millisecond), time.Since(prepareStart).Round(time.Millisecond))
+	}
 
 	runCtx, cancel := context.WithCancel(context.Background())
 	doneCh := make(chan error, 1)
 	go func() {
-		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
+		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut, newWHPPCSampler("linux", kernel))
 		closeFSDevices(fsdevs)
 		err = errors.Join(err, vm.Close())
 		doneCh <- err
 	}()
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: vm run loop started\n", time.Since(startTime).Round(time.Millisecond))
+	}
 
 	var control virtio.VsockConn
 	select {
@@ -106,6 +120,9 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
 	case conn := <-connCh:
 		control = conn
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: control connected\n", time.Since(startTime).Round(time.Millisecond))
+		}
 	case err := <-doneCh:
 		cancel()
 		_ = listener.Close()
@@ -156,6 +173,9 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		}
 		return nil, err
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: ready marker received\n", time.Since(startTime).Round(time.Millisecond))
+	}
 
 	return &ManagedSession{cancel: cancel, doneCh: doneCh, control: control, listener: listener, vsock: vsock, bootWriter: bootWriter, transcript: controlTranscript, serialOut: serialOut, dmesg: dmesg}, nil
 }
@@ -164,10 +184,23 @@ func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (clie
 	if len(req.Command) == 0 {
 		return client.ExecResponse{}, fmt.Errorf("exec command is required")
 	}
+	trace := os.Getenv("CC_WHP_BSD_TIMING") != ""
+	startTime := time.Now()
 	id := strconv.FormatUint(s.nextID.Add(1), 10)
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-managed exec %s start command=%q\n", id, strings.Join(req.Command, " "))
+	}
 	start := s.transcript.Len()
-	if err := s.sendExecMessage(managedagent.ExecRequest(id, req)); err != nil {
+	s.sendMu.Lock()
+	err := managedagent.SendExec(s.control, id, req)
+	s.sendMu.Unlock()
+	if err != nil {
 		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+	}
+	if len(req.Stdin) == 0 {
+		if err := s.sendExecMessage(managedagent.StdinCloseRequest(id)); err != nil {
+			return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+		}
 	}
 	segment, err := s.transcript.WaitFor(ctx, start, func(text string) bool {
 		_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, s.dmesg)
@@ -180,6 +213,9 @@ func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (clie
 	if !ok {
 		return client.ExecResponse{}, transcriptError(fmt.Errorf("exec did not produce a complete result"), s.serialOut.String(), s.transcript.String())
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-managed exec %s done duration=%s code=%d output=%d\n", id, time.Since(startTime).Round(time.Millisecond), code, len(output))
+	}
 	if s.dmesg {
 		output = s.serialOut.String() + "\n[control]\n" + output
 	}
@@ -190,7 +226,12 @@ func (s *ManagedSession) ExecStream(ctx context.Context, req client.ExecRequest,
 	if (req.Kind == "" || req.Kind == "exec") && len(req.Command) == 0 {
 		return fmt.Errorf("exec command is required")
 	}
+	trace := os.Getenv("CC_WHP_BSD_TIMING") != ""
+	startTime := time.Now()
 	id := strconv.FormatUint(s.nextID.Add(1), 10)
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-managed stream %s start command=%q\n", id, strings.Join(req.Command, " "))
+	}
 	start := s.transcript.Len()
 	if err := s.sendExecMessage(managedagent.ExecRequest(id, req)); err != nil {
 		return transcriptError(err, s.serialOut.String(), s.transcript.String())
@@ -200,7 +241,7 @@ func (s *ManagedSession) ExecStream(ctx context.Context, req client.ExecRequest,
 	} else if len(req.Stdin) == 0 && !req.TTY {
 		_ = s.sendExecMessage(managedagent.StdinCloseRequest(id))
 	}
-	return managedsession.StreamExecEvents(ctx, managedsession.StreamExecOptions{
+	err := managedsession.StreamExecEvents(ctx, managedsession.StreamExecOptions{
 		Transcript: s.transcript,
 		Start:      start,
 		ID:         id,
@@ -223,10 +264,19 @@ func (s *ManagedSession) ExecStream(ctx context.Context, req client.ExecRequest,
 			}
 		},
 	})
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-managed stream %s done duration=%s err=%v\n", id, time.Since(startTime).Round(time.Millisecond), err)
+	}
+	return err
 }
 
 func (s *ManagedSession) Flush(ctx context.Context) error {
+	trace := os.Getenv("CC_WHP_BSD_TIMING") != ""
+	startTime := time.Now()
 	id := strconv.FormatUint(s.nextID.Add(1), 10)
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-managed flush %s start\n", id)
+	}
 	start := s.transcript.Len()
 	if err := s.sendExecMessage(managedagent.SyncRequest(id)); err != nil {
 		return transcriptError(err, s.serialOut.String(), s.transcript.String())
@@ -244,6 +294,9 @@ func (s *ManagedSession) Flush(ctx context.Context) error {
 	}
 	if code != 0 {
 		return transcriptError(fmt.Errorf("sync exited with status %d: %s", code, output), s.serialOut.String(), s.transcript.String())
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-managed flush %s done duration=%s\n", id, time.Since(startTime).Round(time.Millisecond))
 	}
 	return nil
 }
@@ -308,6 +361,9 @@ func (s *ManagedSession) Close() error {
 	}
 	if s.bootWriter != nil {
 		_ = s.bootWriter.Close()
+	}
+	if s.cleanup != nil {
+		s.cleanup()
 	}
 	if waitErr != nil && !errors.Is(waitErr, context.Canceled) {
 		return waitErr

--- a/internal/hv/whp/session_windows_arm64.go
+++ b/internal/hv/whp/session_windows_arm64.go
@@ -4,6 +4,7 @@ package whp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -87,9 +88,10 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 	runCtx, cancel := context.WithCancel(context.Background())
 	doneCh := make(chan error, 1)
 	go func() {
-		defer vm.Close()
-		defer closeFSDevices(fsdevs)
-		doneCh <- runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
+		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
+		closeFSDevices(fsdevs)
+		err = errors.Join(err, vm.Close())
+		doneCh <- err
 	}()
 
 	var control virtio.VsockConn
@@ -254,16 +256,47 @@ func (s *ManagedSession) ConsoleHistory(context.Context) (string, error) {
 }
 
 func (s *ManagedSession) Wait() error {
+	return s.waitDone()
+}
+
+func (s *ManagedSession) waitDone() error {
 	if s == nil || s.doneCh == nil {
 		return nil
 	}
-	return <-s.doneCh
+	err := <-s.doneCh
+	select {
+	case s.doneCh <- err:
+	default:
+	}
+	return err
+}
+
+func (s *ManagedSession) waitDoneTimeout(timeout time.Duration) error {
+	if s == nil || s.doneCh == nil {
+		return nil
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-s.doneCh:
+		select {
+		case s.doneCh <- err:
+		default:
+		}
+		return err
+	case <-timer.C:
+		return fmt.Errorf("timed out waiting for managed session to stop")
+	}
 }
 
 func (s *ManagedSession) Close() error {
 	if s == nil {
 		return nil
 	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	waitErr := s.waitDoneTimeout(15 * time.Second)
 	if s.control != nil {
 		_ = s.control.Close()
 	}
@@ -276,8 +309,8 @@ func (s *ManagedSession) Close() error {
 	if s.bootWriter != nil {
 		_ = s.bootWriter.Close()
 	}
-	if s.cancel != nil {
-		s.cancel()
+	if waitErr != nil && !errors.Is(waitErr, context.Canceled) {
+		return waitErr
 	}
 	return nil
 }

--- a/internal/hv/whp/vm_windows_arm64.go
+++ b/internal/hv/whp/vm_windows_arm64.go
@@ -1,0 +1,385 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"time"
+	"unsafe"
+
+	"j5.nz/cc/internal/arm64vm"
+)
+
+type VM struct {
+	part        partitionHandle
+	mem         *allocation
+	memGPA      uint64
+	memSize     uint64
+	vcpuCreated bool
+}
+
+type Exit struct {
+	Reason runVPExitReason
+	PC     uint64
+	CPSR   uint64
+	MMIO   MMIOExit
+}
+
+type MMIOExit struct {
+	Addr       uint64
+	Data       [8]byte
+	Len        uint32
+	Write      bool
+	Reg        int
+	SignExtend bool
+	SF         bool
+	PC         uint64
+	NextPC     uint64
+}
+
+func Supports() error {
+	present, err := isHypervisorPresent()
+	if err != nil {
+		if probeErr := probePartitionSupport(); probeErr == nil {
+			return nil
+		} else {
+			return fmt.Errorf("whp unavailable: query hypervisor presence: %w; partition probe: %w", err, probeErr)
+		}
+	}
+	if !present {
+		return fmt.Errorf("whp unavailable: hypervisor not present")
+	}
+	features, err := getCapability[capabilityFeatures](capabilityCodeFeatures)
+	if err != nil {
+		return fmt.Errorf("whp unavailable: query features: %w", err)
+	}
+	if !features.arm64Support() {
+		return fmt.Errorf("whp unavailable: arm64 support not reported")
+	}
+	return nil
+}
+
+func probePartitionSupport() error {
+	part, err := createPartition()
+	if err != nil {
+		return fmt.Errorf("create partition: %w", err)
+	}
+	if err := deletePartition(part); err != nil {
+		return fmt.Errorf("delete partition: %w", err)
+	}
+	return nil
+}
+
+func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
+	if memorySize == 0 {
+		return nil, fmt.Errorf("memory size must be non-zero")
+	}
+	part, err := createPartition()
+	if err != nil {
+		return nil, fmt.Errorf("create partition: %w", err)
+	}
+	vm := &VM{part: part, memGPA: memoryBase}
+	if err := setPartitionProperty(part, partitionPropertyCodeProcessorCount, uint32(1)); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("set processor count: %w", err)
+	}
+	lpiBits, err := getCapability[uint32](capabilityCodeGicLpiIntIDBits)
+	if err != nil || lpiBits == 0 {
+		lpiBits = 16
+	}
+	ic := arm64ICParameters{
+		EmulationMode: arm64ICEmulationModeGICV3,
+		GICV3Parameters: arm64ICGICV3Parameters{
+			GICDBaseAddress:           0x08000000,
+			GITSTranslaterBaseAddress: 0x08080000,
+			GICLPIIntIDBits:           lpiBits,
+			GICPPIOverflowFromCNTV:    27,
+			GICPPIPerformanceMonitors: 23,
+		},
+	}
+	if err := setPartitionProperty(part, partitionPropertyCodeArm64ICParameters, ic); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("set arm64 interrupt controller parameters: %w", err)
+	}
+	if err := setupPartition(part); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("setup partition: %w", err)
+	}
+	mem, err := virtualAlloc(uintptr(memorySize))
+	if err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("allocate guest memory: %w", err)
+	}
+	vm.mem = mem
+	vm.memSize = memorySize
+	if err := mapGPARange(part, unsafe.Pointer(mem.addr), memoryBase, memorySize, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("map guest memory: %w", err)
+	}
+	if err := createVirtualProcessor(part, 0); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("create virtual processor: %w", err)
+	}
+	vm.vcpuCreated = true
+	if err := vm.setRegister(registerGICR, arm64vm.GICRedistributorMin); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("set gic redistributor base: %w", err)
+	}
+	return vm, nil
+}
+
+func (v *VM) Close() error {
+	if v == nil {
+		return nil
+	}
+	var first error
+	if v.part != 0 && v.vcpuCreated {
+		_ = cancelRunVirtualProcessor(v.part, 0)
+		if err := deleteVirtualProcessor(v.part, 0); err != nil && first == nil {
+			first = err
+		}
+		v.vcpuCreated = false
+	}
+	if v.part != 0 && v.mem != nil {
+		if err := unmapGPARange(v.part, v.memGPA, v.memSize); err != nil && first == nil {
+			first = err
+		}
+	}
+	if v.mem != nil {
+		if err := v.mem.free(); err != nil && first == nil {
+			first = err
+		}
+		v.mem = nil
+	}
+	if v.part != 0 {
+		if err := deletePartition(v.part); err != nil && first == nil {
+			first = err
+		}
+		v.part = 0
+		time.Sleep(3 * time.Second)
+	}
+	return first
+}
+
+func (v *VM) Memory() []byte {
+	if v == nil || v.mem == nil {
+		return nil
+	}
+	return v.mem.bytes()
+}
+
+func (v *VM) ReadIPA(addr uint64, size int) ([]byte, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("invalid read size %d", size)
+	}
+	out := make([]byte, size)
+	if err := v.ReadIPAInto(addr, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (v *VM) ReadIPAInto(addr uint64, dst []byte) error {
+	if v == nil || v.mem == nil {
+		return fmt.Errorf("guest memory is not mapped")
+	}
+	if addr < v.memGPA || addr-v.memGPA > v.memSize || uint64(len(dst)) > v.memSize-(addr-v.memGPA) {
+		return fmt.Errorf("read ipa %#x size %d out of range [%#x,%#x)", addr, len(dst), v.memGPA, v.memGPA+v.memSize)
+	}
+	off := addr - v.memGPA
+	copy(dst, v.mem.bytes()[off:off+uint64(len(dst))])
+	return nil
+}
+
+func (v *VM) WriteIPA(addr uint64, data []byte) error {
+	if v == nil || v.mem == nil {
+		return fmt.Errorf("guest memory is not mapped")
+	}
+	if addr < v.memGPA || addr-v.memGPA > v.memSize || uint64(len(data)) > v.memSize-(addr-v.memGPA) {
+		return fmt.Errorf("write ipa %#x size %d out of range [%#x,%#x)", addr, len(data), v.memGPA, v.memGPA+v.memSize)
+	}
+	off := addr - v.memGPA
+	copy(v.mem.bytes()[off:off+uint64(len(data))], data)
+	return nil
+}
+
+func (v *VM) SetX(index int, value uint64) error {
+	if index < 0 || index > 30 {
+		return fmt.Errorf("invalid x register %d", index)
+	}
+	return v.setRegister(registerX(index), value)
+}
+
+func (v *VM) SetPC(value uint64) error {
+	return v.setRegister(registerPC, value)
+}
+
+func (v *VM) SetPState(value uint64) error {
+	return v.setRegister(registerPSTATE, value)
+}
+
+func (v *VM) SetSpEl1(value uint64) error {
+	return v.setRegister(registerSPEL1, value)
+}
+
+func (v *VM) GetPC() (uint64, error) {
+	return v.getRegister(registerPC)
+}
+
+func (v *VM) setRegister(name registerName, value uint64) error {
+	return setVirtualProcessorRegisters(v.part, 0, []registerName{name}, []registerValue{uint64RegisterValue(value)})
+}
+
+func (v *VM) getRegister(name registerName) (uint64, error) {
+	values := make([]registerValue, 1)
+	if err := getVirtualProcessorRegisters(v.part, 0, []registerName{name}, values); err != nil {
+		return 0, err
+	}
+	return values[0].uint64(), nil
+}
+
+func (v *VM) Run(exit *Exit) error {
+	var raw runVPExitContext
+	if err := runVirtualProcessor(v.part, 0, &raw); err != nil {
+		return fmt.Errorf("run virtual processor: %w", err)
+	}
+	*exit = Exit{Reason: raw.ExitReason}
+	switch raw.ExitReason {
+	case runVPExitReasonUnmappedGPA, runVPExitReasonGPAIntercept:
+		mem := raw.memoryAccess()
+		mmio, err := v.decodeMMIO(*mem)
+		if err != nil {
+			return err
+		}
+		exit.PC = mem.Header.PC
+		exit.CPSR = mem.Header.CPSR
+		exit.MMIO = mmio
+	}
+	return nil
+}
+
+func (v *VM) RunInterruptible(ctx context.Context, exit *Exit) error {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = cancelRunVirtualProcessor(v.part, 0)
+		case <-done:
+		}
+	}()
+	err := v.Run(exit)
+	close(done)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil && exit.Reason == runVPExitReasonCanceled {
+		return ctxErr
+	}
+	return nil
+}
+
+func (v *VM) CancelRun() error {
+	if v == nil || v.part == 0 {
+		return nil
+	}
+	return cancelRunVirtualProcessor(v.part, 0)
+}
+
+func (v *VM) SetIRQ(line uint32, level bool) error {
+	if v == nil || v.part == 0 {
+		return fmt.Errorf("vm is nil")
+	}
+	if err := requestInterrupt(v.part, line+32, level); err != nil {
+		return err
+	}
+	if level {
+		_ = cancelRunVirtualProcessor(v.part, 0)
+	}
+	return nil
+}
+
+func (v *VM) CompleteMMIORead(exit MMIOExit, value uint64) error {
+	if exit.Reg == 31 {
+		return v.SetPC(exit.NextPC)
+	}
+	value = loadResult(value, exit.Len, exit.SignExtend, exit.SF)
+	if err := v.setRegister(registerX(exit.Reg), value); err != nil {
+		return err
+	}
+	return v.SetPC(exit.NextPC)
+}
+
+func (v *VM) CompleteMMIOWrite(exit MMIOExit) error {
+	return v.SetPC(exit.NextPC)
+}
+
+func (v *VM) decodeMMIO(mem memoryAccessContext) (MMIOExit, error) {
+	size := mem.accessSize()
+	if size == 0 || size > 8 {
+		return MMIOExit{}, fmt.Errorf("unsupported arm64 mmio syndrome %#x", mem.Syndrome)
+	}
+	nextPC := mem.Header.PC + uint64(mem.Header.InstructionLength)
+	if nextPC == mem.Header.PC {
+		nextPC += 4
+	}
+	out := MMIOExit{
+		Addr:       mem.GPA,
+		Len:        size,
+		Write:      mem.isWrite(),
+		Reg:        mem.registerIndex(),
+		SignExtend: mem.signExtend(),
+		SF:         mem.sf(),
+		PC:         mem.Header.PC,
+		NextPC:     nextPC,
+	}
+	if out.Write && out.Reg != 31 {
+		value, err := v.getRegister(registerX(out.Reg))
+		if err != nil {
+			return MMIOExit{}, err
+		}
+		switch size {
+		case 1:
+			out.Data[0] = byte(value)
+		case 2:
+			binary.LittleEndian.PutUint16(out.Data[:2], uint16(value))
+		case 4:
+			binary.LittleEndian.PutUint32(out.Data[:4], uint32(value))
+		default:
+			binary.LittleEndian.PutUint64(out.Data[:8], value)
+		}
+	}
+	return out, nil
+}
+
+func loadResult(value uint64, size uint32, signExtend, sf bool) uint64 {
+	switch size {
+	case 1:
+		if signExtend {
+			if sf {
+				return uint64(int64(int8(value)))
+			}
+			return uint64(uint32(int32(int8(value))))
+		}
+		return uint64(uint8(value))
+	case 2:
+		if signExtend {
+			if sf {
+				return uint64(int64(int16(value)))
+			}
+			return uint64(uint32(int32(int16(value))))
+		}
+		return uint64(uint16(value))
+	case 4:
+		if signExtend && sf {
+			return uint64(int64(int32(value)))
+		}
+		return uint64(uint32(value))
+	default:
+		return value
+	}
+}

--- a/internal/hv/whp/vm_windows_arm64.go
+++ b/internal/hv/whp/vm_windows_arm64.go
@@ -20,6 +20,16 @@ type VM struct {
 	vcpuCreated bool
 }
 
+const (
+	defaultCNTVOverflowInterrupt = 27
+	defaultPMUInterrupt          = 23
+)
+
+type VMOptions struct {
+	CNTVOverflowInterrupt uint32
+	GICLPIIntIDBits       uint32
+}
+
 type Exit struct {
 	Reason runVPExitReason
 	PC     uint64
@@ -73,6 +83,10 @@ func probePartitionSupport() error {
 }
 
 func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
+	return NewVMWithOptions(memorySize, memoryBase, VMOptions{})
+}
+
+func NewVMWithOptions(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM, error) {
 	if memorySize == 0 {
 		return nil, fmt.Errorf("memory size must be non-zero")
 	}
@@ -85,18 +99,19 @@ func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
 		_ = vm.Close()
 		return nil, fmt.Errorf("set processor count: %w", err)
 	}
-	lpiBits, err := getCapability[uint32](capabilityCodeGicLpiIntIDBits)
-	if err != nil || lpiBits == 0 {
-		lpiBits = 16
+	opts, err = normalizeVMOptions(opts)
+	if err != nil {
+		_ = vm.Close()
+		return nil, err
 	}
 	ic := arm64ICParameters{
 		EmulationMode: arm64ICEmulationModeGICV3,
 		GICV3Parameters: arm64ICGICV3Parameters{
 			GICDBaseAddress:           0x08000000,
 			GITSTranslaterBaseAddress: 0x08080000,
-			GICLPIIntIDBits:           lpiBits,
-			GICPPIOverflowFromCNTV:    27,
-			GICPPIPerformanceMonitors: 23,
+			GICLPIIntIDBits:           opts.GICLPIIntIDBits,
+			GICPPIOverflowFromCNTV:    opts.CNTVOverflowInterrupt,
+			GICPPIPerformanceMonitors: defaultPMUInterrupt,
 		},
 	}
 	if err := setPartitionProperty(part, partitionPropertyCodeArm64ICParameters, ic); err != nil {
@@ -114,10 +129,12 @@ func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
 	}
 	vm.mem = mem
 	vm.memSize = memorySize
+	vm.preTouchGuestMemory()
 	if err := mapGPARange(part, unsafe.Pointer(mem.addr), memoryBase, memorySize, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
 		_ = vm.Close()
 		return nil, fmt.Errorf("map guest memory: %w", err)
 	}
+	vm.populateGuestMemory()
 	if err := createVirtualProcessor(part, 0); err != nil {
 		_ = vm.Close()
 		return nil, fmt.Errorf("create virtual processor: %w", err)
@@ -128,6 +145,43 @@ func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
 		return nil, fmt.Errorf("set gic redistributor base: %w", err)
 	}
 	return vm, nil
+}
+
+func (v *VM) preTouchGuestMemory() {
+	if v.mem == nil {
+		return
+	}
+	// WHP/arm64 can otherwise populate backing pages lazily on the guest's
+	// first writes, making early kernel page clearing pathologically slow.
+	mem := v.mem.bytes()
+	const pageSize = 4096
+	for off := 0; off < len(mem); off += pageSize {
+		mem[off] = 0
+	}
+	if len(mem) > 0 {
+		mem[len(mem)-1] = 0
+	}
+}
+
+func (v *VM) populateGuestMemory() {
+	flags := adviseGPARangePopulateFlagPrefetch | adviseGPARangePopulateFlagAvoidHardFaults
+	_ = adviseGPARangePopulate(v.part, v.memGPA, v.memSize, memoryAccessRead, flags)
+	_ = adviseGPARangePopulate(v.part, v.memGPA, v.memSize, memoryAccessWrite, flags)
+	_ = adviseGPARangePopulate(v.part, v.memGPA, v.memSize, memoryAccessExecute, flags)
+}
+
+func normalizeVMOptions(opts VMOptions) (VMOptions, error) {
+	if opts.CNTVOverflowInterrupt == 0 {
+		opts.CNTVOverflowInterrupt = defaultCNTVOverflowInterrupt
+	}
+	if opts.GICLPIIntIDBits == 0 {
+		lpiBits, err := getCapability[uint32](capabilityCodeGicLpiIntIDBits)
+		if err != nil || lpiBits == 0 {
+			lpiBits = 16
+		}
+		opts.GICLPIIntIDBits = lpiBits
+	}
+	return opts, nil
 }
 
 func (v *VM) Close() error {
@@ -191,6 +245,20 @@ func (v *VM) ReadIPAInto(addr uint64, dst []byte) error {
 	off := addr - v.memGPA
 	copy(dst, v.mem.bytes()[off:off+uint64(len(dst))])
 	return nil
+}
+
+func (v *VM) SliceIPA(addr uint64, size int) ([]byte, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("invalid slice size %d", size)
+	}
+	if v == nil || v.mem == nil {
+		return nil, fmt.Errorf("guest memory is not mapped")
+	}
+	if addr < v.memGPA || addr-v.memGPA > v.memSize || uint64(size) > v.memSize-(addr-v.memGPA) {
+		return nil, fmt.Errorf("slice ipa %#x size %d out of range [%#x,%#x)", addr, size, v.memGPA, v.memGPA+v.memSize)
+	}
+	off := addr - v.memGPA
+	return v.mem.bytes()[off : off+uint64(size)], nil
 }
 
 func (v *VM) WriteIPA(addr uint64, data []byte) error {
@@ -261,16 +329,14 @@ func (v *VM) Run(exit *Exit) error {
 }
 
 func (v *VM) RunInterruptible(ctx context.Context, exit *Exit) error {
-	done := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = cancelRunVirtualProcessor(v.part, 0)
-		case <-done:
-		}
-	}()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	stopCancel := context.AfterFunc(ctx, func() {
+		_ = cancelRunVirtualProcessor(v.part, 0)
+	})
 	err := v.Run(exit)
-	close(done)
+	stopCancel()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
@@ -300,6 +366,18 @@ func (v *VM) SetIRQ(line uint32, level bool) error {
 	if level {
 		_ = cancelRunVirtualProcessor(v.part, 0)
 	}
+	return nil
+}
+
+func (v *VM) SetMSI(addr uint64, data uint32) error {
+	if v == nil || v.part == 0 {
+		return fmt.Errorf("vm is nil")
+	}
+	const lpiBase = 8192
+	if err := requestInterrupt(v.part, lpiBase+data, true); err != nil {
+		return err
+	}
+	_ = cancelRunVirtualProcessor(v.part, 0)
 	return nil
 }
 

--- a/internal/hv/whp/whp_other.go
+++ b/internal/hv/whp/whp_other.go
@@ -1,9 +1,9 @@
-//go:build !(windows && amd64)
+//go:build !windows || (!amd64 && !arm64)
 
 package whp
 
 import "fmt"
 
 func Supports() error {
-	return fmt.Errorf("whp unavailable: requires windows/amd64")
+	return fmt.Errorf("whp unavailable: requires windows/amd64 or windows/arm64")
 }

--- a/internal/linux/boot/arm64/plan.go
+++ b/internal/linux/boot/arm64/plan.go
@@ -54,6 +54,7 @@ type BootOptions struct {
 	UART        *UARTConfig
 	DisableUART bool
 	Console     bool
+	HyperVTimer bool
 	Initrd      []byte
 	InitrdGPA   uint64
 	ExtraNodes  []fdt.Node
@@ -164,16 +165,17 @@ func PrepareBoot(memory []byte, kernelFile []byte, opts BootOptions) (*BootPlan,
 
 	start = time.Now()
 	dtb, err := buildDeviceTree(deviceTreeConfig{
-		MemoryBase: opts.MemoryBase,
-		MemorySize: opts.MemorySize,
-		NumCPUs:    opts.NumCPUs,
-		Cmdline:    opts.Cmdline,
-		GICVersion: opts.GICVersion,
-		UART:       opts.UART,
-		Console:    opts.Console,
-		InitrdGPA:  initrdAddr,
-		InitrdSize: uint64(len(opts.Initrd)),
-		ExtraNodes: append([]fdt.Node(nil), opts.ExtraNodes...),
+		MemoryBase:  opts.MemoryBase,
+		MemorySize:  opts.MemorySize,
+		NumCPUs:     opts.NumCPUs,
+		Cmdline:     opts.Cmdline,
+		GICVersion:  opts.GICVersion,
+		UART:        opts.UART,
+		Console:     opts.Console,
+		HyperVTimer: opts.HyperVTimer,
+		InitrdGPA:   initrdAddr,
+		InitrdSize:  uint64(len(opts.Initrd)),
+		ExtraNodes:  append([]fdt.Node(nil), opts.ExtraNodes...),
 	})
 	record("build_device_tree", start)
 	if err != nil {
@@ -218,16 +220,17 @@ func PrepareBoot(memory []byte, kernelFile []byte, opts BootOptions) (*BootPlan,
 }
 
 type deviceTreeConfig struct {
-	MemoryBase uint64
-	MemorySize uint64
-	NumCPUs    int
-	Cmdline    string
-	GICVersion GICVersion
-	UART       *UARTConfig
-	Console    bool
-	InitrdGPA  uint64
-	InitrdSize uint64
-	ExtraNodes []fdt.Node
+	MemoryBase  uint64
+	MemorySize  uint64
+	NumCPUs     int
+	Cmdline     string
+	GICVersion  GICVersion
+	UART        *UARTConfig
+	Console     bool
+	HyperVTimer bool
+	InitrdGPA   uint64
+	InitrdSize  uint64
+	ExtraNodes  []fdt.Node
 }
 
 func buildDeviceTree(cfg deviceTreeConfig) ([]byte, error) {
@@ -341,13 +344,18 @@ func buildDeviceTree(cfg deviceTreeConfig) ([]byte, error) {
 		},
 	})
 
+	timerProperties := map[string]fdt.Property{
+		"compatible": {Strings: []string{"arm,armv8-timer"}},
+		"always-on":  {Flag: true},
+		"interrupts": {U32: []uint32{1, 13, 4, 1, 14, 4, 1, 11, 4, 1, 10, 4}},
+	}
+	if cfg.HyperVTimer {
+		timerProperties["interrupt-names"] = fdt.Property{Strings: []string{"virt"}}
+		timerProperties["interrupts"] = fdt.Property{U32: []uint32{1, 4, 8}}
+	}
 	root.Children = append(root.Children, fdt.Node{
-		Name: "timer",
-		Properties: map[string]fdt.Property{
-			"compatible": {Strings: []string{"arm,armv8-timer"}},
-			"always-on":  {Flag: true},
-			"interrupts": {U32: []uint32{1, 13, 4, 1, 14, 4, 1, 11, 4, 1, 10, 4}},
-		},
+		Name:       "timer",
+		Properties: timerProperties,
 	})
 
 	root.Children = append(root.Children, fdt.Node{

--- a/internal/netbsd/guestinit/guestinit.go
+++ b/internal/netbsd/guestinit/guestinit.go
@@ -39,7 +39,7 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 		return nil, fmt.Errorf("locate NetBSD guest init package")
 	}
 	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
-	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", out, "./internal/cmd/netbsd-init")
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-ldflags", "-s -w", "-o", out, "./internal/cmd/netbsd-init")
 	cmd.Dir = moduleRoot
 	cmd.Env = append(os.Environ(), "GOOS=netbsd", "GOARCH="+arch, "CGO_ENABLED=0")
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -28,6 +28,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -2157,6 +2158,12 @@ func (c *tcpConn) handleSegment(h ipv4Header, hdr tcpHeader) error {
 		return nil
 	case tcpStateSynRcvd:
 		if hdr.flags&tcpFlagACK != 0 {
+			if hdr.ack != c.hostSeq {
+				tracef("netstack.tcpConn synrcvd drop badAck", "ack=%d want=%d", hdr.ack, c.hostSeq)
+				c.mu.Unlock()
+				return nil
+			}
+			tracef("netstack.tcpConn established", "seq=%d ack=%d payloadLen=%d", hdr.seq, hdr.ack, len(hdr.payload))
 			c.state = tcpStateEstablished
 			cb := c.onEstablished
 			listener := c.listener
@@ -3974,9 +3981,14 @@ func itoa(v int) string {
 	return strconv.Itoa(v)
 }
 
-const netstackTraceEnabled = false
+var netstackTraceEnabled = os.Getenv("CC_NETSTACK_TRACE") != ""
 
-func tracef(_ string, _ string, _ ...any) {}
+func tracef(event string, format string, args ...any) {
+	if !netstackTraceEnabled {
+		return
+	}
+	fmt.Fprintf(os.Stderr, event+": "+format+"\n", args...)
+}
 
 // proxyConns bridges bytes between a and b until one side closes.
 func proxyConns(a, b net.Conn, bufSize int) error {

--- a/internal/nvme/controller.go
+++ b/internal/nvme/controller.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
+	"time"
 
 	"j5.nz/cc/internal/virtio"
 )
@@ -64,6 +66,14 @@ type Controller struct {
 	queues  map[uint16]*queue
 	scratch []byte
 	prps    []byte
+
+	msi msiConfig
+
+	readOps    uint64
+	readBytes  uint64
+	writeOps   uint64
+	writeBytes uint64
+	lastTrace  time.Time
 }
 
 type queue struct {
@@ -76,6 +86,7 @@ type queue struct {
 	sqTail     uint16
 	cqHead     uint16
 	cqTail     uint16
+	cqPending  uint16
 	cqPhase    bool
 	interrupts bool
 	sqMem      []byte
@@ -104,6 +115,16 @@ type guestMemorySlicer interface {
 	SliceIPA(addr uint64, size int) ([]byte, error)
 }
 
+type msiIRQController interface {
+	SetMSI(addr uint64, data uint32) error
+}
+
+type msiConfig struct {
+	enabled bool
+	addr    uint64
+	data    uint32
+}
+
 func NewController(backend virtio.BlockBackend) *Controller {
 	c := &Controller{
 		Size:    MMIOSize,
@@ -120,6 +141,12 @@ func (c *Controller) Attach(mem virtio.GuestMemory, irq virtio.IRQController) {
 	defer c.mu.Unlock()
 	c.mem = mem
 	c.irq = irq
+}
+
+func (c *Controller) ConfigureMSI(enabled bool, addr uint64, data uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msi = msiConfig{enabled: enabled, addr: addr, data: data}
 }
 
 func (c *Controller) ReadMMIO(offset uint64, size int) (uint64, error) {
@@ -253,7 +280,7 @@ func (c *Controller) writeDoorbellLocked(offset uint64, value uint32) error {
 		q.sqTail = uint16(value)
 		return c.processSubmissionQueueLocked(q)
 	}
-	q.cqHead = uint16(value)
+	q.advanceCompletionHeadLocked(uint16(value))
 	return c.updateIRQLocked()
 }
 
@@ -413,6 +440,7 @@ func (c *Controller) executeIOLocked(cmd command) (uint32, uint16, error) {
 			if err != nil {
 				return 0, 1, err
 			}
+			c.recordIOLocked("read", count)
 			return 0, 0, nil
 		}
 		n, err := c.backend.ReadAt(buf, offset)
@@ -420,12 +448,14 @@ func (c *Controller) executeIOLocked(cmd command) (uint32, uint16, error) {
 			return 0, 1, nil
 		}
 		clear(buf[n:])
+		c.recordIOLocked("read", count)
 		return 0, 0, c.writePRP(cmd.prp1, cmd.prp2, buf)
 	case ioWrite:
 		if ok, err := c.writeBackendFromPRP(offset, count, cmd.prp1, cmd.prp2); ok {
 			if err != nil {
 				return 0, 1, err
 			}
+			c.recordIOLocked("write", count)
 			return 0, 0, nil
 		}
 		if err := c.readPRP(cmd.prp1, cmd.prp2, buf); err != nil {
@@ -434,9 +464,32 @@ func (c *Controller) executeIOLocked(cmd command) (uint32, uint16, error) {
 		if _, err := c.backend.WriteAt(buf, offset); err != nil {
 			return 0, 1, nil
 		}
+		c.recordIOLocked("write", count)
 		return 0, 0, nil
 	default:
 		return 0, 1, nil
+	}
+}
+
+func (c *Controller) recordIOLocked(kind string, size int) {
+	if size < 0 {
+		size = 0
+	}
+	switch kind {
+	case "read":
+		c.readOps++
+		c.readBytes += uint64(size)
+	case "write":
+		c.writeOps++
+		c.writeBytes += uint64(size)
+	}
+	if os.Getenv("CC_NVME_TRACE") == "" {
+		return
+	}
+	now := time.Now()
+	if c.lastTrace.IsZero() || now.Sub(c.lastTrace) >= 5*time.Second {
+		_, _ = fmt.Fprintf(os.Stderr, "nvme io read_ops=%d read_bytes=%d write_ops=%d write_bytes=%d\n", c.readOps, c.readBytes, c.writeOps, c.writeBytes)
+		c.lastTrace = now
 	}
 }
 
@@ -622,6 +675,9 @@ func (c *Controller) writeCompletionLocked(q *queue, sqid uint16, sqHead uint16,
 		return fmt.Errorf("write cq%d entry tail=%d addr=%#x: %w", q.id, q.cqTail, q.cqAddr, err)
 	}
 	q.cqTail = (q.cqTail + 1) % q.size
+	if q.cqPending < q.size {
+		q.cqPending++
+	}
 	if q.cqTail == 0 {
 		q.cqPhase = !q.cqPhase
 	}
@@ -632,7 +688,7 @@ func (c *Controller) updateIRQLocked() error {
 	high := false
 	if c.intMask&1 == 0 {
 		for _, q := range c.queues {
-			if q.interrupts && q.cqHead != q.cqTail {
+			if q.interrupts && q.cqPending != 0 {
 				high = true
 				break
 			}
@@ -645,7 +701,40 @@ func (c *Controller) updateIRQLocked() error {
 	if c.irq == nil {
 		return nil
 	}
+	if c.msi.enabled {
+		if !high {
+			return nil
+		}
+		irq, ok := c.irq.(msiIRQController)
+		if !ok {
+			return nil
+		}
+		return irq.SetMSI(c.msi.addr, c.msi.data)
+	}
 	return c.irq.SetIRQ(c.IRQ, high)
+}
+
+func (q *queue) advanceCompletionHeadLocked(head uint16) {
+	if q.size == 0 {
+		q.cqHead = head
+		q.cqPending = 0
+		return
+	}
+	oldHead := q.cqHead
+	q.cqHead = head % q.size
+	consumed := q.cqHead - oldHead
+	if q.cqHead < oldHead {
+		consumed = q.size - oldHead + q.cqHead
+	}
+	if consumed == 0 && q.cqPending == q.size {
+		q.cqPending = 0
+		return
+	}
+	if consumed >= q.cqPending {
+		q.cqPending = 0
+		return
+	}
+	q.cqPending -= consumed
 }
 
 func (c *Controller) readPRP(prp1, prp2 uint64, dst []byte) error {

--- a/internal/nvme/controller_test.go
+++ b/internal/nvme/controller_test.go
@@ -27,13 +27,23 @@ func (m *testMemory) WriteIPA(addr uint64, data []byte) error {
 }
 
 type testIRQ struct {
-	line  uint32
-	level bool
+	line    uint32
+	level   bool
+	msiAddr uint64
+	msiData uint32
+	msis    int
 }
 
 func (i *testIRQ) SetIRQ(line uint32, level bool) error {
 	i.line = line
 	i.level = level
+	return nil
+}
+
+func (i *testIRQ) SetMSI(addr uint64, data uint32) error {
+	i.msiAddr = addr
+	i.msiData = data
+	i.msis++
 	return nil
 }
 
@@ -113,6 +123,94 @@ func TestControllerIdentifyAndReadWrite(t *testing.T) {
 	}
 	if !irq.level {
 		t.Fatalf("completion interrupt was not asserted")
+	}
+}
+
+func TestControllerInterruptRemainsAssertedForFullCompletionQueue(t *testing.T) {
+	mem := newTestMemory(0x20000)
+	disk := newTestDisk(1024 * 1024)
+	irq := &testIRQ{}
+	ctrl := NewController(disk)
+	ctrl.IRQ = 10
+	ctrl.Attach(mem, irq)
+
+	adminSQ := uint64(0x1000)
+	adminCQ := uint64(0x2000)
+	ioSQ := uint64(0x3000)
+	ioCQ := uint64(0x4000)
+	data := uint64(0x5000)
+
+	mustWriteMMIO(t, ctrl, regAQA, 4-1|uint64(4-1)<<16)
+	mustWriteMMIO(t, ctrl, regASQ, adminSQ)
+	mustWriteMMIO(t, ctrl, regACQ, adminCQ)
+	mustWriteMMIO(t, ctrl, regCC, 1)
+
+	writeAdminCommand(mem, adminSQ, 0, command{opcode: adminCreateCQ, cid: 1, prp1: ioCQ, cdw10: 1 | uint32(2-1)<<16, cdw11: 2})
+	mustWriteMMIO(t, ctrl, doorbellBase, 1)
+	writeAdminCommand(mem, adminSQ, 1, command{opcode: adminCreateSQ, cid: 2, prp1: ioSQ, cdw10: 1 | uint32(4-1)<<16, cdw11: 1 << 16})
+	mustWriteMMIO(t, ctrl, doorbellBase, 2)
+	mustWriteMMIO(t, ctrl, doorbellBase+4, 2)
+
+	writeIOCommand(mem, ioSQ, 0, command{opcode: ioRead, cid: 3, nsid: 1, prp1: data, cdw12: 0})
+	writeIOCommand(mem, ioSQ, 1, command{opcode: ioRead, cid: 4, nsid: 1, prp1: data + 512, cdw12: 0})
+	mustWriteMMIO(t, ctrl, doorbellBase+8, 2)
+	if !irq.level {
+		t.Fatalf("interrupt level = false after completion queue wrapped full")
+	}
+	if got := binary.LittleEndian.Uint16(mem.data[ioCQ+12 : ioCQ+14]); got != 3 {
+		t.Fatalf("first completion cid = %d", got)
+	}
+	if got := binary.LittleEndian.Uint16(mem.data[ioCQ+16+12 : ioCQ+16+14]); got != 4 {
+		t.Fatalf("second completion cid = %d", got)
+	}
+
+	mustWriteMMIO(t, ctrl, doorbellBase+12, 1)
+	if !irq.level {
+		t.Fatalf("interrupt level = false after only one full-queue completion was acknowledged")
+	}
+	mustWriteMMIO(t, ctrl, doorbellBase+12, 0)
+	if irq.level {
+		t.Fatalf("interrupt level = true after all full-queue completions were acknowledged")
+	}
+}
+
+func TestControllerUsesMSIWhenConfigured(t *testing.T) {
+	mem := newTestMemory(0x20000)
+	disk := newTestDisk(1024 * 1024)
+	irq := &testIRQ{}
+	ctrl := NewController(disk)
+	ctrl.IRQ = 10
+	ctrl.Attach(mem, irq)
+	ctrl.ConfigureMSI(true, 0x8080000, 3)
+
+	adminSQ := uint64(0x1000)
+	adminCQ := uint64(0x2000)
+	ioSQ := uint64(0x3000)
+	ioCQ := uint64(0x4000)
+	data := uint64(0x5000)
+
+	mustWriteMMIO(t, ctrl, regAQA, 4-1|uint64(4-1)<<16)
+	mustWriteMMIO(t, ctrl, regASQ, adminSQ)
+	mustWriteMMIO(t, ctrl, regACQ, adminCQ)
+	mustWriteMMIO(t, ctrl, regCC, 1)
+
+	writeAdminCommand(mem, adminSQ, 0, command{opcode: adminCreateCQ, cid: 1, prp1: ioCQ, cdw10: 1 | uint32(4-1)<<16, cdw11: 2})
+	mustWriteMMIO(t, ctrl, doorbellBase, 1)
+	writeAdminCommand(mem, adminSQ, 1, command{opcode: adminCreateSQ, cid: 2, prp1: ioSQ, cdw10: 1 | uint32(4-1)<<16, cdw11: 1 << 16})
+	mustWriteMMIO(t, ctrl, doorbellBase, 2)
+	mustWriteMMIO(t, ctrl, doorbellBase+4, 2)
+	irq.msis = 0
+
+	writeIOCommand(mem, ioSQ, 0, command{opcode: ioRead, cid: 3, nsid: 1, prp1: data, cdw12: 0})
+	mustWriteMMIO(t, ctrl, doorbellBase+8, 1)
+	if irq.level {
+		t.Fatalf("INTx level asserted while MSI enabled")
+	}
+	if irq.msis != 1 {
+		t.Fatalf("MSI count = %d, want 1", irq.msis)
+	}
+	if irq.msiAddr != 0x8080000 || irq.msiData != 3 {
+		t.Fatalf("MSI addr/data = %#x/%#x, want %#x/%#x", irq.msiAddr, irq.msiData, uint64(0x8080000), uint32(3))
 	}
 }
 

--- a/internal/openbsd/boot/arm64/plan.go
+++ b/internal/openbsd/boot/arm64/plan.go
@@ -26,10 +26,15 @@ const (
 	defaultGICDistributorSize           = 0x00010000
 	defaultGICv2CPUInterfaceBase        = 0x08010000
 	defaultGICv2CPUInterfaceSize        = 0x00002000
+	defaultGICITSBase                   = 0x08080000
+	defaultGICITSSize                   = 0x00020000
 	defaultGICRedistributorBase         = 0x080a0000
 	defaultGICRedistributorSize         = 0x00020000
 	gicDefaultPhandle            uint32 = 1
+	gicITSDefaultPhandle         uint32 = 2
 )
+
+const DefaultGICITSPhandle = gicITSDefaultPhandle
 
 type GICVersion int
 
@@ -40,13 +45,17 @@ const (
 )
 
 type BootOptions struct {
-	MemoryBase uint64
-	MemorySize uint64
-	NumCPUs    int
-	GICVersion GICVersion
-	UART       *UARTConfig
-	Console    bool
-	ExtraNodes []fdt.Node
+	MemoryBase                      uint64
+	MemorySize                      uint64
+	NumCPUs                         int
+	GICVersion                      GICVersion
+	UART                            *UARTConfig
+	Console                         bool
+	VirtualTimerPPI                 uint32
+	EnableGICITS                    bool
+	UsePMRShiftForInterruptPriority bool
+	DisableNVMeINTxMasking          bool
+	ExtraNodes                      []fdt.Node
 }
 
 type UARTConfig struct {
@@ -103,15 +112,26 @@ func PrepareBoot(memory []byte, kernelFile []byte, opts BootOptions) (*BootPlan,
 	if err != nil {
 		return nil, err
 	}
-
+	if opts.UsePMRShiftForInterruptPriority {
+		if err := patchAGINTCPriorityShift(memory, kernelFile); err != nil {
+			return nil, err
+		}
+	}
+	if opts.DisableNVMeINTxMasking {
+		if err := patchNVMeINTxMasking(memory, kernelFile); err != nil {
+			return nil, err
+		}
+	}
 	dtb, err := buildDeviceTree(deviceTreeConfig{
-		MemoryBase: opts.MemoryBase,
-		MemorySize: opts.MemorySize,
-		NumCPUs:    opts.NumCPUs,
-		GICVersion: opts.GICVersion,
-		UART:       opts.UART,
-		Console:    opts.Console,
-		ExtraNodes: append([]fdt.Node(nil), opts.ExtraNodes...),
+		MemoryBase:      opts.MemoryBase,
+		MemorySize:      opts.MemorySize,
+		NumCPUs:         opts.NumCPUs,
+		GICVersion:      opts.GICVersion,
+		UART:            opts.UART,
+		Console:         opts.Console,
+		VirtualTimerPPI: opts.VirtualTimerPPI,
+		EnableGICITS:    opts.EnableGICITS,
+		ExtraNodes:      append([]fdt.Node(nil), opts.ExtraNodes...),
 	})
 	if err != nil {
 		return nil, err
@@ -178,14 +198,133 @@ func loadELF(memory []byte, kernel []byte, memoryBase uint64) (uint64, uint64, u
 	return entryGPA, kernelEndVA, kernelEndGPA, nil
 }
 
+func patchAGINTCPriorityShift(memory []byte, kernel []byte) error {
+	f, err := elf.NewFile(bytes.NewReader(kernel))
+	if err != nil {
+		return fmt.Errorf("parse OpenBSD kernel ELF for agintc priority patch: %w", err)
+	}
+	syms, err := f.Symbols()
+	if err != nil {
+		return fmt.Errorf("read OpenBSD kernel symbols for agintc priority patch: %w", err)
+	}
+	if err := patchAGINTCFunctionPriorityShift(memory, syms, "agintc_set_priority", 96); err != nil {
+		return err
+	}
+	if err := patchAGINTCFunctionPriorityShift(memory, syms, "agintc_calc_irq", 768); err != nil {
+		return err
+	}
+	return nil
+}
+
+func patchAGINTCFunctionPriorityShift(memory []byte, syms []elf.Symbol, name string, scanSize uint64) error {
+	var symbol *elf.Symbol
+	for i := range syms {
+		if syms[i].Name == name {
+			symbol = &syms[i]
+			break
+		}
+	}
+	if symbol == nil {
+		return fmt.Errorf("OpenBSD kernel missing %s symbol", name)
+	}
+	if symbol.Value < kernelBaseVA {
+		return fmt.Errorf("OpenBSD %s value %#x below kernel base %#x", name, symbol.Value, uint64(kernelBaseVA))
+	}
+	start := symbol.Value - kernelBaseVA
+	if start >= uint64(len(memory)) {
+		return fmt.Errorf("OpenBSD %s offset %#x exceeds guest memory %#x", name, start, len(memory))
+	}
+
+	code := memory[start:min(start+scanSize, uint64(len(memory)))]
+	old := []byte{0x0a, 0x30, 0x43, 0xb9}     // ldr w10, [x0, #816]  ; sc_prio_shift
+	newInst := []byte{0x0a, 0x34, 0x43, 0xb9} // ldr w10, [x0, #820]  ; sc_pmr_shift
+	idx := bytes.Index(code, old)
+	if idx < 0 {
+		return fmt.Errorf("OpenBSD %s patch instruction not found", name)
+	}
+	if bytes.Index(code[idx+1:], old) >= 0 {
+		return fmt.Errorf("OpenBSD %s patch instruction is ambiguous", name)
+	}
+	copy(code[idx:], newInst)
+	return nil
+}
+
+func patchNVMeINTxMasking(memory []byte, kernel []byte) error {
+	f, err := elf.NewFile(bytes.NewReader(kernel))
+	if err != nil {
+		return fmt.Errorf("parse OpenBSD kernel ELF for nvme intx patch: %w", err)
+	}
+	syms, err := f.Symbols()
+	if err != nil {
+		return fmt.Errorf("read OpenBSD kernel symbols for nvme intx patch: %w", err)
+	}
+	symbol, err := openBSDKernelSymbol(syms, "nvme_intr_intx")
+	if err != nil {
+		return err
+	}
+	start := symbol.Value - kernelBaseVA
+	if start >= uint64(len(memory)) {
+		return fmt.Errorf("OpenBSD nvme_intr_intx offset %#x exceeds guest memory %#x", start, len(memory))
+	}
+	code := memory[start:min(start+192, uint64(len(memory)))]
+	nop := []byte{0x1f, 0x20, 0x03, 0xd5}
+	patterns := [][]byte{
+		{
+			0x00, 0x2c, 0x40, 0xf9, // ldr x0, [x0, #88]
+			0x82, 0x01, 0x80, 0x52, // mov w2, #12 ; NVME_INTMS
+			0x61, 0x32, 0x40, 0xf9, // ldr x1, [x19, #96]
+			0x23, 0x00, 0x80, 0x52, // mov w3, #1
+			0x08, 0x1c, 0x40, 0xf9, // ldr x8, [x0, #56]
+			0x00, 0x01, 0x3f, 0xd6, // blr x8
+		},
+		{
+			0x68, 0x86, 0x45, 0xa9, // ldp x8, x1, [x19, #88]
+			0x09, 0x00, 0x14, 0x2a, // orr w9, w0, w20
+			0x3f, 0x01, 0x00, 0x71, // cmp w9, #0
+			0x02, 0x02, 0x80, 0x52, // mov w2, #16 ; NVME_INTMC
+			0x23, 0x00, 0x80, 0x52, // mov w3, #1
+			0xf3, 0x07, 0x9f, 0x1a, // cset w19, ne
+			0x09, 0x1d, 0x40, 0xf9, // ldr x9, [x8, #56]
+			0xe0, 0x03, 0x08, 0xaa, // mov x0, x8
+			0x20, 0x01, 0x3f, 0xd6, // blr x9
+		},
+	}
+	for _, pattern := range patterns {
+		idx := bytes.Index(code, pattern)
+		if idx < 0 {
+			return fmt.Errorf("OpenBSD nvme_intr_intx patch pattern not found")
+		}
+		if bytes.Index(code[idx+1:], pattern) >= 0 {
+			return fmt.Errorf("OpenBSD nvme_intr_intx patch pattern is ambiguous")
+		}
+		copy(code[idx+len(pattern)-4:], nop)
+	}
+	return nil
+}
+
+func openBSDKernelSymbol(syms []elf.Symbol, name string) (*elf.Symbol, error) {
+	for i := range syms {
+		if syms[i].Name != name {
+			continue
+		}
+		if syms[i].Value < kernelBaseVA {
+			return nil, fmt.Errorf("OpenBSD %s value %#x below kernel base %#x", name, syms[i].Value, uint64(kernelBaseVA))
+		}
+		return &syms[i], nil
+	}
+	return nil, fmt.Errorf("OpenBSD kernel missing %s symbol", name)
+}
+
 type deviceTreeConfig struct {
-	MemoryBase uint64
-	MemorySize uint64
-	NumCPUs    int
-	GICVersion GICVersion
-	UART       *UARTConfig
-	Console    bool
-	ExtraNodes []fdt.Node
+	MemoryBase      uint64
+	MemorySize      uint64
+	NumCPUs         int
+	GICVersion      GICVersion
+	UART            *UARTConfig
+	Console         bool
+	VirtualTimerPPI uint32
+	EnableGICITS    bool
+	ExtraNodes      []fdt.Node
 }
 
 func buildDeviceTree(cfg deviceTreeConfig) ([]byte, error) {
@@ -278,12 +417,16 @@ func buildDeviceTree(cfg deviceTreeConfig) ([]byte, error) {
 			"method":     {Strings: []string{"hvc"}},
 		},
 	})
+	virtualTimerPPI := cfg.VirtualTimerPPI
+	if virtualTimerPPI == 0 {
+		virtualTimerPPI = 11
+	}
 	root.Children = append(root.Children, fdt.Node{
 		Name: "timer",
 		Properties: map[string]fdt.Property{
 			"compatible": {Strings: []string{"arm,armv8-timer"}},
 			"always-on":  {Flag: true},
-			"interrupts": {U32: []uint32{1, 13, 4, 1, 14, 4, 1, 11, 4, 1, 10, 4}},
+			"interrupts": {U32: []uint32{1, 13, 4, 1, 14, 4, 1, virtualTimerPPI, 4, 1, 10, 4}},
 		},
 	})
 	root.Children = append(root.Children, fdt.Node{
@@ -306,6 +449,19 @@ func buildDeviceTree(cfg deviceTreeConfig) ([]byte, error) {
 			defaultGICDistributorBase, defaultGICDistributorSize,
 			defaultGICRedistributorBase, redistributorSize,
 		}}
+		if cfg.EnableGICITS {
+			root.Children[len(root.Children)-1].Children = append(root.Children[len(root.Children)-1].Children, fdt.Node{
+				Name: fmt.Sprintf("msi-controller@%x", defaultGICITSBase),
+				Properties: map[string]fdt.Property{
+					"compatible":     {Strings: []string{"arm,gic-v3-its"}},
+					"msi-controller": {Flag: true},
+					"#msi-cells":     {U32: []uint32{1}},
+					"phandle":        {U32: []uint32{gicITSDefaultPhandle}},
+					"linux,phandle":  {U32: []uint32{gicITSDefaultPhandle}},
+					"reg":            {U64: []uint64{defaultGICITSBase, defaultGICITSSize}},
+				},
+			})
+		}
 	} else {
 		gicProps["compatible"] = fdt.Property{Strings: []string{"arm,gic-400"}}
 		gicProps["reg"] = fdt.Property{U64: []uint64{

--- a/internal/openbsd/guestinit/guestinit.go
+++ b/internal/openbsd/guestinit/guestinit.go
@@ -39,7 +39,7 @@ func BuildForArch(ctx context.Context, cacheDir string, arch string) ([]byte, er
 		return nil, fmt.Errorf("locate OpenBSD guest init package")
 	}
 	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
-	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", out, "./internal/cmd/openbsd-init")
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-ldflags", "-s -w", "-o", out, "./internal/cmd/openbsd-init")
 	cmd.Env = append(os.Environ(), "GOOS=openbsd", "GOARCH="+arch, "CGO_ENABLED=0")
 	cmd.Dir = moduleRoot
 	data, err := cmd.CombinedOutput()

--- a/internal/openbsd/rootfs/rootfs.go
+++ b/internal/openbsd/rootfs/rootfs.go
@@ -178,7 +178,7 @@ func buildManagedRootFromPreparedBase(root imagefs.Directory, closeRoot func() e
 	overlay := imagefs.NewOverlay(root)
 	if err := rootplan.AddFiles(overlay, []rootplan.File{
 		{"/sbin/cc-openbsd-init", 0o755, initBin},
-		{"/etc/fstab", 0o644, []byte("/dev/sd0a / ffs rw 1 1\n")},
+		{"/etc/fstab", 0o644, []byte("/dev/sd0a / ffs rw,noatime 1 1\n")},
 		{"/etc/myname", 0o644, []byte(network.Hostname + "\n")},
 		{"/etc/resolv.conf", 0o644, []byte("nameserver " + network.DNSIPv4 + "\n")},
 		{"/etc/hosts", 0o644, []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
@@ -359,7 +359,7 @@ func versionNoDot(version string) string {
 
 const managedInitScript = `#!/bin/sh
 exec >/dev/console 2>&1
-/sbin/mount -uw / || {
+/sbin/mount -u -o rw,noatime / || {
 	echo OPENBSD_MANAGED_REMOUNT_FAILED
 	while :; do /bin/sleep 3600; done
 }

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -2586,6 +2586,9 @@ func (f *FS) updateIRQLocked() error {
 	}
 	level := f.interruptStatus != 0
 	if f.irqHigh == level {
+		if level {
+			return f.irq.SetIRQ(f.IRQ, true)
+		}
 		return nil
 	}
 	f.irqHigh = level

--- a/internal/virtio/net.go
+++ b/internal/virtio/net.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"j5.nz/cc/internal/fdt"
 )
@@ -18,6 +19,7 @@ const (
 	netQueueSize = 256
 
 	netFeatureCSUM          = uint64(1) << 0
+	vringAvailNoInterrupt   = 1
 	netFeatureMAC           = uint64(1) << 5
 	netFeatureHostTSO4      = uint64(1) << 11
 	netFeatureStatus        = uint64(1) << 16
@@ -86,11 +88,15 @@ type NetBackend interface {
 }
 
 type Net struct {
-	Base       uint64
-	Size       uint64
-	IRQ        uint32
-	MAC        net.HardwareAddr
-	LegacyMMIO bool
+	Base         uint64
+	Size         uint64
+	IRQ          uint32
+	MAC          net.HardwareAddr
+	LegacyMMIO   bool
+	AsyncTX      bool
+	AsyncTXDelay time.Duration
+	NoTXIRQ      bool
+	NoTXUsed     bool
 
 	DisableMergeRX     bool
 	CompleteTXChecksum bool
@@ -114,6 +120,9 @@ type Net struct {
 	scratch4           [4]byte
 	scratch8           [8]byte
 	scratch16          [16]byte
+	asyncTXRunning     bool
+	asyncTXAgain       bool
+	asyncTXErr         error
 }
 
 type netTXPacket struct {
@@ -229,6 +238,12 @@ func (n *Net) Read(addr uint64, size int) (uint64, error) {
 
 func (n *Net) Write(addr uint64, size int, value uint64) error {
 	n.mu.Lock()
+	if n.asyncTXErr != nil {
+		err := n.asyncTXErr
+		n.asyncTXErr = nil
+		n.mu.Unlock()
+		return err
+	}
 
 	offset := addr - n.Base
 	switch offset {
@@ -335,6 +350,11 @@ func (n *Net) Write(addr uint64, size int, value uint64) error {
 	case regQueueNotify:
 		switch value {
 		case netQueueTX:
+			if n.AsyncTX {
+				n.scheduleAsyncTXLocked()
+				n.mu.Unlock()
+				return nil
+			}
 			packetBatch := getNetTXPacketBatch()
 			packets, err := n.processTXLocked(packetBatch[:0])
 			n.mu.Unlock()
@@ -397,6 +417,12 @@ func (n *Net) ReadLegacy(offset uint16, size int) (uint64, error) {
 func (n *Net) WriteLegacy(offset uint16, size int, value uint64) error {
 	n.mu.Lock()
 	n.legacy = true
+	if n.asyncTXErr != nil {
+		err := n.asyncTXErr
+		n.asyncTXErr = nil
+		n.mu.Unlock()
+		return err
+	}
 
 	switch offset {
 	case 4:
@@ -425,6 +451,11 @@ func (n *Net) WriteLegacy(offset uint16, size int, value uint64) error {
 	case 16:
 		switch value {
 		case netQueueTX:
+			if n.AsyncTX {
+				n.scheduleAsyncTXLocked()
+				n.mu.Unlock()
+				return nil
+			}
 			packetBatch := getNetTXPacketBatch()
 			packets, err := n.processTXLocked(packetBatch[:0])
 			n.mu.Unlock()
@@ -450,6 +481,45 @@ func (n *Net) WriteLegacy(offset uint16, size int, value uint64) error {
 	}
 	n.mu.Unlock()
 	return nil
+}
+
+func (n *Net) scheduleAsyncTXLocked() {
+	if n.asyncTXRunning {
+		n.asyncTXAgain = true
+		return
+	}
+	n.asyncTXRunning = true
+	if n.AsyncTXDelay > 0 {
+		time.AfterFunc(n.AsyncTXDelay, n.runAsyncTX)
+		return
+	}
+	go n.runAsyncTX()
+}
+
+func (n *Net) runAsyncTX() {
+	for {
+		packetBatch := getNetTXPacketBatch()
+		n.mu.Lock()
+		packets, err := n.processTXLocked(packetBatch[:0])
+		n.mu.Unlock()
+		if err == nil {
+			err = n.deliverTXPackets(packets)
+		}
+		releaseNetTXPacketBatch(packetBatch, len(packets))
+
+		n.mu.Lock()
+		if err != nil {
+			n.asyncTXErr = err
+		}
+		if !n.asyncTXAgain || err != nil {
+			n.asyncTXRunning = false
+			n.asyncTXAgain = false
+			n.mu.Unlock()
+			return
+		}
+		n.asyncTXAgain = false
+		n.mu.Unlock()
+	}
 }
 
 func (n *Net) EnqueueRxPacket(packet []byte) error {
@@ -617,22 +687,26 @@ func (n *Net) processTXLocked(packets []netTXPacket) ([]netTXPacket, error) {
 			}
 		}
 		releaseNetPacketBuffer(releaseData)
-		if err := n.writeUsedLocked(q, head, 0); err != nil {
-			releaseNetTXPackets(packets)
-			return nil, err
+		if !n.NoTXUsed {
+			if err := n.writeUsedLocked(q, head, 0); err != nil {
+				releaseNetTXPackets(packets)
+				return nil, err
+			}
 		}
 		q.lastAvailIdx++
 	}
-	n.interruptStatus |= intVring
-	if err := n.updateIRQLocked(); err != nil {
-		releaseNetTXPackets(packets)
-		return nil, err
+	if !n.NoTXUsed && !n.NoTXIRQ && !n.queueInterruptSuppressedLocked(q) {
+		n.interruptStatus |= intVring
+		if err := n.updateIRQLocked(); err != nil {
+			releaseNetTXPackets(packets)
+			return nil, err
+		}
 	}
 	return packets, nil
 }
 
 func (n *Net) deliverTXPackets(packets []netTXPacket) error {
-	for _, packet := range packets {
+	for i, packet := range packets {
 		if n.backend == nil {
 			releaseNetPacketBuffer(packet.buffer)
 			continue
@@ -640,6 +714,7 @@ func (n *Net) deliverTXPackets(packets []netTXPacket) error {
 		err := n.backend.HandleTxPacket(packet.packet)
 		releaseNetPacketBuffer(packet.buffer)
 		if err != nil {
+			releaseNetTXPackets(packets[i+1:])
 			return err
 		}
 	}
@@ -681,8 +756,10 @@ func (n *Net) processRXLocked() error {
 		processed = true
 	}
 	if processed {
-		n.interruptStatus |= intVring
-		return n.updateIRQLocked()
+		if !n.queueInterruptSuppressedLocked(q) {
+			n.interruptStatus |= intVring
+			return n.updateIRQLocked()
+		}
 	}
 	return nil
 }
@@ -712,8 +789,11 @@ func (n *Net) processOneRXPacketLocked(packet []byte) (bool, error) {
 		return false, err
 	}
 	q.lastAvailIdx++
-	n.interruptStatus |= intVring
-	return true, n.updateIRQLocked()
+	if !n.queueInterruptSuppressedLocked(q) {
+		n.interruptStatus |= intVring
+		return true, n.updateIRQLocked()
+	}
+	return true, nil
 }
 
 func (n *Net) readChainLocked(q *queue, head uint16, writable bool) ([]byte, error) {
@@ -867,6 +947,18 @@ func (n *Net) writeUsedLocked(q *queue, head uint16, usedLen uint32) error {
 	}
 	binary.LittleEndian.PutUint16(n.scratch2[:], q.usedIdx)
 	return n.mem.WriteIPA(q.usedAddr+2, n.scratch2[:])
+}
+
+func (n *Net) queueInterruptSuppressedLocked(q *queue) bool {
+	if q == nil || n.mem == nil || q.availAddr == 0 {
+		return false
+	}
+	header, err := n.mem.ReadIPA(q.availAddr, 2)
+	if err != nil || len(header) < 2 {
+		return false
+	}
+	flags := binary.LittleEndian.Uint16(header)
+	return flags&vringAvailNoInterrupt != 0
 }
 
 func (n *Net) selectedQueueLocked() *queue {

--- a/internal/virtio/net_test.go
+++ b/internal/virtio/net_test.go
@@ -78,6 +78,41 @@ func TestNetLegacyTXStripsTenByteHeader(t *testing.T) {
 	}
 }
 
+func TestNetLegacyTXHonorsAvailNoInterrupt(t *testing.T) {
+	mem := make(testGuestMemory, 0x20000)
+	backend := &testNetBackend{}
+	irq := &testIRQ{}
+	dev := NewNet(0, 0x1000, 11, nil, backend)
+	dev.DisableMergeRX = true
+	dev.Attach(mem, irq)
+
+	if err := dev.WriteLegacy(14, 2, netQueueTX); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.WriteLegacy(8, 4, 0x10); err != nil {
+		t.Fatal(err)
+	}
+	packet := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02, 0x08, 0x06}
+	copy(mem[0x2000+netHeaderLen:], packet)
+	writeDesc(mem, 0x10000, 0x2000, uint32(netHeaderLen+len(packet)), 0, 0)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize:], vringAvailNoInterrupt)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+2:], 1)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+4:], 0)
+
+	if err := dev.WriteLegacy(16, 2, netQueueTX); err != nil {
+		t.Fatal(err)
+	}
+	if len(backend.packets) != 1 {
+		t.Fatalf("packets = %d", len(backend.packets))
+	}
+	if irq.level || dev.IRQAsserted() {
+		t.Fatalf("TX queue asserted IRQ despite avail no-interrupt flag")
+	}
+	if isr, err := dev.ReadLegacy(19, 1); err != nil || isr != 0 {
+		t.Fatalf("legacy ISR = %#x, %v; want 0, nil", isr, err)
+	}
+}
+
 func TestNetTXCanForceTwelveByteHeader(t *testing.T) {
 	mem := make(testGuestMemory, 0x20000)
 	backend := &testNetBackend{}
@@ -140,6 +175,40 @@ func TestNetLegacyRXWritesTenByteHeader(t *testing.T) {
 	}
 	if !bytes.Equal(mem[0x3000+netHeaderLen:0x3000+netHeaderLen+uint64(len(packet))], packet) {
 		t.Fatalf("packet payload was not written after ten-byte header")
+	}
+}
+
+func TestNetLegacyRXHonorsAvailNoInterrupt(t *testing.T) {
+	mem := make(testGuestMemory, 0x20000)
+	irq := &testIRQ{}
+	dev := NewNet(0, 0x1000, 11, nil, nil)
+	dev.DisableMergeRX = true
+	dev.Attach(mem, irq)
+
+	if err := dev.WriteLegacy(14, 2, netQueueRX); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.WriteLegacy(8, 4, 0x10); err != nil {
+		t.Fatal(err)
+	}
+	writeDesc(mem, 0x10000, 0x3000, 2048, descFWrite, 0)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize:], vringAvailNoInterrupt)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+2:], 1)
+	binary.LittleEndian.PutUint16(mem[0x10000+16*netQueueSize+4:], 0)
+
+	packet := []byte{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x08, 0x00}
+	if err := dev.EnqueueRxPacket(packet); err != nil {
+		t.Fatal(err)
+	}
+	if irq.level || dev.IRQAsserted() {
+		t.Fatalf("RX queue asserted IRQ despite avail no-interrupt flag")
+	}
+	usedLen := binary.LittleEndian.Uint32(mem[0x10000+16*netQueueSize+4096+8:])
+	if usedLen != uint32(netHeaderLen+len(packet)) {
+		t.Fatalf("used len = %d, want %d", usedLen, netHeaderLen+len(packet))
+	}
+	if isr, err := dev.ReadLegacy(19, 1); err != nil || isr != 0 {
+		t.Fatalf("legacy ISR = %#x, %v; want 0, nil", isr, err)
 	}
 }
 

--- a/internal/virtio/vsock.go
+++ b/internal/virtio/vsock.go
@@ -726,6 +726,9 @@ func (v *Vsock) updateIRQLocked() error {
 	}
 	level := v.interruptStatus != 0
 	if v.irqHigh == level {
+		if level {
+			return v.irq.SetIRQ(v.IRQ, true)
+		}
 		return nil
 	}
 	v.irqHigh = level

--- a/internal/vm/backend_builtin_bsd_windows_arm64.go
+++ b/internal/vm/backend_builtin_bsd_windows_arm64.go
@@ -1,0 +1,310 @@
+//go:build windows && arm64
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/hv/whp"
+	"j5.nz/cc/internal/imagefs"
+	managedguest "j5.nz/cc/internal/managed/guest"
+	"j5.nz/cc/internal/managed/machine"
+	managedruntime "j5.nz/cc/internal/managed/runtime"
+	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/nfs"
+	"j5.nz/cc/internal/vm/builtin"
+	hostmanaged "j5.nz/cc/internal/vm/host/managed"
+	"j5.nz/cc/internal/vm/netstate"
+)
+
+func builtinGuestForImage(image string) (managedguest.Profile, bool) {
+	return builtin.GuestForImage(image)
+}
+
+func isBuiltinGuestImage(image string) bool {
+	return builtin.IsGuestImage(image)
+}
+
+func (b *runtimeBackend) startBuiltinGuestProfile(ctx context.Context, profile managedguest.Profile, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	switch profile.Canonical {
+	case managedguest.OpenBSDImageName:
+		return b.startOpenBSDStream(ctx, req, onEvent)
+	case managedguest.FreeBSDImageName:
+		return b.startFreeBSDStream(ctx, req, onEvent)
+	case managedguest.NetBSDImageName:
+		return b.startNetBSDStream(ctx, req, onEvent)
+	default:
+		return nil, fmt.Errorf("managed guest profile %q is not supported on windows/arm64", profile.Canonical)
+	}
+}
+
+func (b *runtimeBackend) startBuiltinGuestStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return nil, false, nil
+	}
+	req.Image = profile.Canonical
+	inst, err := b.startBuiltinGuestProfile(ctx, profile, req, onEvent)
+	return inst, true, err
+}
+
+func (b *runtimeBackend) startBuiltinGuestBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return nil, false, nil
+	}
+	inst, err := b.startBuiltinGuestProfile(ctx, profile, client.CreateInstanceRequest{
+		ID:             req.ID,
+		Image:          profile.Canonical,
+		InitSystem:     req.InitSystem,
+		Kernel:         req.Kernel,
+		Shares:         append([]client.ShareMount(nil), req.Shares...),
+		Network:        req.Network,
+		KernelModules:  append([]string(nil), req.KernelModules...),
+		MemoryMB:       req.MemoryMB,
+		CPUs:           req.CPUs,
+		NestedVirt:     req.NestedVirt,
+		Dmesg:          req.Dmesg,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}, onEvent)
+	return inst, true, err
+}
+
+func (b *runtimeBackend) runBuiltinGuest(ctx context.Context, req client.RunRequest) (client.ExecResponse, bool, error) {
+	profile, ok := builtinGuestForImage(req.Image)
+	if !ok {
+		return client.ExecResponse{}, false, nil
+	}
+	inst, err := b.startBuiltinGuestProfile(ctx, profile, client.CreateInstanceRequest{
+		ID:             req.ID,
+		Image:          profile.Canonical,
+		InitSystem:     req.InitSystem,
+		Network:        req.Network,
+		MemoryMB:       req.MemoryMB,
+		CPUs:           req.CPUs,
+		Dmesg:          req.Dmesg,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}, nil)
+	if err != nil {
+		return client.ExecResponse{}, true, err
+	}
+	defer inst.Close()
+	if len(req.Command) == 0 {
+		if history, ok := inst.(consoleHistoryProvider); ok {
+			output, _ := history.ConsoleHistory(ctx)
+			return client.ExecResponse{ExitCode: 0, Output: output}, true, nil
+		}
+		return client.ExecResponse{}, true, nil
+	}
+	resp, err := inst.Exec(ctx, runExecRequest(req))
+	return resp, true, err
+}
+
+func (b *runtimeBackend) startOpenBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	return b.startBSDManagedStream(ctx, req, onEvent, builtin.OpenBSDDefinitionForArch(b.guestInitCache, "arm64"))
+}
+
+func managedBSDNetworkConfig(cfg *client.NetworkConfig) *client.NetworkConfig {
+	if cfg == nil {
+		return &client.NetworkConfig{Enabled: true, AllowInternet: true}
+	}
+	copyCfg := *cfg
+	return &copyCfg
+}
+
+func (b *runtimeBackend) startFreeBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	return b.startBSDManagedStream(ctx, req, onEvent, builtin.FreeBSDDefinitionForArch(b.guestInitCache, "arm64"))
+}
+
+func (b *runtimeBackend) startNetBSDStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	return b.startBSDManagedStream(ctx, req, onEvent, builtin.NetBSDDefinitionForArch(b.guestInitCache, "evbarm-aarch64"))
+}
+
+func (b *runtimeBackend) startBSDManagedStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error, def builtin.BSDDefinition) (inst Instance, err error) {
+	if b == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	displayName := def.Profile.Name
+	if displayName == "" {
+		displayName = def.BootKind
+	}
+	if req.Network != nil && !req.Network.Enabled {
+		return nil, fmt.Errorf("%s runtime requires virtio-net for the managed control channel", displayName)
+	}
+	if req.CPUs > 1 {
+		return nil, fmt.Errorf("%s runtime currently supports one vCPU", displayName)
+	}
+	if req.NestedVirt {
+		return nil, fmt.Errorf("%s runtime does not support nested virtualization", displayName)
+	}
+	if def.BuildArtifact == nil {
+		return nil, fmt.Errorf("%s runtime root builder is not configured", displayName)
+	}
+	network, err := newWindowsARM64NetworkRuntime(managedBSDNetworkConfig(req.Network))
+	if err != nil {
+		return nil, err
+	}
+	if network == nil {
+		return nil, fmt.Errorf("%s runtime requires virtio-net for the managed control channel", displayName)
+	}
+	defer func() {
+		if err != nil {
+			_ = network.Close()
+		}
+	}()
+	networkSpec := machine.NetworkSpec{
+		GuestIPv4:   network.GuestAddress(),
+		GatewayIPv4: "10.42.0.1",
+		GatewayMAC:  defaultGatewayMAC,
+		DNSIPv4:     "10.42.0.1",
+		Hostname:    def.Hostname,
+		Interface:   def.Interface,
+		MAC:         network.mac.String(),
+	}
+	artifact, err := def.BuildArtifact(ctx, def.CacheDir, networkSpec)
+	if err != nil {
+		return nil, err
+	}
+	started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+		Profile: def.Profile,
+		Host:    whp.Host{},
+		Spec: machine.Spec{
+			Guest:    def.Profile.Name,
+			Arch:     "arm64",
+			MemoryMB: req.MemoryMB,
+			Dmesg:    req.Dmesg,
+			Boot:     machine.BootSpec{Kind: def.BootKind},
+			Network:  &networkSpec,
+		},
+		Artifact: artifact,
+		Attachments: whp.BSDManagedAttachments{
+			GuestIPv4: network.ip,
+			GuestMAC:  network.mac,
+			NetDevice: network.Device(),
+			NetStack:  network.stack,
+		},
+	}, onEvent)
+	if err != nil {
+		_ = artifact.Close()
+		return nil, err
+	}
+	nfsServer := nfs.New(network.stack)
+	if err := nfsServer.Start(); err != nil {
+		_ = started.Session.Close()
+		_ = artifact.Close()
+		return nil, err
+	}
+	inst = newWindowsBSDInstance(windowsBSDInstanceConfig{
+		OSName:       displayName,
+		Session:      started.Session,
+		CloseRuntime: artifact.Close,
+		Root:         started.Artifact.RootFS,
+		Network:      network,
+		NFS:          nfsServer,
+		Capabilities: def.Profile.Caps,
+	})
+	for _, share := range req.Shares {
+		if err := inst.AddShare(ctx, share); err != nil {
+			_ = inst.Close()
+			return nil, err
+		}
+	}
+	return inst, nil
+}
+
+func builtinGuestCapabilities(image string) guestCapabilities {
+	profile, ok := builtinGuestForImage(image)
+	if !ok {
+		return guestCapabilities{}
+	}
+	return profile.Caps
+}
+
+type windowsBSDInstanceConfig struct {
+	OSName       string
+	Session      managedsession.Session
+	CloseRuntime func() error
+	Root         imagefs.Directory
+	Network      *windowsNetworkRuntime
+	NFS          *nfs.Server
+	Capabilities guestCapabilities
+}
+
+type windowsBSDInstance struct {
+	*managedInstanceCore
+	session      managedsession.Session
+	closeRuntime func() error
+	network      *windowsNetworkRuntime
+	nfs          *nfs.Server
+	osName       string
+}
+
+func newWindowsBSDInstance(cfg windowsBSDInstanceConfig) *windowsBSDInstance {
+	return &windowsBSDInstance{
+		managedInstanceCore: hostmanaged.NewCore(hostmanaged.Config{
+			OSName:       cfg.OSName,
+			Session:      cfg.Session,
+			Root:         cfg.Root,
+			BaseEnv:      builtin.EffectiveExecEnv(nil, nil, false),
+			WorkDir:      "/",
+			Capabilities: cfg.Capabilities,
+			Env:          builtin.EffectiveExecEnv,
+		}),
+		session:      cfg.Session,
+		closeRuntime: cfg.CloseRuntime,
+		network:      cfg.Network,
+		nfs:          cfg.NFS,
+		osName:       cfg.OSName,
+	}
+}
+
+func (i *windowsBSDInstance) AddShare(ctx context.Context, share client.ShareMount) error {
+	if i == nil || i.nfs == nil {
+		return i.managedInstanceCore.AddShare(ctx, share)
+	}
+	exp, err := i.nfs.AddShare(share)
+	if err != nil {
+		return err
+	}
+	return nfs.MountShare(ctx, i.osName, i.Exec, exp)
+}
+
+func (i *windowsBSDInstance) AddPortForward(ctx context.Context, forward client.PortForward) error {
+	if i == nil || i.network == nil {
+		return netstate.AddManagedNetworkPortForward(ctx, nil, forward)
+	}
+	return netstate.AddManagedNetworkPortForward(ctx, i.network.networkRuntime, forward)
+}
+
+func (i *windowsBSDInstance) AllowServiceProxyPort(ctx context.Context, port int) error {
+	if i == nil || i.network == nil {
+		return netstate.AllowManagedNetworkServiceProxyPort(ctx, nil, port)
+	}
+	return netstate.AllowManagedNetworkServiceProxyPort(ctx, i.network.networkRuntime, port)
+}
+
+func (i *windowsBSDInstance) NetworkIPv4() string {
+	if i == nil || i.network == nil {
+		return ""
+	}
+	return netstate.IPv4(i.network.networkRuntime, "")
+}
+
+func (i *windowsBSDInstance) Close() error {
+	if i == nil {
+		return nil
+	}
+	return hostmanaged.CloseSession(i.session, func() error {
+		if i.nfs != nil {
+			return i.nfs.Close()
+		}
+		return nil
+	}, func() error {
+		if i.network != nil {
+			return i.network.Close()
+		}
+		return nil
+	}, i.closeRuntime)
+}

--- a/internal/vm/backend_builtin_bsd_windows_arm64_test.go
+++ b/internal/vm/backend_builtin_bsd_windows_arm64_test.go
@@ -1,0 +1,54 @@
+//go:build windows && arm64
+
+package vm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"j5.nz/cc/client"
+)
+
+func TestWindowsARM64RuntimeBuiltinBSDDoesNotFallThroughToImageStore(t *testing.T) {
+	backend := NewRuntimeBackend(nil, nil, t.TempDir())
+	for _, tc := range []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{
+			name: "start",
+			run: func(ctx context.Context) error {
+				_, err := backend.StartStream(ctx, client.CreateInstanceRequest{Image: "@freebsd", Network: &client.NetworkConfig{Enabled: false}}, nil)
+				return err
+			},
+		},
+		{
+			name: "start_blank",
+			run: func(ctx context.Context) error {
+				_, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{Image: "@openbsd", Network: &client.NetworkConfig{Enabled: false}}, nil)
+				return err
+			},
+		},
+		{
+			name: "run",
+			run: func(ctx context.Context) error {
+				_, err := backend.Run(ctx, client.RunRequest{Image: "@netbsd", Network: &client.NetworkConfig{Enabled: false}})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run(context.Background())
+			if err == nil {
+				t.Fatal("built-in BSD request unexpectedly succeeded")
+			}
+			if strings.Contains(err.Error(), "image store") || strings.Contains(err.Error(), "image.json") {
+				t.Fatalf("built-in BSD request fell through to image store: %v", err)
+			}
+			if !strings.Contains(err.Error(), "requires virtio-net") {
+				t.Fatalf("built-in BSD request error = %v, want managed BSD network validation", err)
+			}
+		})
+	}
+}

--- a/internal/vm/backend_other.go
+++ b/internal/vm/backend_other.go
@@ -1,4 +1,4 @@
-//go:build (!darwin || !arm64) && (!linux || (!arm64 && !amd64)) && (!windows || !amd64)
+//go:build (!darwin || !arm64) && (!linux || (!arm64 && !amd64)) && (!windows || (!amd64 && !arm64))
 
 package vm
 

--- a/internal/vm/backend_windows_arm64.go
+++ b/internal/vm/backend_windows_arm64.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -53,6 +54,14 @@ func (b *runtimeBackend) StartBlank(ctx context.Context, req client.StartInstanc
 }
 
 func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if inst, ok, err := b.startBuiltinGuestStream(ctx, req, onEvent); ok || err != nil {
+		return inst, err
+	}
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != "" || os.Getenv("CC_WHP_BSD_TIMING") != ""
+	startTime := time.Now()
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +0s: StartStream image=%q\n", req.Image)
+	}
 	if b == nil || b.kernel == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
@@ -63,9 +72,15 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: kernel read bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(kernel))
+	}
 	image, err := b.images.Open(req.Image)
 	if err != nil {
 		return nil, err
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: image opened\n", time.Since(startTime).Round(time.Millisecond))
 	}
 	if err := ensureWindowsARM64Image(image); err != nil {
 		return nil, err
@@ -75,9 +90,15 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: planned modules=%d\n", time.Since(startTime).Round(time.Millisecond), len(modules))
+	}
 	qemuX8664, err := PrepareAMD64Emulator(ctx, image, b.kernel.ExtractPackageFile)
 	if err != nil {
 		return nil, err
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: amd64 emulator prepared=%v\n", time.Since(startTime).Round(time.Millisecond), qemuX8664 != "")
 	}
 	network, err := newWindowsARM64NetworkRuntime(req.Network)
 	if err != nil {
@@ -98,9 +119,15 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: fs devices built=%d\n", time.Since(startTime).Round(time.Millisecond), len(fsdevs))
+	}
 	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "arm64")
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: guest init bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(initBin))
 	}
 	workDir := image.Config.WorkingDir
 	if workDir == "" {
@@ -118,6 +145,9 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
 	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: initramfs bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(initrd))
+	}
 	started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
 		Profile: managedguest.LinuxProfile,
 		Host:    whp.Host{},
@@ -133,6 +163,9 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	}, onEvent)
 	if err != nil {
 		return nil, err
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: managed service ready\n", time.Since(startTime).Round(time.Millisecond))
 	}
 	return &windowsInstance{
 		managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(image.Config.Env), workDir),
@@ -219,6 +252,9 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 }
 
 func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client.ExecResponse, error) {
+	if resp, ok, err := b.runBuiltinGuest(ctx, req); ok || err != nil {
+		return resp, err
+	}
 	inst, err := b.StartStream(ctx, client.CreateInstanceRequest{
 		Image:         req.Image,
 		InitSystem:    req.InitSystem,

--- a/internal/vm/backend_windows_arm64.go
+++ b/internal/vm/backend_windows_arm64.go
@@ -1,0 +1,605 @@
+//go:build windows && arm64
+
+package vm
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/guestinit"
+	"j5.nz/cc/internal/hv/whp"
+	"j5.nz/cc/internal/imagefs"
+	"j5.nz/cc/internal/kernel/alpine"
+	managedguest "j5.nz/cc/internal/managed/guest"
+	"j5.nz/cc/internal/managed/machine"
+	"j5.nz/cc/internal/managed/rootartifact"
+	managedruntime "j5.nz/cc/internal/managed/runtime"
+	managedsession "j5.nz/cc/internal/managed/session"
+	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vm/execplan"
+	vmhost "j5.nz/cc/internal/vm/host"
+	hostmanaged "j5.nz/cc/internal/vm/host/managed"
+	"j5.nz/cc/internal/vm/mounts"
+	"j5.nz/cc/internal/vm/netstate"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const windowsInitReadyMarker = vmruntime.InstanceReadyMarker
+
+type runtimeBackend struct {
+	vmhost.UnsupportedBackend
+	kernel         *alpine.Manager
+	images         *oci.Store
+	guestInitCache string
+}
+
+func NewRuntimeBackend(kernel *alpine.Manager, images *oci.Store, guestInitCache string) Backend {
+	return &runtimeBackend{kernel: kernel, images: images, guestInitCache: guestInitCache}
+}
+
+func (b *runtimeBackend) Start(ctx context.Context, req client.CreateInstanceRequest) (Instance, error) {
+	return b.StartStream(ctx, req, nil)
+}
+
+func (b *runtimeBackend) StartBlank(ctx context.Context, req client.StartInstanceRequest) (Instance, error) {
+	return b.StartBlankStream(ctx, req, nil)
+}
+
+func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if b == nil || b.kernel == nil || b.images == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	if req.CPUs > 1 {
+		return nil, fmt.Errorf("windows arm64 runtime currently supports only 1 CPU")
+	}
+	kernel, err := b.kernel.ReadKernel()
+	if err != nil {
+		return nil, err
+	}
+	image, err := b.images.Open(req.Image)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureWindowsARM64Image(image); err != nil {
+		return nil, err
+	}
+	image = withWindowsRuntimeMountDirs(image)
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(image), windowsRuntimeModuleMap())
+	if err != nil {
+		return nil, err
+	}
+	qemuX8664, err := PrepareAMD64Emulator(ctx, image, b.kernel.ExtractPackageFile)
+	if err != nil {
+		return nil, err
+	}
+	network, err := newWindowsARM64NetworkRuntime(req.Network)
+	if err != nil {
+		return nil, err
+	}
+	if network != nil {
+		defer func() {
+			if err != nil {
+				_ = network.Close()
+			}
+		}()
+	}
+	fsdevs, rootFS, err := arm64vm.BuildFSDevices(vmruntime.RunRequest{
+		Image:             image,
+		AMD64EmulatorPath: qemuX8664,
+		Shares:            mounts.ConvertShareMounts(req.Shares),
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "arm64")
+	if err != nil {
+		return nil, fmt.Errorf("build guest init: %w", err)
+	}
+	workDir := image.Config.WorkingDir
+	if workDir == "" {
+		workDir = "/"
+	}
+	initCfg := windowsGuestInitConfig(modules, true)
+	initCfg.RootFSTag = vmruntime.RootFSTag
+	if qemuX8664 != "" {
+		initCfg.EmulatorTag = vmruntime.EmulatorTag
+	}
+	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
+	initCfg.WorkDir = workDir
+	initCfg.Network = windowsNetworkGuestInitConfig(network)
+	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build initramfs: %w", err)
+	}
+	started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+		Profile: managedguest.LinuxProfile,
+		Host:    whp.Host{},
+		Spec:    windowsLinuxMachineSpec(req.MemoryMB, req.CPUs, req.Dmesg),
+		Artifact: rootartifact.Artifact{
+			Kernel: kernel,
+			Initrd: initrd,
+		},
+		Attachments: whp.LinuxManagedAttachments{
+			FSDevices: fsdevs,
+			NetDevice: windowsNetworkDevice(network),
+		},
+	}, onEvent)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsInstance{
+		managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(image.Config.Env), workDir),
+		image:               image,
+		rootFS:              rootFS,
+		fsdevs:              fsdevs,
+		network:             network,
+		dmesg:               req.Dmesg,
+	}, nil
+}
+
+func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	if strings.TrimSpace(req.Image) != "" {
+		return b.StartStream(ctx, client.CreateInstanceRequest{
+			ID:             req.ID,
+			Image:          req.Image,
+			InitSystem:     req.InitSystem,
+			Kernel:         req.Kernel,
+			Network:        req.Network,
+			KernelModules:  append([]string(nil), req.KernelModules...),
+			MemoryMB:       req.MemoryMB,
+			CPUs:           req.CPUs,
+			NestedVirt:     req.NestedVirt,
+			Dmesg:          req.Dmesg,
+			TimeoutSeconds: req.TimeoutSeconds,
+		}, onEvent)
+	}
+	if b == nil || b.kernel == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	kernel, err := b.kernel.ReadKernel()
+	if err != nil {
+		return nil, err
+	}
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(nil), windowsRuntimeModuleMap())
+	if err != nil {
+		return nil, err
+	}
+	network, err := newWindowsARM64NetworkRuntime(req.Network)
+	if err != nil {
+		return nil, err
+	}
+	rootFSBackend := virtio.NewImageFS(blankWindowsRuntimeRootFS(), "")
+	fsdevs, rootFS, err := arm64vm.BuildFSDevices(vmruntime.RunRequest{RootFS: rootFSBackend}, nil)
+	if err != nil {
+		return nil, err
+	}
+	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "arm64")
+	if err != nil {
+		return nil, fmt.Errorf("build guest init: %w", err)
+	}
+	initCfg := windowsGuestInitConfig(modules, true)
+	initCfg.RootFSTag = vmruntime.RootFSTag
+	initCfg.Env = vmruntime.WithDefaultEnv(nil)
+	initCfg.WorkDir = "/"
+	initCfg.Network = windowsNetworkGuestInitConfig(network)
+	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build initramfs: %w", err)
+	}
+	started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+		Profile: managedguest.LinuxProfile,
+		Host:    whp.Host{},
+		Spec:    windowsLinuxMachineSpec(req.MemoryMB, req.CPUs, req.Dmesg),
+		Artifact: rootartifact.Artifact{
+			Kernel: kernel,
+			Initrd: initrd,
+		},
+		Attachments: whp.LinuxManagedAttachments{
+			FSDevices: fsdevs,
+			NetDevice: windowsNetworkDevice(network),
+		},
+	}, onEvent)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsInstance{
+		managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(nil), "/"),
+		rootFS:              rootFS,
+		fsdevs:              fsdevs,
+		network:             network,
+		dmesg:               req.Dmesg,
+	}, nil
+}
+
+func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client.ExecResponse, error) {
+	inst, err := b.StartStream(ctx, client.CreateInstanceRequest{
+		Image:         req.Image,
+		InitSystem:    req.InitSystem,
+		Kernel:        req.Kernel,
+		Shares:        append([]client.ShareMount(nil), req.Shares...),
+		Network:       req.Network,
+		KernelModules: append([]string(nil), req.KernelModules...),
+		MemoryMB:      req.MemoryMB,
+		CPUs:          req.CPUs,
+		NestedVirt:    req.NestedVirt,
+		Dmesg:         req.Dmesg,
+	}, nil)
+	if err != nil {
+		return client.ExecResponse{}, err
+	}
+	defer inst.Close()
+	if len(req.Command) == 0 {
+		return client.ExecResponse{ExitCode: 0}, nil
+	}
+	return inst.Exec(ctx, runExecRequest(req))
+}
+
+func (b *runtimeBackend) RunStream(ctx context.Context, req client.RunRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	inst, err := b.StartStream(ctx, client.CreateInstanceRequest{
+		Image:         req.Image,
+		InitSystem:    req.InitSystem,
+		Kernel:        req.Kernel,
+		Shares:        append([]client.ShareMount(nil), req.Shares...),
+		Network:       req.Network,
+		KernelModules: append([]string(nil), req.KernelModules...),
+		MemoryMB:      req.MemoryMB,
+		CPUs:          req.CPUs,
+		NestedVirt:    req.NestedVirt,
+		Dmesg:         req.Dmesg,
+	}, nil)
+	if err != nil {
+		return err
+	}
+	defer inst.Close()
+	return inst.ExecStream(ctx, runExecRequest(req), inputs, onEvent)
+}
+
+func (b *runtimeBackend) RunInInstance(ctx context.Context, inst Instance, runningImage string, req client.RunRequest) (client.ExecResponse, error) {
+	targetImage := strings.TrimSpace(req.Image)
+	if targetImage == "" || targetImage == runningImage {
+		if err := mounts.AddRuntimeShares(ctx, inst, req.Shares); err != nil {
+			return client.ExecResponse{}, err
+		}
+		return inst.Exec(ctx, runExecRequest(req))
+	}
+
+	if err := execplan.CheckAlternateImageExec(inst); err != nil {
+		return client.ExecResponse{}, err
+	}
+	session, ok := inst.(*windowsInstance)
+	if !ok {
+		return client.ExecResponse{}, fmt.Errorf("running instance does not support image mounts")
+	}
+	if b == nil || b.images == nil {
+		return client.ExecResponse{}, fmt.Errorf("runtime backend is not configured")
+	}
+	image, err := b.images.Open(targetImage)
+	if err != nil {
+		return client.ExecResponse{}, err
+	}
+	if err := ensureWindowsARM64Image(image); err != nil {
+		return client.ExecResponse{}, err
+	}
+	image = withWindowsRuntimeMountDirs(image)
+	mountPath := windowsImageMountPath(targetImage)
+	if err := mounts.MountAlternateImageWithShares(ctx, inst, session, mountPath, image, req.Shares); err != nil {
+		return client.ExecResponse{}, err
+	}
+
+	execReq, err := execplan.ResolveRunRequest(req, mountPath, execplan.Resolver{
+		Root:           image.RootFS,
+		BaseEnv:        image.Config.Env,
+		DefaultWorkDir: image.Config.WorkingDir,
+		Env:            windowsEffectiveExecEnv,
+	})
+	if err != nil {
+		return client.ExecResponse{}, err
+	}
+	return inst.Exec(ctx, execReq)
+}
+
+func (b *runtimeBackend) RunInInstanceStream(ctx context.Context, inst Instance, runningImage string, req client.RunRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	targetImage := strings.TrimSpace(req.Image)
+	if targetImage == "" || targetImage == runningImage {
+		if err := mounts.AddRuntimeShares(ctx, inst, req.Shares); err != nil {
+			return err
+		}
+		return inst.ExecStream(ctx, runExecRequest(req), inputs, onEvent)
+	}
+
+	if err := execplan.CheckAlternateImageExec(inst); err != nil {
+		return err
+	}
+	session, ok := inst.(*windowsInstance)
+	if !ok {
+		return fmt.Errorf("running instance does not support image mounts")
+	}
+	if b == nil || b.images == nil {
+		return fmt.Errorf("runtime backend is not configured")
+	}
+	image, err := b.images.Open(targetImage)
+	if err != nil {
+		return err
+	}
+	if err := ensureWindowsARM64Image(image); err != nil {
+		return err
+	}
+	image = withWindowsRuntimeMountDirs(image)
+	mountPath := windowsImageMountPath(targetImage)
+	if err := mounts.MountAlternateImageWithShares(ctx, inst, session, mountPath, image, req.Shares); err != nil {
+		return err
+	}
+
+	execReq, err := execplan.ResolveRunRequest(req, mountPath, execplan.Resolver{
+		Root:           image.RootFS,
+		BaseEnv:        image.Config.Env,
+		DefaultWorkDir: image.Config.WorkingDir,
+		Env:            windowsEffectiveExecEnv,
+	})
+	if err != nil {
+		return err
+	}
+	return inst.ExecStream(ctx, execReq, inputs, onEvent)
+}
+
+func (b *runtimeBackend) ExecInInstanceStream(ctx context.Context, inst Instance, runningImage string, req client.ExecRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	targetImage := strings.TrimSpace(req.Image)
+	req.Image = ""
+	if targetImage == "" || targetImage == runningImage {
+		return inst.ExecStream(ctx, req, inputs, onEvent)
+	}
+
+	if err := execplan.CheckAlternateImageExec(inst); err != nil {
+		return err
+	}
+	session, ok := inst.(*windowsInstance)
+	if !ok {
+		return fmt.Errorf("running instance does not support image mounts")
+	}
+	if b == nil || b.images == nil {
+		return fmt.Errorf("runtime backend is not configured")
+	}
+	image, err := b.images.Open(targetImage)
+	if err != nil {
+		return err
+	}
+	if err := ensureWindowsARM64Image(image); err != nil {
+		return err
+	}
+	image = withWindowsRuntimeMountDirs(image)
+	mountPath := windowsImageMountPath(targetImage)
+	if err := mounts.MountAlternateImageWithShares(ctx, inst, session, mountPath, image, nil); err != nil {
+		return err
+	}
+	req.RootDir = rootDirWithinMount(mountPath, req.RootDir)
+	return inst.ExecStream(ctx, req, inputs, onEvent)
+}
+
+func ensureWindowsARM64Image(image *oci.Image) error {
+	if image == nil {
+		return nil
+	}
+	arch := strings.TrimSpace(image.Architecture)
+	if arch == "" || arch == "arm64" || arch == "amd64" {
+		return nil
+	}
+	name := strings.TrimSpace(image.Name)
+	if name == "" {
+		name = "image"
+	}
+	return fmt.Errorf("windows/arm64 runtime supports only arm64 or amd64 images; %s is %s", name, arch)
+}
+
+type windowsInstance struct {
+	*managedInstanceCore
+	image   *oci.Image
+	rootFS  virtio.ShareMounter
+	fsdevs  []*virtio.FS
+	dmesg   bool
+	network *windowsNetworkRuntime
+	mounts  mounts.State
+}
+
+func (i *windowsInstance) ManagedCapabilities() guestCapabilities {
+	return managedguest.LinuxProfile.Caps
+}
+
+func newWindowsManagedCore(session managedsession.Session, image *oci.Image, baseEnv []string, workDir string) *managedInstanceCore {
+	var root imagefs.Directory
+	if image != nil {
+		root = image.RootFS
+	}
+	return hostmanaged.NewCore(hostmanaged.Config{
+		OSName:         "Linux",
+		Session:        session,
+		Root:           root,
+		BaseEnv:        baseEnv,
+		WorkDir:        workDir,
+		Capabilities:   managedguest.LinuxProfile.Caps,
+		Env:            windowsEffectiveExecEnv,
+		MissingRootErr: "running instance does not have a default image root filesystem",
+	})
+}
+
+func windowsLinuxMachineSpec(memoryMB uint64, cpus int, dmesg bool) machine.Spec {
+	return machine.Spec{
+		Guest:    "Linux",
+		Arch:     "arm64",
+		MemoryMB: memoryMB,
+		CPUs:     cpus,
+		Dmesg:    dmesg,
+		Boot:     machine.BootSpec{Kind: "linux"},
+		Control:  machine.ControlSpec{Kind: "vsock", Port: vmruntime.ControlPort},
+	}
+}
+
+func (i *windowsInstance) core() *managedInstanceCore {
+	if i == nil {
+		return nil
+	}
+	return i.managedInstanceCore
+}
+
+func (i *windowsInstance) VirtioFSStats() []virtio.FSStats {
+	if i == nil {
+		return nil
+	}
+	return virtioFSStats(i.fsdevs)
+}
+
+func (i *windowsInstance) Exec(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {
+	return i.core().Exec(ctx, req)
+}
+
+func (i *windowsInstance) ExecStream(ctx context.Context, req client.ExecRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
+	return i.core().ExecStream(ctx, req, inputs, onEvent)
+}
+
+func (i *windowsInstance) ConsoleHistory(ctx context.Context) (string, error) {
+	return i.core().ConsoleHistory(ctx)
+}
+
+func (i *windowsInstance) AddShare(ctx context.Context, share client.ShareMount) error {
+	_ = ctx
+	if i == nil || i.rootFS == nil {
+		return mounts.AddRuntimeShareMount(nil, nil, nil, share, "shares", nil)
+	}
+	return i.mounts.AddShare(i.rootFS, share, "shares", func(share client.ShareMount) (virtio.ShareMount, error) {
+		return mounts.BuildRuntimeDirectoryShare(share, arm64vm.BuildShareMount)
+	})
+}
+
+func (i *windowsInstance) AddImage(ctx context.Context, mountPath string, image *oci.Image) error {
+	_ = ctx
+	if i == nil {
+		return mounts.AddImageMount(nil, nil, nil, mountPath, image, nil)
+	}
+	return i.mounts.AddImage(i.rootFS, mountPath, image, mounts.ImageFSBackend(image))
+}
+
+func (i *windowsInstance) AddPortForward(ctx context.Context, forward client.PortForward) error {
+	if i == nil || i.network == nil {
+		return netstate.AddManagedNetworkPortForward(ctx, nil, forward)
+	}
+	return netstate.AddManagedNetworkPortForward(ctx, i.network.networkRuntime, forward)
+}
+
+func (i *windowsInstance) AllowServiceProxyPort(ctx context.Context, port int) error {
+	if i == nil || i.network == nil {
+		return netstate.AllowManagedNetworkServiceProxyPort(ctx, nil, port)
+	}
+	return netstate.AllowManagedNetworkServiceProxyPort(ctx, i.network.networkRuntime, port)
+}
+
+func (i *windowsInstance) Wait() error {
+	if i == nil {
+		return nil
+	}
+	return i.core().Wait()
+}
+
+func (i *windowsInstance) Close() error {
+	if i == nil {
+		return nil
+	}
+	var session managedsession.Session
+	if core := i.core(); core != nil {
+		session = core.Session()
+	}
+	var network hostmanaged.NetworkCloser
+	if i.network != nil {
+		network = i.network
+	}
+	return hostmanaged.CloseSessionWithNetwork(session, network)
+}
+
+func (i *windowsInstance) NetworkIPv4() string {
+	if i == nil || i.network == nil {
+		return ""
+	}
+	return netstate.IPv4(i.network.networkRuntime, "")
+}
+
+func windowsGuestInitConfig(modules []alpine.Module, managedExec bool) vmruntime.GuestInitConfig {
+	cfg := vmruntime.GuestInitConfig{
+		Modules:            vmruntime.ModulePaths(modules),
+		ReadyMarker:        windowsInitReadyMarker,
+		BeginMarker:        vmruntime.CommandBeginMarker,
+		OutputMarkerPref:   vmruntime.CommandOutputMarker,
+		ErrorMarkerPref:    vmruntime.CommandErrorMarker,
+		ControlMarkerPref:  vmruntime.CommandControlMarker,
+		UsageMarkerPref:    vmruntime.CommandUsageMarker,
+		ExitMarkerPrefix:   vmruntime.CommandExitMarkerPref,
+		DisableCgroupMount: true,
+		UnixTime:           time.Now().Unix(),
+	}
+	if managedExec {
+		cfg.VsockPort = vmruntime.ControlPort
+	}
+	return cfg
+}
+
+func windowsRuntimeConfigVars(image *oci.Image) []string {
+	vars := []string{"CONFIG_VIRTIO_MMIO", "CONFIG_FUSE_FS", "CONFIG_VIRTIO_FS", "CONFIG_VSOCKETS", "CONFIG_VIRTIO_VSOCKETS", "CONFIG_HW_RANDOM", "CONFIG_HW_RANDOM_VIRTIO", "CONFIG_VIRTIO_NET", "CONFIG_OVERLAY_FS"}
+	if NeedsAMD64Emulation(image) {
+		vars = append(vars, "CONFIG_BINFMT_MISC")
+	}
+	return vars
+}
+
+func windowsRuntimeModuleMap() map[string]string {
+	return map[string]string{
+		"CONFIG_VIRTIO_MMIO":      "kernel/drivers/virtio/virtio_mmio.ko.gz",
+		"CONFIG_FUSE_FS":          "kernel/fs/fuse/fuse.ko.gz",
+		"CONFIG_VIRTIO_FS":        "kernel/fs/fuse/virtiofs.ko.gz",
+		"CONFIG_VSOCKETS":         "kernel/net/vmw_vsock/vsock.ko.gz",
+		"CONFIG_VIRTIO_VSOCKETS":  "kernel/net/vmw_vsock/vmw_vsock_virtio_transport.ko.gz",
+		"CONFIG_HW_RANDOM":        "kernel/drivers/char/hw_random/rng-core.ko.gz",
+		"CONFIG_HW_RANDOM_VIRTIO": "kernel/drivers/char/hw_random/virtio-rng.ko.gz",
+		"CONFIG_VIRTIO_NET":       "kernel/drivers/net/virtio_net.ko.gz",
+		"CONFIG_OVERLAY_FS":       "kernel/fs/overlayfs/overlay.ko.gz",
+		"CONFIG_BINFMT_MISC":      "kernel/fs/binfmt_misc.ko.gz",
+	}
+}
+
+func withWindowsRuntimeMountDirs(image *oci.Image) *oci.Image {
+	if image == nil || image.RootFS == nil {
+		return image
+	}
+	overlay := imagefs.NewOverlay(image.RootFS)
+	for _, dir := range []string{"/dev", "/proc", "/sys", "/run"} {
+		_ = overlay.AddDir(dir, fs.ModeDir|0o755)
+	}
+	_ = overlay.AddDir("/tmp", fs.ModeDir|0o1777)
+	cloned := *image
+	cloned.RootFS = overlay.Root()
+	return &cloned
+}
+
+func blankWindowsRuntimeRootFS() imagefs.Directory {
+	overlay := imagefs.NewOverlay(nil)
+	for _, dir := range []string{"/dev", "/proc", "/sys", "/run", "/.ccx3", "/.ccx3/images"} {
+		_ = overlay.AddDir(dir, fs.ModeDir|0o755)
+	}
+	_ = overlay.AddDir("/tmp", fs.ModeDir|0o1777)
+	return overlay.Root()
+}
+
+func windowsEffectiveExecEnv(base, overrides []string, replace bool) []string {
+	if replace {
+		return vmruntime.WithDefaultEnv(overrides)
+	}
+	return vmruntime.WithDefaultEnv(vmruntime.MergeEnv(base, overrides))
+}
+
+func windowsImageMountPath(image string) string {
+	replacer := strings.NewReplacer("/", "_", ":", "_", "@", "_", " ", "_")
+	return path.Join("/.ccx3", "images", replacer.Replace(image))
+}

--- a/internal/vm/instance_snapshot_windows_arm64.go
+++ b/internal/vm/instance_snapshot_windows_arm64.go
@@ -1,0 +1,31 @@
+//go:build windows && arm64
+
+package vm
+
+import (
+	"context"
+
+	"j5.nz/cc/internal/imagefs"
+	"j5.nz/cc/internal/vm/mounts"
+)
+
+func (i *windowsInstance) Flush(ctx context.Context) error {
+	return i.core().Flush(ctx)
+}
+
+func (i *windowsInstance) RootSnapshot() (imagefs.Directory, error) {
+	if i == nil || i.rootFS == nil {
+		return mounts.RootSnapshot(nil, "")
+	}
+	return mounts.RootSnapshotWithCapabilities("Linux", i.ManagedCapabilities(), i.rootFS, "")
+}
+
+func (i *windowsInstance) SnapshotImage(imageName string) (imagefs.Directory, error) {
+	if i == nil || i.rootFS == nil {
+		return mounts.RootSnapshot(nil, "")
+	}
+	if i.image != nil && i.image.Name == imageName {
+		return i.RootSnapshot()
+	}
+	return mounts.ImageSnapshotWithCapabilities("Linux", i.ManagedCapabilities(), i.rootFS, imageName, windowsImageMountPath(imageName))
+}

--- a/internal/vm/network_windows_arm64.go
+++ b/internal/vm/network_windows_arm64.go
@@ -1,0 +1,45 @@
+//go:build windows && arm64
+
+package vm
+
+import (
+	"net"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+type windowsNetworkRuntime struct {
+	*networkRuntime
+}
+
+func newWindowsARM64NetworkRuntime(cfg *client.NetworkConfig) (*windowsNetworkRuntime, error) {
+	common, err := newNetworkRuntime(networkDeviceConfig{
+		Config: cfg,
+		IP:     net.IPv4(10, 42, 0, 2),
+		MAC:    net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02},
+		Base:   arm64vm.NetBase,
+		Size:   arm64vm.NetSize,
+		IRQ:    arm64vm.NetIRQ,
+	})
+	if err != nil || common == nil {
+		return nil, err
+	}
+	return &windowsNetworkRuntime{networkRuntime: common}, nil
+}
+
+func windowsNetworkDevice(network *windowsNetworkRuntime) *virtio.Net {
+	if network == nil {
+		return nil
+	}
+	return network.Device()
+}
+
+func windowsNetworkGuestInitConfig(network *windowsNetworkRuntime) *vmruntime.GuestNetworkConfig {
+	if network == nil {
+		return nil
+	}
+	return network.GuestInitConfig()
+}

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -356,6 +356,17 @@ func TestRuntimeBootsPersistentLinuxAndExecsCommands(t *testing.T) {
 	requireGuestOutput(t, second.Output, "42", "persisted")
 }
 
+func TestRuntimePersistentLinuxStreamsStdin(t *testing.T) {
+	env := newRuntimeBootEnv(t)
+	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{})
+	defer inst.Close()
+
+	output := execStreamInRuntime(t, inst, client.ExecRequest{
+		Command: []string{"sh", "-lc", "set -eu; while IFS= read -r line; do printf 'line:%s\n' \"$line\"; done"},
+	}, execStreamInput("alpha\n", "beta\n"), 0)
+	requireGuestOutput(t, output, "line:alpha", "line:beta")
+}
+
 func TestRuntimePersistentRejectsRuntimeMountConflicts(t *testing.T) {
 	env := newRuntimeBootEnv(t)
 	sourceA := t.TempDir()

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -197,7 +197,7 @@ func TestRuntimeBootsNetBSDBuiltinImage(t *testing.T) {
 		envVar:   "CC_TEST_NETBSD_KVM",
 		image:    "@netbsd",
 		memoryMB: 1024,
-		timeout:  180 * time.Second,
+		timeout:  240 * time.Second,
 		guestOS:  "NetBSD",
 		label:    "netbsd",
 	})

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -135,7 +135,7 @@ func HostCapabilities() client.CapabilitiesResponse {
 		caps.MaxInstances = 1
 		caps.Notes = append(caps.Notes, "macOS HVF currently limits ccx3 to one running instance")
 	}
-	if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
+	if runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64") {
 		caps.MaxInstances = 1
 		caps.Notes = append(caps.Notes, "Windows WHP currently supports one vCPU per instance")
 	}
@@ -169,7 +169,7 @@ func networkModesForHost(goos, goarch string) []string {
 		return []string{"user"}
 	case goos == "darwin" && goarch == "arm64":
 		return []string{"user"}
-	case goos == "windows" && goarch == "amd64":
+	case goos == "windows" && (goarch == "amd64" || goarch == "arm64"):
 		return []string{"user"}
 	default:
 		return []string{}
@@ -182,7 +182,7 @@ func backendName() string {
 		return "kvm"
 	case runtime.GOOS == "darwin" && runtime.GOARCH == "arm64":
 		return "hvf"
-	case runtime.GOOS == "windows" && runtime.GOARCH == "amd64":
+	case runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64"):
 		return "whp"
 	default:
 		return "unsupported"


### PR DESCRIPTION
## Summary

Adds Windows/arm64 WHP support for Linux guests, including:

- WHP arm64 partition/vCPU bindings, GICv3 setup, interrupt injection, MMIO decode, serial, vsock, virtio-fs, rng, and net plumbing.
- Windows/arm64 runtime backend support with persistent sessions, dynamic shares, alternate image exec, image mounts, snapshots, console history, and network hooks.
- Guest-init stdio ownership fixes for managed exec so non-PTY stdout/stderr/stdin are copied explicitly and process reaping does not depend on `exec.Cmd.Wait` hidden copy cleanup.
- Deterministic WHP managed-session teardown so repeated Windows WHP boots do not race the next partition against the previous partition cleanup.

## Root Cause

The original WHP arm64 wait hang was in guest-init's non-PTY managed exec path. The guest was delivering serial, vsock, and command stdout, and the child process could already be gone, but `exec.Cmd.Wait` could remain stuck in Go's hidden stdio cleanup because cc also had its own protocol stream readers. The fix gives guest-init explicit ownership of the child stdio pipes and reaps with `Process.Wait`, deriving exit status from `ProcessState`.

Follow-up CI/root-cause work found two related lifecycle bugs instead of masking the symptoms:

- Non-PTY stdin copying moved to a separate `stdinDone` channel, but the main stream wait count still included stdin. Commands with stdin could wait forever for a completion signal that no goroutine sent.
- WHP session `Close` returned after receiving the runner result, but the runner sent that result before deferred `vm.Close()` ran. The next test could create a WHP partition while the previous partition teardown and delay were still pending.

## Validation

- WSL/Linux: `go test ./...`
- Windows/arm64 host: `go test -short ./... -count=1 -timeout 30m`
- Windows/arm64 host with generated guest-init payloads: `go test -tags embed_guestinit -p 1 ./... -count=1 -timeout 420s`
- Windows/arm64 host with generated guest-init payloads: `go test -tags embed_guestinit ./internal/vm -count=1 -timeout 420s -v`

Notes: plain full Windows runtime tests require generated guest-init payloads and `-tags embed_guestinit`; the short matrix intentionally skips those runtime boot tests.