### PR TITLE
[codex] fix HVF startup snapshot restore

### DIFF
--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -392,8 +392,18 @@ func run() error {
 	}
 	configureMemoryOvercommit("/proc")
 
+	modules := cfg.Modules
+	var deferredModulePaths []string
+	var deferredModules []modulePayload
+	if cfg.SnapshotMMIOBase != 0 {
+		modules, deferredModulePaths = splitSnapshotDeferredModules(cfg.Modules)
+		deferredModules, err = readModulePayloads(deferredModulePaths)
+		if err != nil {
+			return err
+		}
+	}
 	writeStage(bootStart, "loading modules")
-	if err := loadModules(cfg.Modules); err != nil {
+	if err := loadModules(modules); err != nil {
 		return err
 	}
 	writeStage(bootStart, "modules loaded")
@@ -455,6 +465,13 @@ func run() error {
 				}
 				writeStage(bootStart, "entropy seeded")
 			}
+			if len(deferredModules) > 0 {
+				writeStage(bootStart, "loading deferred modules")
+				if err := loadModulePayloads(deferredModules); err != nil {
+					return err
+				}
+				writeStage(bootStart, "deferred modules loaded")
+			}
 			writeStage(bootStart, "connecting vsock control")
 			control, err := connectVsock(cfg.VsockPort)
 			if err != nil {
@@ -466,7 +483,6 @@ func run() error {
 				writeStage(bootStart, "sending ready marker")
 				writeProtocolLineTo(control, cfg.ReadyMarker)
 			}
-			writeStage(bootStart, "entering command loop")
 			return commandLoop(cfg, control)
 		}
 		if cfg.ReadyMarker != "" {
@@ -1860,19 +1876,73 @@ func loadModules(modules []string) error {
 		if err != nil {
 			return fmt.Errorf("read module %s: %w", path, err)
 		}
-		if len(data) == 0 {
-			return fmt.Errorf("module %s is empty", path)
-		}
-		params, err := syscall.BytePtrFromString("")
-		if err != nil {
-			return fmt.Errorf("init module params: %w", err)
-		}
-		_, _, errno := syscall.RawSyscall(syscall.SYS_INIT_MODULE, uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)), uintptr(unsafe.Pointer(params)))
-		if errno != 0 {
-			return fmt.Errorf("load module %s: errno=%d", path, errno)
+		if err := loadModuleData(path, data); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+type modulePayload struct {
+	path string
+	data []byte
+}
+
+func readModulePayloads(modules []string) ([]modulePayload, error) {
+	payloads := make([]modulePayload, 0, len(modules))
+	for _, path := range modules {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read module %s: %w", path, err)
+		}
+		payloads = append(payloads, modulePayload{path: path, data: data})
+	}
+	return payloads, nil
+}
+
+func loadModulePayloads(modules []modulePayload) error {
+	for _, module := range modules {
+		if err := loadModuleData(module.path, module.data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadModuleData(path string, data []byte) error {
+	if len(data) == 0 {
+		return fmt.Errorf("module %s is empty", path)
+	}
+	params, err := syscall.BytePtrFromString("")
+	if err != nil {
+		return fmt.Errorf("init module params: %w", err)
+	}
+	_, _, errno := syscall.RawSyscall(syscall.SYS_INIT_MODULE, uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)), uintptr(unsafe.Pointer(params)))
+	if errno != 0 {
+		return fmt.Errorf("load module %s: errno=%d", path, errno)
+	}
+	return nil
+}
+
+func splitSnapshotDeferredModules(modules []string) ([]string, []string) {
+	var early []string
+	var deferred []string
+	for _, path := range modules {
+		if snapshotDeferredModule(path) {
+			deferred = append(deferred, path)
+			continue
+		}
+		early = append(early, path)
+	}
+	return early, deferred
+}
+
+func snapshotDeferredModule(path string) bool {
+	name := filepath.Base(path)
+	return name == "vsock.ko" ||
+		strings.HasPrefix(name, "vsock.ko.") ||
+		strings.HasPrefix(name, "vmw_vsock_") ||
+		strings.HasPrefix(name, "virtio_vsock")
 }
 
 func execCommand(cfg config) error {

--- a/internal/hv/hvf/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings_darwin_arm64.go
@@ -150,6 +150,13 @@ const (
 	hvSysRegVBAR_EL1         SysReg = 0xc600
 	hvSysRegCNTHCTL_EL2      SysReg = 0xe708
 	hvSysRegCNTVOFF_EL2      SysReg = 0xe703
+	hvSysRegCNTFRQ_EL0       SysReg = 0xdf00
+	hvSysRegCNTP_TVAL_EL0    SysReg = 0xdf10
+	hvSysRegCNTP_CTL_EL0     SysReg = 0xdf11
+	hvSysRegCNTP_CVAL_EL0    SysReg = 0xdf12
+	hvSysRegCNTV_TVAL_EL0    SysReg = 0xdf18
+	hvSysRegCNTV_CTL_EL0     SysReg = 0xdf19
+	hvSysRegCNTV_CVAL_EL0    SysReg = 0xdf1a
 	hvSysRegCPTR_EL2         SysReg = 0xe08a
 	hvSysRegHCR_EL2          SysReg = 0xe088
 	hvSysRegSP_EL2           SysReg = 0xf208

--- a/internal/hv/hvf/snapshot_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64.go
@@ -270,8 +270,9 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 		}()
 		runner := newVMRunManager(vm)
 		for {
+			active := activeExecs.Load() > 0
 			runStart := time.Now()
-			runRes, err, stalled := runner.Run(runCtx, persistentRunSlice(guestReady.Load(), activeExecs.Load() > 0))
+			runRes, err, stalled := runner.Run(runCtx, persistentRunSlice(guestReady.Load(), active))
 			timing.Since(ctx, "hvf.restore.run_loop.run_with_cancel", runStart)
 			if stalled {
 				if runCtx.Err() != nil {
@@ -376,7 +377,7 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 			cancel: cancel, closeDone: closeDone, image: req.Image, baseEnv: baseEnv, workDir: workDir,
 			dmesg: req.Dmesg, uart: uart, control: res.conn, transcript: controlTranscript, serialOut: serialOut,
 			listener: listener, vsock: vsock, rootFS: rootFS, fsdevs: fsdevs, shares: shareState,
-			imageMounts: map[string]string{}, activeExecs: activeExecs, inlineExec: true,
+			imageMounts: map[string]string{}, activeExecs: activeExecs,
 		}
 		timing.Since(ctx, "hvf.restore.total_ready", startTotal)
 		timingLog("hvf.restore total ready=%s", time.Since(startTotal))
@@ -533,6 +534,13 @@ func snapshotVCPUSysRegisters(vm *VM, vcpuIndex int) map[string]uint64 {
 	regs := map[string]SysReg{
 		"amair_el1":      hvSysRegAMAIR_EL1,
 		"contextidr_el1": hvSysRegCONTEXTIDR_EL1,
+		"cntfrq_el0":     hvSysRegCNTFRQ_EL0,
+		"cntp_ctl_el0":   hvSysRegCNTP_CTL_EL0,
+		"cntp_cval_el0":  hvSysRegCNTP_CVAL_EL0,
+		"cntp_tval_el0":  hvSysRegCNTP_TVAL_EL0,
+		"cntv_ctl_el0":   hvSysRegCNTV_CTL_EL0,
+		"cntv_cval_el0":  hvSysRegCNTV_CVAL_EL0,
+		"cntv_tval_el0":  hvSysRegCNTV_TVAL_EL0,
 		"cntvoff_el2":    hvSysRegCNTVOFF_EL2,
 		"cpacr_el1":      hvSysRegCPACR_EL1,
 		"elr_el1":        hvSysRegELR_EL1,
@@ -890,31 +898,26 @@ func restoreSnapshotGIC(vm *VM, manifest snapshotManifest) error {
 			timingLog("restore gic redistributor %s failed: %v", name, err)
 		}
 	}
+	for name, value := range manifest.GICICC {
+		reg, ok := gicICCRegByName(name)
+		if !ok {
+			continue
+		}
+		if err := vm.SetGICICCRegForVCPU(manifest.CapturedVCPU, reg, value); err != nil {
+			timingLog("restore gic icc %s failed: %v", name, err)
+		}
+	}
 	return nil
 }
 
 func restoreSnapshotVTimer(vm *VM, manifest snapshotManifest) error {
-	offset := manifest.VTimerOffset + restoreVTimerElapsedOffset(manifest.CapturedAt)
-	if err := vm.SetVTimerOffset(offset); err != nil {
+	if err := vm.SetVTimerOffset(manifest.VTimerOffset); err != nil {
 		return fmt.Errorf("restore vtimer offset: %w", err)
 	}
 	if err := vm.SetVTimerMask(manifest.VTimerMasked); err != nil {
 		return fmt.Errorf("restore vtimer mask: %w", err)
 	}
 	return nil
-}
-
-func restoreVTimerElapsedOffset(capturedAt string) uint64 {
-	captured, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(capturedAt))
-	if err != nil {
-		return 0
-	}
-	elapsed := time.Since(captured)
-	if elapsed <= 0 {
-		return 0
-	}
-	const archTimerHz = 24_000_000
-	return uint64(elapsed.Nanoseconds()) * archTimerHz / uint64(time.Second)
 }
 
 func gicDistributorRuntimeReg(reg GICDistributorReg) bool {
@@ -943,6 +946,23 @@ func parseGICRedistributorReg(name string) (GICRedistributorReg, error) {
 	return GICRedistributorReg(value), nil
 }
 
+func gicICCRegByName(name string) (GICICCReg, bool) {
+	switch name {
+	case "ctlr_el1":
+		return hvGICICCRegCTLR_EL1, true
+	case "igrpen0_el1":
+		return hvGICICCRegIGRPEN0_EL1, true
+	case "igrpen1_el1":
+		return hvGICICCRegIGRPEN1_EL1, true
+	case "pmr_el1":
+		return hvGICICCRegPMR_EL1, true
+	case "sre_el1":
+		return hvGICICCRegSRE_EL1, true
+	default:
+		return 0, false
+	}
+}
+
 func snapshotRegByName(name string) (Reg, bool) {
 	switch name {
 	case "pc":
@@ -965,6 +985,20 @@ func snapshotSysRegByName(name string) (SysReg, bool) {
 		return hvSysRegAMAIR_EL1, true
 	case "contextidr_el1":
 		return hvSysRegCONTEXTIDR_EL1, true
+	case "cntfrq_el0":
+		return hvSysRegCNTFRQ_EL0, true
+	case "cntp_ctl_el0":
+		return hvSysRegCNTP_CTL_EL0, true
+	case "cntp_cval_el0":
+		return hvSysRegCNTP_CVAL_EL0, true
+	case "cntp_tval_el0":
+		return hvSysRegCNTP_TVAL_EL0, true
+	case "cntv_ctl_el0":
+		return hvSysRegCNTV_CTL_EL0, true
+	case "cntv_cval_el0":
+		return hvSysRegCNTV_CVAL_EL0, true
+	case "cntv_tval_el0":
+		return hvSysRegCNTV_TVAL_EL0, true
 	case "cntvoff_el2":
 		return hvSysRegCNTVOFF_EL2, true
 	case "cpacr_el1":

--- a/internal/vm/backend_darwin_arm64.go
+++ b/internal/vm/backend_darwin_arm64.go
@@ -560,8 +560,11 @@ func (b *runtimeBackend) buildBlankStartRequest(ctx context.Context, req client.
 		if err != nil {
 			return vmruntime.RunRequest{}, err
 		}
+		shares := mounts.ConvertShareMounts(req.Shares)
 		if rootFS == nil {
 			rootFS = virtio.NewImageFS(blankRuntimeRootFS(), "")
+		} else {
+			shares = nil
 		}
 		return vmruntime.RunRequest{
 			Kernel:            append([]byte(nil), bundle.Kernel...),
@@ -571,6 +574,7 @@ func (b *runtimeBackend) buildBlankStartRequest(ctx context.Context, req client.
 			Image:             sidecarBundleImage(bundle),
 			InitSystem:        req.InitSystem,
 			RootFS:            rootFS,
+			Shares:            shares,
 			MemoryMB:          req.MemoryMB,
 			CPUs:              req.CPUs,
 			NestedVirt:        req.NestedVirt,
@@ -625,8 +629,11 @@ func (b *runtimeBackend) buildBlankStartRequest(ctx context.Context, req client.
 	if err != nil {
 		return vmruntime.RunRequest{}, err
 	}
+	shares := mounts.ConvertShareMounts(req.Shares)
 	if rootFS == nil && image == nil {
 		rootFS = virtio.NewImageFS(blankRuntimeRootFS(), "")
+	} else if rootFS != nil {
+		shares = nil
 	}
 	return vmruntime.RunRequest{
 		Kernel:            kernel,
@@ -636,6 +643,7 @@ func (b *runtimeBackend) buildBlankStartRequest(ctx context.Context, req client.
 		Image:             image,
 		InitSystem:        req.InitSystem,
 		RootFS:            rootFS,
+		Shares:            shares,
 		MemoryMB:          req.MemoryMB,
 		CPUs:              req.CPUs,
 		NestedVirt:        req.NestedVirt,
@@ -667,17 +675,21 @@ func (b *runtimeBackend) buildBlankRestoreRequest(ctx context.Context, req clien
 	if err != nil {
 		return vmruntime.RunRequest{}, err
 	}
+	shares := mounts.ConvertShareMounts(req.Shares)
 	if rootFS == nil {
 		if image != nil {
 			rootFS = virtio.NewImageFS(image.RootFS, image.RootFSDir)
 		} else {
 			rootFS = virtio.NewImageFS(blankRuntimeRootFS(), "")
 		}
+	} else {
+		shares = nil
 	}
 	return vmruntime.RunRequest{
 		Image:           image,
 		InitSystem:      req.InitSystem,
 		RootFS:          rootFS,
+		Shares:          shares,
 		MemoryMB:        req.MemoryMB,
 		CPUs:            req.CPUs,
 		NestedVirt:      req.NestedVirt,

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -115,6 +115,33 @@ func TestManagerBlankStartRemembersImageForRunIn(t *testing.T) {
 	}
 }
 
+func TestManagerBlankSnapshotStartKeepsSharesInStartRequest(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2, SupportsL2: true})
+	inst := newFakeInstance()
+	host.queueInstance(inst)
+	manager := testManager(host)
+	defer manager.ShutdownAll(ctx)
+
+	share := client.ShareMount{Source: "/tmp/host", Mount: "/host", Writable: true}
+	if _, err := manager.StartBlankInstanceStream(ctx, "alpha", client.StartInstanceRequest{
+		Image:       "alpine",
+		SnapshotDir: "/tmp/snapshots",
+		Shares:      []client.ShareMount{share},
+	}, nil); err != nil {
+		t.Fatalf("start blank: %v", err)
+	}
+	if len(host.blankStarts) != 1 {
+		t.Fatalf("blank starts = %+v", host.blankStarts)
+	}
+	if got := host.blankStarts[0].Shares; len(got) != 1 || got[0] != share {
+		t.Fatalf("start shares = %+v, want %+v", got, []client.ShareMount{share})
+	}
+	if len(inst.shares) != 0 {
+		t.Fatalf("post-start shares = %+v, want none", inst.shares)
+	}
+}
+
 func TestManagerRunWithoutInstanceRequiresOrUsesImage(t *testing.T) {
 	ctx := context.Background()
 	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -114,7 +114,11 @@ func prepareSidecarBlankResources(h *sidecarVMHost, ctx context.Context, req cli
 	} else {
 		root = virtio.NewImageFS(blankRuntimeRootFS(), "")
 	}
-	rootFS, err := sidecarSnapshotRoot(virtio.NewMountedFS(root, nil))
+	shares, err := sidecarShareMounts(req.Shares)
+	if err != nil {
+		return sidecarStartResources{}, err
+	}
+	rootFS, err := sidecarSnapshotRoot(virtio.NewMountedFS(root, shares))
 	if err != nil {
 		return sidecarStartResources{}, err
 	}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -317,19 +317,24 @@ func (m *Manager) StartBlankInstanceStream(
 	m.mu.Unlock()
 
 	shares := append([]client.ShareMount(nil), req.Shares...)
-	req.Shares = nil
+	snapshotStartup := strings.TrimSpace(req.SnapshotDir) != "" || strings.TrimSpace(req.RestoreSnapshot) != ""
+	if !snapshotStartup {
+		req.Shares = nil
+	}
 	inst, err := m.host.StartBlankStream(ctx, req, onEvent)
 	if err != nil {
 		m.clearStarting(id)
 		m.releaseNetworkLease(id)
 		return client.InstanceState{}, err
 	}
-	for _, share := range shares {
-		if err := inst.AddShare(ctx, share); err != nil {
-			_ = inst.Close()
-			m.clearStarting(id)
-			m.releaseNetworkLease(id)
-			return client.InstanceState{}, err
+	if !snapshotStartup {
+		for _, share := range shares {
+			if err := inst.AddShare(ctx, share); err != nil {
+				_ = inst.Close()
+				m.clearStarting(id)
+				m.releaseNetworkLease(id)
+				return client.InstanceState{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Cherry-picks the orphaned HVF startup snapshot restore fix back onto current `main`.

The original commit was `dfe8e28857fd1fc04ce7bd382a9f3eae6c840a8d` on `codex/hvf-snapshot-restore`, added after PR #34 had already merged. This PR reapplies that fix as `06c88eae2f6c537a6e979f6a7136b2550c28e18d` on top of current `main`.

## Why

`vmsh` was pinned to the post-merge branch tip, so updating it to `cc/main` would otherwise drop this follow-up fix. Landing this in `cc/main` lets `vmsh` move to main without losing the HVF startup snapshot restore fix.

## Validation

- `go test ./internal/cmd/init ./internal/hv/hvf`
- `go test ./internal/vm -run '^TestManagerBlankSnapshotStartKeepsSharesInStartRequest$'`
- `git diff --check origin/main...HEAD`

Attempted `go test ./internal/cmd/init ./internal/hv/hvf ./internal/vm`; `internal/vm` boot tests require embedded guest init payloads in this checkout. Attempted `go test -tags embed_guestinit ./internal/vm`; setup failed because the generated embedded payload files are not present locally.
