### PR TITLE
[codex] Add WHP Linux startup snapshots

### DIFF
--- a/cmd/tinyboot/main_other.go
+++ b/cmd/tinyboot/main_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin || !arm64
+//go:build (!darwin || !arm64) && (!windows || !amd64)
 
 package main
 

--- a/cmd/tinyboot/main_windows_amd64.go
+++ b/cmd/tinyboot/main_windows_amd64.go
@@ -1,0 +1,241 @@
+//go:build windows && amd64
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/amd64vm"
+	"j5.nz/cc/internal/guestinit"
+	"j5.nz/cc/internal/hv/whp"
+	"j5.nz/cc/internal/kernel/alpine"
+	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/simg"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "tinyboot:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var cacheDir string
+	var simgPath string
+	var timeout time.Duration
+	var memoryMB uint64
+	var dmesg bool
+	var runCommand string
+	var stdin string
+	var runs int
+	var warmup int
+	var snapshotDir string
+	var restoreSnapshot string
+
+	flag.StringVar(&cacheDir, "cache-dir", "", "cache directory")
+	flag.StringVar(&simgPath, "simg", "./fixtures/alpine.simg", "SIMG root filesystem")
+	flag.DurationVar(&timeout, "timeout", 30*time.Second, "boot timeout")
+	flag.Uint64Var(&memoryMB, "memory-mb", 512, "guest memory in MiB")
+	flag.BoolVar(&dmesg, "dmesg", false, "enable serial console and dmesg capture")
+	flag.StringVar(&runCommand, "exec", "", "optional command to run after boot, split on spaces")
+	flag.StringVar(&stdin, "stdin", "", "stdin for the optional command")
+	flag.IntVar(&runs, "runs", 10, "number of boot runs to average")
+	flag.IntVar(&warmup, "warmup", 1, "number of boot runs to exclude from averages")
+	flag.StringVar(&snapshotDir, "snapshot-dir", "", "write checkpoint files under this directory when the guest reaches the snapshot trigger")
+	flag.StringVar(&restoreSnapshot, "restore-snapshot", "", "restore from this snapshot directory instead of booting from kernel entry")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flag.Args(), " "))
+	}
+	if runs <= 0 {
+		return fmt.Errorf("runs must be positive")
+	}
+	if warmup < 0 {
+		return fmt.Errorf("warmup must be non-negative")
+	}
+	if cacheDir == "" {
+		dir, err := os.MkdirTemp("", "cc-tinyboot-*")
+		if err != nil {
+			return fmt.Errorf("create cache dir: %w", err)
+		}
+		cacheDir = dir
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var kernel []byte
+	var modules []alpine.Module
+	var initBin []byte
+	if restoreSnapshot == "" {
+		kernelManager := alpine.NewManager(filepath.Join(cacheDir, "kernel"))
+		if err := kernelManager.Ensure(ctx); err != nil {
+			return fmt.Errorf("ensure kernel: %w", err)
+		}
+		var err error
+		kernel, err = kernelManager.ReadKernel()
+		if err != nil {
+			return fmt.Errorf("read kernel: %w", err)
+		}
+		modules, err = kernelManager.PlanModuleLoad(windowsTinybootConfigVars(), windowsTinybootModuleMap())
+		if err != nil {
+			return fmt.Errorf("plan modules: %w", err)
+		}
+		initBin, err = guestinit.BuildForArch(ctx, filepath.Join(cacheDir, "guestinit"), "amd64")
+		if err != nil {
+			return fmt.Errorf("build guest init: %w", err)
+		}
+	}
+	rootFS, _, arch, err := simg.BuildImageFS(simgPath)
+	if err != nil {
+		return fmt.Errorf("open simg rootfs: %w", err)
+	}
+	image := &oci.Image{
+		Name:         "tinyboot",
+		Source:       simgPath,
+		SourceKind:   oci.SourceKindSIMG,
+		Architecture: arch,
+		RootFS:       rootFS,
+		Config: oci.RuntimeConfig{
+			WorkingDir: "/",
+		},
+	}
+	var totalBoot time.Duration
+	var totalExec time.Duration
+	var measuredBoots int
+	var measuredExecs int
+	totalRuns := warmup + runs
+	for i := 1; i <= totalRuns; i++ {
+		measured := i > warmup
+		runCtx, runCancel := context.WithTimeout(context.Background(), timeout)
+		start := time.Now()
+		fsdevs, _, err := amd64vm.BuildFSDevices(vmruntime.RunRequest{Image: image}, nil)
+		if err != nil {
+			runCancel()
+			return fmt.Errorf("build fs devices run %d: %w", i, err)
+		}
+		onEvent := func(event client.BootEvent) error {
+			if event.Kind == "status" && event.Message != "" {
+				fmt.Fprintf(os.Stderr, "run %d boot: %s\n", i, event.Message)
+			}
+			return nil
+		}
+		var session *whp.ManagedSession
+		if restoreSnapshot != "" {
+			session, err = whp.StartManagedSessionFromSnapshot(runCtx, restoreSnapshot, memoryMB, dmesg, fsdevs, nil, onEvent)
+		} else {
+			initCfg := vmruntime.GuestInitConfig{
+				Modules:            vmruntime.ModulePaths(modules),
+				RootFSTag:          vmruntime.RootFSTag,
+				Env:                vmruntime.WithDefaultEnv(image.Config.Env),
+				WorkDir:            "/",
+				VsockPort:          vmruntime.ControlPort,
+				ReadyMarker:        vmruntime.InstanceReadyMarker,
+				BeginMarker:        vmruntime.CommandBeginMarker,
+				OutputMarkerPref:   vmruntime.CommandOutputMarker,
+				ErrorMarkerPref:    vmruntime.CommandErrorMarker,
+				ControlMarkerPref:  vmruntime.CommandControlMarker,
+				UsageMarkerPref:    vmruntime.CommandUsageMarker,
+				ExitMarkerPrefix:   vmruntime.CommandExitMarkerPref,
+				DisableCgroupMount: true,
+				UnixTime:           time.Now().Unix(),
+			}
+			if strings.TrimSpace(snapshotDir) != "" {
+				initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
+			}
+			var initrd []byte
+			initrd, err = vmruntime.BuildInitramfs(initBin, modules, initCfg)
+			if err != nil {
+				runCancel()
+				return fmt.Errorf("build initramfs run %d: %w", i, err)
+			}
+			session, err = whp.StartManagedSessionWithNetOptions(runCtx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, whp.ManagedSessionOptions{
+				SnapshotDir: snapshotDir,
+			}, onEvent)
+		}
+		if err != nil {
+			runCancel()
+			return fmt.Errorf("boot VM run %d: %w", i, err)
+		}
+		bootDuration := time.Since(start)
+		if measured {
+			totalBoot += bootDuration
+			measuredBoots++
+		}
+		fmt.Fprintf(os.Stderr, "run %d booted in %s%s\n", i, bootDuration.Round(time.Millisecond), warmupSuffix(measured))
+
+		if strings.TrimSpace(runCommand) != "" {
+			execStart := time.Now()
+			resp, err := session.Exec(runCtx, client.ExecRequest{
+				Command: strings.Fields(runCommand),
+				Stdin:   []byte(stdin),
+			})
+			if err != nil {
+				_ = session.Close()
+				runCancel()
+				return fmt.Errorf("exec command run %d: %w", i, err)
+			}
+			execDuration := time.Since(execStart)
+			if measured {
+				totalExec += execDuration
+				measuredExecs++
+			}
+			fmt.Print(resp.Output)
+			fmt.Fprintf(os.Stderr, "run %d exec exit=%d duration=%s%s\n", i, resp.ExitCode, execDuration.Round(time.Millisecond), warmupSuffix(measured))
+		}
+		if err := session.Close(); err != nil {
+			runCancel()
+			return fmt.Errorf("close VM run %d: %w", i, err)
+		}
+		runCancel()
+	}
+	fmt.Fprintf(os.Stderr, "average boot over %d measured runs", measuredBoots)
+	if warmup > 0 {
+		fmt.Fprintf(os.Stderr, " after %d warmup", warmup)
+	}
+	fmt.Fprintf(os.Stderr, ": %s\n", (totalBoot / time.Duration(measuredBoots)).Round(time.Millisecond))
+	if measuredExecs > 0 {
+		fmt.Fprintf(os.Stderr, "average exec over %d measured runs: %s\n", measuredExecs, (totalExec / time.Duration(measuredExecs)).Round(time.Millisecond))
+	}
+	return nil
+}
+
+func warmupSuffix(measured bool) string {
+	if measured {
+		return ""
+	}
+	return " (warmup)"
+}
+
+func windowsTinybootConfigVars() []string {
+	return []string{
+		"CONFIG_VIRTIO_MMIO",
+		"CONFIG_FUSE_FS",
+		"CONFIG_VIRTIO_FS",
+		"CONFIG_VSOCKETS",
+		"CONFIG_VIRTIO_VSOCKETS",
+		"CONFIG_HW_RANDOM",
+		"CONFIG_HW_RANDOM_VIRTIO",
+	}
+}
+
+func windowsTinybootModuleMap() map[string]string {
+	return map[string]string{
+		"CONFIG_VIRTIO_MMIO":      "kernel/drivers/virtio/virtio_mmio.ko.gz",
+		"CONFIG_FUSE_FS":          "kernel/fs/fuse/fuse.ko.gz",
+		"CONFIG_VIRTIO_FS":        "kernel/fs/fuse/virtiofs.ko.gz",
+		"CONFIG_VSOCKETS":         "kernel/net/vmw_vsock/vsock.ko.gz",
+		"CONFIG_VIRTIO_VSOCKETS":  "kernel/net/vmw_vsock/vmw_vsock_virtio_transport.ko.gz",
+		"CONFIG_HW_RANDOM":        "kernel/drivers/char/hw_random/rng-core.ko.gz",
+		"CONFIG_HW_RANDOM_VIRTIO": "kernel/drivers/char/hw_random/virtio-rng.ko.gz",
+	}
+}

--- a/internal/amd64vm/layout.go
+++ b/internal/amd64vm/layout.go
@@ -23,6 +23,9 @@ const (
 	ShareFSIRQ  = 9
 	FSStride    = 0x1000
 
+	SnapshotBase = 0xd0009000
+	SnapshotSize = 0x1000
+
 	RootFSTag   = vmruntime.RootFSTag
 	EmulatorTag = vmruntime.EmulatorTag
 	GuestCID    = vmruntime.GuestCID

--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -296,7 +295,38 @@ func startPreparedExec(cfg config, control io.Writer, active *guestagent.ActiveE
 
 func runPreparedExecInline(cfg config, control io.Writer, req preparedExecRequest, waitReady func() error) {
 	managed := &managedExec{start: time.Now()}
-	runManagedExec(cfg, control, req.ID, req.Command, req.Env, req.RootDir, req.WorkDir, req.User, io.NopCloser(bytes.NewReader(req.Stdin)), managed, req.TTY, req.ControlFD, req.Cols, req.Rows, waitReady, func() {})
+	stdin, cleanup, err := inlineExecStdin(req.Stdin)
+	if err != nil {
+		writeKernel("ccx3-init: prepare inline stdin: " + err.Error())
+		writeExecStderr(cfg, control, req.ID, "ccx3-init: prepare inline stdin: "+err.Error()+"\n")
+		reporterForConfig(cfg, control, req.ID, time.Now()).Exit(126)
+		return
+	}
+	runManagedExec(cfg, control, req.ID, req.Command, req.Env, req.RootDir, req.WorkDir, req.User, stdin, managed, req.TTY, req.ControlFD, req.Cols, req.Rows, waitReady, cleanup)
+}
+
+func inlineExecStdin(data []byte) (io.ReadCloser, func(), error) {
+	if len(data) == 0 {
+		return nil, func() {}, nil
+	}
+	file, err := os.CreateTemp("", "ccx3-stdin-*")
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() {
+		_ = os.Remove(file.Name())
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		cleanup()
+		return nil, nil, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		cleanup()
+		return nil, nil, err
+	}
+	return file, cleanup, nil
 }
 
 func newSystemdCommandGate(initSystem string) *systemdCommandGate {
@@ -403,15 +433,21 @@ func run() error {
 			return err
 		}
 		writeStage(bootStart, "rootfs mounted")
+		writeStage(bootStart, "configuring hostname")
 		if err := configureHostname(cfg.Hostname); err != nil {
 			return fmt.Errorf("configure hostname: %w", err)
 		}
+		writeStage(bootStart, "hostname configured")
+		writeStage(bootStart, "configuring runtime filesystem")
 		if err := configureRuntimeFilesystem(); err != nil {
 			return fmt.Errorf("configure runtime filesystem: %w", err)
 		}
+		writeStage(bootStart, "runtime filesystem configured")
+		writeStage(bootStart, "configuring package managers")
 		if err := configurePackageManagers(""); err != nil {
 			return fmt.Errorf("configure package managers: %w", err)
 		}
+		writeStage(bootStart, "package managers configured")
 		if cfg.PrecopyAMD64Root {
 			writeStage(bootStart, "precopying amd64 root")
 			if err := precopyAMD64Root(); err != nil {
@@ -1075,24 +1111,7 @@ func triggerSnapshotMMIO(base uint64) error {
 	if base == 0 {
 		return nil
 	}
-	file, err := os.OpenFile("/dev/mem", os.O_RDWR|syscall.O_SYNC, 0)
-	if err != nil {
-		return fmt.Errorf("open /dev/mem: %w", err)
-	}
-	defer file.Close()
-
-	pageSize := uint64(os.Getpagesize())
-	pageBase := base & ^(pageSize - 1)
-	pageOff := int(base - pageBase)
-	mapped, err := syscall.Mmap(int(file.Fd()), int64(pageBase), int(pageSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
-	if err != nil {
-		return fmt.Errorf("mmap snapshot trigger %#x: %w", base, err)
-	}
-	defer syscall.Munmap(mapped)
-	if pageOff+8 > len(mapped) {
-		return fmt.Errorf("snapshot trigger offset %#x exceeds mapped page", pageOff)
-	}
-	binary.LittleEndian.PutUint64(mapped[pageOff:pageOff+8], 0x43535833534e4150)
+	writeConsole("__CCX3_SNAPSHOT__\n")
 	return nil
 }
 

--- a/internal/hv/whp/bindings_windows_amd64.go
+++ b/internal/hv/whp/bindings_windows_amd64.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -27,6 +29,8 @@ var (
 	procWHvRunVirtualProcessor          = winhvplatform.NewProc("WHvRunVirtualProcessor")
 	procWHvGetVirtualProcessorRegisters = winhvplatform.NewProc("WHvGetVirtualProcessorRegisters")
 	procWHvSetVirtualProcessorRegisters = winhvplatform.NewProc("WHvSetVirtualProcessorRegisters")
+	procWHvGetVirtualProcessorState     = winhvplatform.NewProc("WHvGetVirtualProcessorState")
+	procWHvSetVirtualProcessorState     = winhvplatform.NewProc("WHvSetVirtualProcessorState")
 	procWHvCancelRunVirtualProcessor    = winhvplatform.NewProc("WHvCancelRunVirtualProcessor")
 	procWHvRequestInterrupt             = winhvplatform.NewProc("WHvRequestInterrupt")
 	procWHvEmulatorCreateEmulator       = winhvemulation.NewProc("WHvEmulatorCreateEmulator")
@@ -115,6 +119,13 @@ type translateGVAResult struct {
 
 type registerName uint32
 
+type virtualProcessorStateType uint32
+
+const (
+	virtualProcessorStateTypeInterruptControllerState2 virtualProcessorStateType = 0x00001000
+	virtualProcessorStateTypeXsaveState                virtualProcessorStateType = 0x00001001
+)
+
 const (
 	registerRax    registerName = 0x00000000
 	registerRcx    registerName = 0x00000001
@@ -140,10 +151,49 @@ const (
 	registerDs     registerName = 0x00000015
 	registerFs     registerName = 0x00000016
 	registerGs     registerName = 0x00000017
+	registerLdtr   registerName = 0x00000018
+	registerTr     registerName = 0x00000019
+	registerIdtr   registerName = 0x0000001a
+	registerGdtr   registerName = 0x0000001b
 	registerCr0    registerName = 0x0000001c
+	registerCr2    registerName = 0x0000001d
 	registerCr3    registerName = 0x0000001e
 	registerCr4    registerName = 0x0000001f
-	registerEfer   registerName = 0x00002001
+	registerCr8    registerName = 0x00000020
+	registerXCr0   registerName = 0x00000027
+
+	registerXmm0             registerName = 0x00001000
+	registerXmm15            registerName = 0x0000100f
+	registerFpMmx0           registerName = 0x00001010
+	registerFpMmx7           registerName = 0x00001017
+	registerFpControlStatus  registerName = 0x00001018
+	registerXmmControlStatus registerName = 0x00001019
+
+	registerTsc          registerName = 0x00002000
+	registerEfer         registerName = 0x00002001
+	registerKernelGsBase registerName = 0x00002002
+	registerApicBase     registerName = 0x00002003
+	registerPat          registerName = 0x00002004
+	registerSysenterCs   registerName = 0x00002005
+	registerSysenterEip  registerName = 0x00002006
+	registerSysenterEsp  registerName = 0x00002007
+	registerStar         registerName = 0x00002008
+	registerLstar        registerName = 0x00002009
+	registerCstar        registerName = 0x0000200a
+	registerSfmask       registerName = 0x0000200b
+	registerXss          registerName = 0x0000208b
+	registerUCet         registerName = 0x0000208c
+	registerSCet         registerName = 0x0000208d
+	registerSsp          registerName = 0x0000208e
+	registerPl0Ssp       registerName = 0x0000208f
+	registerPl1Ssp       registerName = 0x00002090
+	registerPl2Ssp       registerName = 0x00002091
+	registerPl3Ssp       registerName = 0x00002092
+	registerInterruptSsp registerName = 0x00002093
+	registerTscDeadline  registerName = 0x00002095
+	registerTscAdjust    registerName = 0x00002096
+	registerXfd          registerName = 0x00002099
+	registerXfdErr       registerName = 0x0000209a
 
 	registerPendingInterruption         registerName = 0x80000000
 	registerDeliverabilityNotifications registerName = 0x80000004
@@ -350,8 +400,9 @@ func (c *runVPExitContext) apicEoi() *x64ApicEoiContext {
 }
 
 type allocation struct {
-	addr uintptr
-	size uintptr
+	addr    uintptr
+	size    uintptr
+	mapping windows.Handle
 }
 
 func virtualAlloc(size uintptr) (*allocation, error) {
@@ -370,6 +421,40 @@ func virtualAlloc(size uintptr) (*allocation, error) {
 	return &allocation{addr: ptr, size: size}, nil
 }
 
+func virtualMapFile(path string, size uintptr) (*allocation, error) {
+	if size == 0 {
+		return nil, fmt.Errorf("memory mapping size must be non-zero")
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ|windows.GENERIC_EXECUTE,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(file)
+
+	mapping, err := windows.CreateFileMapping(file, nil, windows.PAGE_EXECUTE_WRITECOPY, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_COPY|windows.FILE_MAP_EXECUTE, 0, 0, size)
+	if err != nil {
+		_ = windows.CloseHandle(mapping)
+		return nil, err
+	}
+	return &allocation{addr: addr, size: size, mapping: mapping}, nil
+}
+
 func (a *allocation) bytes() []byte {
 	return unsafe.Slice((*byte)(unsafe.Pointer(a.addr)), int(a.size))
 }
@@ -377,6 +462,19 @@ func (a *allocation) bytes() []byte {
 func (a *allocation) free() error {
 	if a == nil || a.addr == 0 {
 		return nil
+	}
+	if a.mapping != 0 {
+		var first error
+		if err := windows.UnmapViewOfFile(a.addr); err != nil && first == nil {
+			first = err
+		}
+		if err := windows.CloseHandle(a.mapping); err != nil && first == nil {
+			first = err
+		}
+		a.addr = 0
+		a.size = 0
+		a.mapping = 0
+		return first
 	}
 	const memRelease = 0x8000
 	r1, _, err := procVirtualFree.Call(a.addr, 0, memRelease)
@@ -524,6 +622,59 @@ func setVirtualProcessorRegisters(part partitionHandle, vpIndex uint32, names []
 	runtime.KeepAlive(names)
 	runtime.KeepAlive(values)
 	runtime.KeepAlive(backing)
+	return err
+}
+
+func getVirtualProcessorState(part partitionHandle, vpIndex uint32, stateType virtualProcessorStateType) ([]byte, error) {
+	var written uint32
+	probe := []byte{0}
+	err := callGetVirtualProcessorState(part, vpIndex, stateType, probe, &written)
+	if err == nil {
+		return probe[:written], nil
+	}
+	if written == 0 {
+		return nil, err
+	}
+	buf := make([]byte, written)
+	if err := callGetVirtualProcessorState(part, vpIndex, stateType, buf, &written); err != nil {
+		return nil, err
+	}
+	return buf[:written], nil
+}
+
+func callGetVirtualProcessorState(part partitionHandle, vpIndex uint32, stateType virtualProcessorStateType, buf []byte, written *uint32) error {
+	if len(buf) == 0 {
+		return fmt.Errorf("virtual processor state buffer is empty")
+	}
+	r1, _, callErr := procWHvGetVirtualProcessorState.Call(
+		uintptr(part),
+		uintptr(vpIndex),
+		uintptr(stateType),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		uintptr(unsafe.Pointer(written)),
+	)
+	if callErr != syscall.Errno(0) && r1 == 0 {
+		return callErr
+	}
+	runtime.KeepAlive(buf)
+	runtime.KeepAlive(written)
+	return hresult(int32(r1)).Err()
+}
+
+func setVirtualProcessorState(part partitionHandle, vpIndex uint32, stateType virtualProcessorStateType, buf []byte) error {
+	if len(buf) == 0 {
+		return fmt.Errorf("virtual processor state buffer is empty")
+	}
+	err := callHRESULT(
+		procWHvSetVirtualProcessorState,
+		uintptr(part),
+		uintptr(vpIndex),
+		uintptr(stateType),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+	)
+	runtime.KeepAlive(buf)
 	return err
 }
 

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -338,6 +338,7 @@ type bootPlatform struct {
 	i8042         *I8042
 	rtc           *CMOSRTC
 	acpiPM        *ACPIPM
+	snapshot      *snapshotTrigger
 	start         time.Time
 	irqAttempts   uint64
 	irqDelivered  uint64
@@ -430,13 +431,21 @@ func (p *bootPlatform) vpRegisterSummary() string {
 }
 
 func newBootPlatform(vm *VM, uart *serial.UART8250) *bootPlatform {
+	return newBootPlatformWithOptions(vm, uart, true)
+}
+
+func newRestoredBootPlatform(vm *VM, uart *serial.UART8250) *bootPlatform {
+	return newBootPlatformWithOptions(vm, uart, false)
+}
+
+func newBootPlatformWithOptions(vm *VM, uart *serial.UART8250, attachUARTIRQ bool) *bootPlatform {
 	p := &bootPlatform{vm: vm, uart: uart, start: time.Now()}
 	p.pic.master.vectorBase = 0x20
 	p.pic.slave.vectorBase = 0x28
 	p.pic.master.mask = 0xff
 	p.pic.slave.mask = 0xff
 	p.ioapic.init()
-	if uart != nil {
+	if uart != nil && attachUARTIRQ {
 		uart.AttachIRQ(p, amd64vm.COM1IRQ)
 	}
 	p.pit = newBootPIT(func() {
@@ -809,7 +818,7 @@ func (p *bootPlatform) armPendingIRQWindow() error {
 	if !p.hasPendingIRQ() {
 		return nil
 	}
-	if delivered, err := p.flushHaltedPICIRQ(); err != nil {
+	if delivered, err := p.flushHaltedPendingIRQ(); err != nil {
 		return err
 	} else if delivered {
 		return nil
@@ -818,6 +827,26 @@ func (p *bootPlatform) armPendingIRQWindow() error {
 }
 
 func (p *bootPlatform) resampleDeviceIRQs() {
+	if p.vsock != nil && p.vsock.IRQAsserted() {
+		line := uint8(p.vsock.IRQ)
+		if route, pending := p.ioapic.assert(line, true); pending {
+			p.injectIOAPIC(route, true)
+		}
+	}
+	if p.rng != nil && p.rng.IRQAsserted() {
+		line := uint8(p.rng.IRQ)
+		if route, pending := p.ioapic.assert(line, true); pending {
+			p.injectIOAPIC(route, true)
+		}
+	}
+	for _, fsdev := range p.fsdevs {
+		if fsdev != nil && fsdev.IRQAsserted() {
+			line := uint8(fsdev.IRQ)
+			if route, pending := p.ioapic.assert(line, true); pending {
+				p.injectIOAPIC(route, true)
+			}
+		}
+	}
 	if p.netdev != nil && p.netdev.IRQAsserted() {
 		line := uint8(p.netdev.IRQ)
 		if route, pending := p.ioapic.assert(line, true); pending {
@@ -887,14 +916,28 @@ func (p *bootPlatform) queuePendingPICIRQ(route bootIOAPICRoute, trigger interru
 	})
 }
 
-func (p *bootPlatform) flushHaltedPICIRQ() (bool, error) {
+func (p *bootPlatform) injectPendingInterruption(vector uint8) (bool, error) {
+	ready, err := p.vm.canSetPendingInterruption(vector)
+	if err != nil || !ready {
+		return false, err
+	}
+	if err := p.vm.SetPendingInterruption(vector); err != nil {
+		return false, err
+	}
+	_ = p.vm.kickOutOfHLT()
+	p.vm.kickIfRunning()
+	atomic.AddUint64(&p.irqDelivered, 1)
+	return true, nil
+}
+
+func (p *bootPlatform) flushHaltedPendingIRQ() (bool, error) {
 	p.pendingMu.Lock()
 	if len(p.pendingIRQs) == 0 {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
 	pending := p.pendingIRQs[0]
-	if !pending.pic {
+	if !pending.pic && !p.usePendingInterruptionFallback(pending.route.line) {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
@@ -907,7 +950,12 @@ func (p *bootPlatform) flushHaltedPICIRQ() (bool, error) {
 	}
 
 	p.pendingMu.Lock()
-	if len(p.pendingIRQs) == 0 || !p.pendingIRQs[0].pic || p.pendingIRQs[0].route.vector != route.vector {
+	if len(p.pendingIRQs) == 0 || p.pendingIRQs[0].route.vector != route.vector {
+		p.pendingMu.Unlock()
+		return false, nil
+	}
+	pending = p.pendingIRQs[0]
+	if !pending.pic && !p.usePendingInterruptionFallback(pending.route.line) {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
@@ -916,13 +964,7 @@ func (p *bootPlatform) flushHaltedPICIRQ() (bool, error) {
 	p.pendingIRQ[route.vector] = false
 	p.pendingMu.Unlock()
 
-	if err := p.vm.SetPendingInterruption(route.vector); err != nil {
-		atomic.AddUint64(&p.irqFailed, 1)
-		return false, err
-	}
-	_ = p.vm.kickOutOfHLT()
-	atomic.AddUint64(&p.irqDelivered, 1)
-	return true, nil
+	return p.injectPendingInterruption(route.vector)
 }
 
 func (p *bootPlatform) markDeferredDeviceIRQ(line uint8) {
@@ -1000,12 +1042,13 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 		return false, nil
 	}
 	pending := p.pendingIRQs[0]
+	fallback := pending.pic || p.usePendingInterruptionFallback(pending.route.line)
 	if ctx == nil {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
 	windowExit := ctx.ExitReason == runVPExitReasonX64InterruptWindow
-	if !windowExit && !canAcceptInterrupt(ctx, pending.route.vector) {
+	if !windowExit && !canAcceptInterrupt(ctx, pending.route.vector) && !(fallback && canSetPendingInterruption(ctx, pending.route.vector)) {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
@@ -1034,7 +1077,7 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 		p.pendingIRQ[route.vector] = false
 		p.pendingMu.Unlock()
 		var err error
-		if pending.pic || p.usePendingInterruptionFallback(route.line) {
+		if fallback {
 			err = p.vm.SetPendingInterruption(route.vector)
 		} else {
 			if route.level && !p.ioapic.beginInterrupt(route.vector) {
@@ -1057,7 +1100,7 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 	p.pendingMu.Unlock()
 
 	_ = p.vm.kickOutOfHLT()
-	if pending.pic {
+	if fallback {
 		if err := p.vm.SetPendingInterruption(route.vector); err != nil {
 			atomic.AddUint64(&p.irqFailed, 1)
 			return false, err
@@ -1144,6 +1187,17 @@ func canAcceptInterrupt(ctx *runVPExitContext, vector uint8) bool {
 	}
 	const rflagsInterruptEnable = uint64(1 << 9)
 	if ctx.VpContext.Rflags&rflagsInterruptEnable == 0 {
+		return false
+	}
+	priority := vector >> 4
+	return priority == 0 || priority > ctx.VpContext.cr8()
+}
+
+func canSetPendingInterruption(ctx *runVPExitContext, vector uint8) bool {
+	if ctx == nil {
+		return true
+	}
+	if ctx.VpContext.ExecutionState.interruptionPending() || ctx.VpContext.ExecutionState.interruptShadow() {
 		return false
 	}
 	priority := vector >> 4
@@ -1238,6 +1292,42 @@ type bootHPET struct {
 	config     uint64
 	counter    uint64
 	lastUpdate time.Time
+}
+
+type bootHPETState struct {
+	Config       uint64 `json:"config"`
+	Counter      uint64 `json:"counter"`
+	ElapsedNanos int64  `json:"elapsed_nanos,omitempty"`
+}
+
+func (h *bootHPET) SnapshotState() bootHPETState {
+	if h == nil {
+		return bootHPETState{}
+	}
+	h.update()
+	state := bootHPETState{
+		Config:  h.config,
+		Counter: h.counter,
+	}
+	if !h.lastUpdate.IsZero() {
+		state.ElapsedNanos = time.Since(h.lastUpdate).Nanoseconds()
+	}
+	return state
+}
+
+func (h *bootHPET) RestoreState(state bootHPETState) {
+	if h == nil {
+		return
+	}
+	h.config = state.Config
+	h.counter = state.Counter
+	if state.ElapsedNanos != 0 {
+		h.lastUpdate = time.Now().Add(-time.Duration(state.ElapsedNanos))
+	} else if h.config&1 != 0 {
+		h.lastUpdate = time.Now()
+	} else {
+		h.lastUpdate = time.Time{}
+	}
 }
 
 func (h *bootHPET) read(offset uint64) uint64 {

--- a/internal/hv/whp/exec_windows_amd64.go
+++ b/internal/hv/whp/exec_windows_amd64.go
@@ -50,7 +50,7 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 		_, _ = io.Copy(controlTranscript, conn)
 	}()
 
-	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, nil)
+	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, "", nil)
 	if err != nil {
 		return client.ExecResponse{}, "", err
 	}
@@ -151,7 +151,7 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 	return client.ExecResponse{ExitCode: code, Output: output, Usage: usage}, serialOut.String(), nil
 }
 
-func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
+func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, snapshotDir string, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
 	vm, err := newBootVM(amd64vm.MemorySizeBytes(memoryMB))
 	if err != nil {
 		return nil, nil, nil, err
@@ -196,7 +196,10 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 	} else {
 		serialWriter = io.MultiWriter(serialOut, serialWriter)
 	}
+	snapshot := newSnapshotTrigger(snapshotDir, vm.Memory())
+	serialWriter = snapshot.wrapSerialWriter(serialWriter)
 	platform := newBootPlatform(vm, serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter))
+	platform.snapshot = snapshot
 	for _, fsdev := range fsdevs {
 		if fsdev != nil {
 			platform.AttachFS(fsdev)
@@ -239,6 +242,9 @@ func runManagedExecVM(ctx context.Context, vm *VM, platform *bootPlatform, seria
 			if err := vm.emulateIO(&raw); err != nil {
 				io := raw.ioPortAccess()
 				return fmt.Errorf("emulate io at rip=%#x port=%#x: %w", exit.RIP, io.Port, err)
+			}
+			if err := platform.captureSnapshotIfPending(vm); err != nil {
+				return err
 			}
 		case runVPExitReasonMemoryAccess:
 			if err := vm.emulateMMIO(&raw); err != nil {

--- a/internal/hv/whp/host_windows_amd64.go
+++ b/internal/hv/whp/host_windows_amd64.go
@@ -19,16 +19,20 @@ import (
 type Host struct{}
 
 type LinuxManagedMachine struct {
-	Spec      machine.Spec
-	Kernel    []byte
-	Initrd    []byte
-	FSDevices []*virtio.FS
-	NetDevice *virtio.Net
+	Spec            machine.Spec
+	Kernel          []byte
+	Initrd          []byte
+	FSDevices       []*virtio.FS
+	NetDevice       *virtio.Net
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 type LinuxManagedAttachments struct {
-	FSDevices []*virtio.FS
-	NetDevice *virtio.Net
+	FSDevices       []*virtio.FS
+	NetDevice       *virtio.Net
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 type BSDManagedAttachments struct {
@@ -108,26 +112,23 @@ func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEven
 		return nil, fmt.Errorf("whp linux managed attachments have type %T", req.Attachments)
 	}
 	return Host{}.StartLinuxManaged(ctx, LinuxManagedMachine{
-		Spec:      req.Spec,
-		Kernel:    req.Artifact.Kernel,
-		Initrd:    req.Artifact.Initrd,
-		FSDevices: attachments.FSDevices,
-		NetDevice: attachments.NetDevice,
+		Spec:            req.Spec,
+		Kernel:          req.Artifact.Kernel,
+		Initrd:          req.Artifact.Initrd,
+		FSDevices:       attachments.FSDevices,
+		NetDevice:       attachments.NetDevice,
+		SnapshotDir:     attachments.SnapshotDir,
+		RestoreSnapshot: attachments.RestoreSnapshot,
 	}, onEvent)
 }
 
 func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
 	machine = normalizeLinuxManagedMachine(machine)
-	return StartManagedSessionWithNet(
-		ctx,
-		machine.Kernel,
-		machine.Initrd,
-		machine.Spec.MemoryMB,
-		machine.Spec.Dmesg,
-		machine.FSDevices,
-		machine.NetDevice,
-		onEvent,
-	)
+	opts := ManagedSessionOptions{
+		SnapshotDir:     strings.TrimSpace(machine.SnapshotDir),
+		RestoreSnapshot: strings.TrimSpace(machine.RestoreSnapshot),
+	}
+	return StartManagedSessionWithNetOptions(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, opts, onEvent)
 }
 
 func normalizeLinuxManagedMachine(machine LinuxManagedMachine) LinuxManagedMachine {

--- a/internal/hv/whp/platform_amd64_windows.go
+++ b/internal/hv/whp/platform_amd64_windows.go
@@ -28,6 +28,71 @@ type bootPICChip struct {
 	lastIRR    byte
 }
 
+type bootPICState struct {
+	Master   bootPICChipState `json:"master"`
+	Slave    bootPICChipState `json:"slave"`
+	ELCR     [2]byte          `json:"elcr"`
+	LineHigh [16]bool         `json:"line_high"`
+}
+
+type bootPICChipState struct {
+	VectorBase uint8 `json:"vector_base"`
+	Mask       uint8 `json:"mask"`
+	ICWStep    uint8 `json:"icw_step"`
+	OCW3       byte  `json:"ocw3"`
+	IRR        byte  `json:"irr"`
+	ISR        byte  `json:"isr"`
+	LastIRR    byte  `json:"last_irr"`
+}
+
+func (p *bootPIC) SnapshotState() bootPICState {
+	if p == nil {
+		return bootPICState{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return bootPICState{
+		Master:   p.master.snapshotState(),
+		Slave:    p.slave.snapshotState(),
+		ELCR:     p.elcr,
+		LineHigh: p.lineHigh,
+	}
+}
+
+func (p *bootPIC) RestoreState(state bootPICState) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.master.restoreState(state.Master)
+	p.slave.restoreState(state.Slave)
+	p.elcr = state.ELCR
+	p.lineHigh = state.LineHigh
+}
+
+func (c bootPICChip) snapshotState() bootPICChipState {
+	return bootPICChipState{
+		VectorBase: c.vectorBase,
+		Mask:       c.mask,
+		ICWStep:    c.icwStep,
+		OCW3:       c.ocw3,
+		IRR:        c.irr,
+		ISR:        c.isr,
+		LastIRR:    c.lastIRR,
+	}
+}
+
+func (c *bootPICChip) restoreState(state bootPICChipState) {
+	c.vectorBase = state.VectorBase
+	c.mask = state.Mask
+	c.icwStep = state.ICWStep
+	c.ocw3 = state.OCW3
+	c.irr = state.IRR
+	c.isr = state.ISR
+	c.lastIRR = state.LastIRR
+}
+
 func (p *bootPIC) Read(port uint16, data []byte) bool {
 	if len(data) != 1 {
 		return false
@@ -351,6 +416,70 @@ type bootPITChannel struct {
 	gate     bool
 }
 
+type bootPITState struct {
+	Channels [3]bootPITChannelState `json:"channels"`
+	Selected uint8                  `json:"selected"`
+	Port61   byte                   `json:"port61"`
+}
+
+type bootPITChannelState struct {
+	Reload       uint16 `json:"reload"`
+	LowByte      byte   `json:"low_byte"`
+	HaveLow      bool   `json:"have_low"`
+	ReadHigh     bool   `json:"read_high"`
+	ElapsedNanos int64  `json:"elapsed_nanos"`
+	Gate         bool   `json:"gate"`
+}
+
+func (p *bootPIT) SnapshotState() bootPITState {
+	if p == nil {
+		return bootPITState{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	var state bootPITState
+	state.Selected = p.selected
+	state.Port61 = p.port61
+	for i, ch := range p.channels {
+		state.Channels[i] = bootPITChannelState{
+			Reload:       ch.reload,
+			LowByte:      ch.lowByte,
+			HaveLow:      ch.haveLow,
+			ReadHigh:     ch.readHigh,
+			ElapsedNanos: now.Sub(ch.start).Nanoseconds(),
+			Gate:         ch.gate,
+		}
+	}
+	return state
+}
+
+func (p *bootPIT) RestoreState(state bootPITState) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.stopTickerLocked()
+	p.selected = state.Selected
+	p.port61 = state.Port61
+	now := time.Now()
+	for i, ch := range state.Channels {
+		p.channels[i] = bootPITChannel{
+			reload:   ch.Reload,
+			lowByte:  ch.LowByte,
+			haveLow:  ch.HaveLow,
+			readHigh: ch.ReadHigh,
+			start:    now.Add(-time.Duration(ch.ElapsedNanos)),
+			gate:     ch.Gate,
+		}
+		if p.channels[i].reload == 0 {
+			p.channels[i].reload = 0xffff
+		}
+	}
+	p.armChannel0Locked()
+}
+
 func (p *bootPIT) Close() {
 	p.mu.Lock()
 	p.closed = true
@@ -536,6 +665,45 @@ type bootIOAPIC struct {
 	version  uint32
 	inFlight [256]bool
 	lineHigh [ioapicRedirEntries]bool
+}
+
+type bootIOAPICState struct {
+	Index    uint32                     `json:"index"`
+	Redir    [ioapicRedirEntries]uint64 `json:"redir"`
+	Version  uint32                     `json:"version"`
+	InFlight [256]bool                  `json:"in_flight"`
+	LineHigh [ioapicRedirEntries]bool   `json:"line_high"`
+}
+
+func (a *bootIOAPIC) SnapshotState() bootIOAPICState {
+	if a == nil {
+		return bootIOAPICState{}
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return bootIOAPICState{
+		Index:    a.index,
+		Redir:    a.redir,
+		Version:  a.version,
+		InFlight: a.inFlight,
+		LineHigh: a.lineHigh,
+	}
+}
+
+func (a *bootIOAPIC) RestoreState(state bootIOAPICState) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.index = state.Index
+	a.redir = state.Redir
+	a.version = state.Version
+	if a.version == 0 {
+		a.version = 0x11 | ((ioapicRedirEntries - 1) << 16)
+	}
+	a.inFlight = state.InFlight
+	a.lineHigh = state.LineHigh
 }
 
 type bootIOAPICRoute struct {

--- a/internal/hv/whp/session_windows_amd64.go
+++ b/internal/hv/whp/session_windows_amd64.go
@@ -4,6 +4,7 @@ package whp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -30,9 +31,16 @@ type ManagedSession struct {
 	transcript *vmruntime.SerialTranscript
 	serialOut  *vmruntime.SerialTranscript
 	platform   *bootPlatform
+	waitOnce   sync.Once
+	waitErr    error
 	sendMu     sync.Mutex
 	nextID     atomic.Uint64
 	dmesg      bool
+}
+
+type ManagedSessionOptions struct {
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 const (
@@ -45,6 +53,13 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 }
 
 func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithNetOptions(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, netdev, ManagedSessionOptions{}, onEvent)
+}
+
+func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if snapshotPath := strings.TrimSpace(opts.RestoreSnapshot); snapshotPath != "" {
+		return StartManagedSessionFromSnapshot(ctx, snapshotPath, memoryMB, dmesg, fsdevs, netdev, onEvent)
+	}
 	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
 		return nil, err
 	}
@@ -74,7 +89,7 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = bootWriter
 	}
-	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, serialWriter)
+	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, strings.TrimSpace(opts.SnapshotDir), serialWriter)
 	if err != nil {
 		_ = listener.Close()
 		vsock.Close()
@@ -87,9 +102,10 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 	runCtx, cancel := context.WithCancel(context.Background())
 	doneCh := make(chan error, 1)
 	go func() {
-		defer vm.Close()
-		defer platform.Close()
-		doneCh <- runManagedExecVM(runCtx, vm, platform, serialOut)
+		err := runManagedExecVM(runCtx, vm, platform, serialOut)
+		platform.Close()
+		vm.Close()
+		doneCh <- err
 	}()
 
 	var control virtio.VsockConn
@@ -178,10 +194,9 @@ func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (clie
 	}
 	id := strconv.FormatUint(s.nextID.Add(1), 10)
 	start := s.transcript.Len()
-	s.sendMu.Lock()
-	err := managedagent.SendExec(s.control, id, req)
-	s.sendMu.Unlock()
-	if err != nil {
+	execReq := req
+	execReq.Kind = "exec_inline"
+	if err := s.sendExecMessage(managedagent.ExecRequest(id, execReq)); err != nil {
 		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
 	}
 	segment, err := s.transcript.WaitFor(ctx, start, func(text string) bool {
@@ -189,7 +204,7 @@ func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (clie
 		return ok
 	})
 	if err != nil {
-		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+		return client.ExecResponse{}, transcriptError(s.withPlatformSummary(err), s.serialOut.String(), s.transcript.String())
 	}
 	code, output, usage, ok := vmruntime.ExtractManagedExecResult(segment, id, s.dmesg)
 	if !ok {
@@ -212,7 +227,7 @@ func (s *ManagedSession) Flush(ctx context.Context) error {
 		return ok
 	})
 	if err != nil {
-		return transcriptError(err, s.serialOut.String(), s.transcript.String())
+		return transcriptError(s.withPlatformSummary(err), s.serialOut.String(), s.transcript.String())
 	}
 	code, output, _, ok := vmruntime.ExtractManagedExecResult(segment, id, s.dmesg)
 	if !ok {
@@ -292,7 +307,13 @@ func (s *ManagedSession) sendStdinClose(id string) error {
 func (s *ManagedSession) sendExecMessage(msg vmruntime.ManagedExecRequest) error {
 	s.sendMu.Lock()
 	defer s.sendMu.Unlock()
-	return managedagent.Send(s.control, msg)
+	if err := managedagent.Send(s.control, msg); err != nil {
+		return err
+	}
+	if s.vsock != nil {
+		return s.vsock.Kick()
+	}
+	return nil
 }
 
 func (s *ManagedSession) streamExecEvents(ctx context.Context, start int, id string, onEvent func(client.ExecEvent) error) error {
@@ -326,9 +347,16 @@ func (s *ManagedSession) streamExecEvents(ctx context.Context, start int, id str
 		},
 	})
 	if err != nil {
-		return transcriptError(err, s.serialOut.String(), s.transcript.String())
+		return transcriptError(s.withPlatformSummary(err), s.serialOut.String(), s.transcript.String())
 	}
 	return nil
+}
+
+func (s *ManagedSession) withPlatformSummary(err error) error {
+	if err == nil || s == nil || s.platform == nil {
+		return err
+	}
+	return fmt.Errorf("%w (%s)", err, s.platform.Summary())
 }
 
 func (s *ManagedSession) terminateExecAndWait(id string, start int) {
@@ -354,7 +382,10 @@ func (s *ManagedSession) Wait() error {
 	if s == nil || s.doneCh == nil {
 		return nil
 	}
-	return <-s.doneCh
+	s.waitOnce.Do(func() {
+		s.waitErr = <-s.doneCh
+	})
+	return s.waitErr
 }
 
 func (s *ManagedSession) Close() error {
@@ -375,6 +406,9 @@ func (s *ManagedSession) Close() error {
 	}
 	if s.cancel != nil {
 		s.cancel()
+	}
+	if err := s.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		return err
 	}
 	return nil
 }

--- a/internal/hv/whp/snapshot_windows_amd64.go
+++ b/internal/hv/whp/snapshot_windows_amd64.go
@@ -1,0 +1,839 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/amd64vm"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const (
+	snapshotTriggerMagic        = 0x43535833534e4150
+	snapshotTriggerSerialMarker = "__CCX3_SNAPSHOT__"
+)
+
+type snapshotTrigger struct {
+	base uint64
+	size uint64
+	dir  string
+	mem  []byte
+
+	mu      sync.Mutex
+	pending bool
+	value   uint64
+	once    sync.Once
+	err     error
+}
+
+type whpSnapshotManifest struct {
+	Format        string                      `json:"format"`
+	Partial       bool                        `json:"partial"`
+	CapturedAt    string                      `json:"captured_at"`
+	TriggerBase   uint64                      `json:"trigger_base"`
+	TriggerValue  uint64                      `json:"trigger_value"`
+	MemoryBase    uint64                      `json:"memory_base"`
+	MemorySize    uint64                      `json:"memory_size"`
+	MemoryFile    string                      `json:"memory_file"`
+	CapturedVCPU  int                         `json:"captured_vcpu"`
+	VCPURegisters map[string]snapshotRegister `json:"vcpu_registers"`
+	VCPUStates    map[string][]byte           `json:"vcpu_states,omitempty"`
+	Devices       map[string]virtio.MMIOState `json:"devices,omitempty"`
+	Platform      whpSnapshotPlatformManifest `json:"platform"`
+	Note          string                      `json:"note"`
+}
+
+type snapshotRegister struct {
+	Low64  uint64 `json:"low64"`
+	High64 uint64 `json:"high64,omitempty"`
+}
+
+type whpSnapshotPlatformManifest struct {
+	PIC    bootPICState    `json:"pic"`
+	PIT    bootPITState    `json:"pit"`
+	IOAPIC bootIOAPICState `json:"ioapic"`
+	HPET   bootHPETState   `json:"hpet"`
+}
+
+func newSnapshotTrigger(dir string, mem []byte) *snapshotTrigger {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	return &snapshotTrigger{
+		base: amd64vm.SnapshotBase,
+		size: amd64vm.SnapshotSize,
+		dir:  dir,
+		mem:  mem,
+	}
+}
+
+func (s *snapshotTrigger) contains(addr uint64, size int) bool {
+	return s != nil && size > 0 && addr >= s.base && addr+uint64(size) <= s.base+s.size
+}
+
+func (s *snapshotTrigger) markWrite(value uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.pending = true
+	s.value = value
+	s.mu.Unlock()
+}
+
+func (s *snapshotTrigger) takePending() (uint64, bool) {
+	if s == nil {
+		return 0, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.pending {
+		return 0, false
+	}
+	s.pending = false
+	return s.value, true
+}
+
+func (s *snapshotTrigger) wrapSerialWriter(w io.Writer) io.Writer {
+	if s == nil {
+		return w
+	}
+	return &snapshotSerialWriter{dst: w, trigger: s}
+}
+
+type snapshotSerialWriter struct {
+	dst     io.Writer
+	trigger *snapshotTrigger
+	recent  string
+}
+
+func (w *snapshotSerialWriter) Write(data []byte) (int, error) {
+	if w.trigger != nil && len(data) != 0 {
+		w.recent += string(data)
+		if len(w.recent) > len(snapshotTriggerSerialMarker)*2 {
+			w.recent = w.recent[len(w.recent)-len(snapshotTriggerSerialMarker)*2:]
+		}
+		if strings.Contains(w.recent, snapshotTriggerSerialMarker) {
+			w.trigger.markWrite(snapshotTriggerMagic)
+			w.recent = ""
+		}
+	}
+	if w.dst == nil {
+		return len(data), nil
+	}
+	return w.dst.Write(data)
+}
+
+func (p *bootPlatform) captureSnapshotIfPending(vm *VM) error {
+	if p == nil || p.snapshot == nil {
+		return nil
+	}
+	value, ok := p.snapshot.takePending()
+	if !ok {
+		return nil
+	}
+	p.snapshot.once.Do(func() {
+		p.snapshot.err = p.snapshot.capture(vm, p, value)
+	})
+	if p.snapshot.err != nil {
+		return fmt.Errorf("capture WHP snapshot: %w", p.snapshot.err)
+	}
+	return nil
+}
+
+func (s *snapshotTrigger) capture(vm *VM, platform *bootPlatform, value uint64) error {
+	if s == nil || strings.TrimSpace(s.dir) == "" {
+		return nil
+	}
+	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create snapshot dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
+		return fmt.Errorf("write snapshot memory: %w", err)
+	}
+	states, err := snapshotWHPStates(vm)
+	if err != nil {
+		return fmt.Errorf("capture WHP vCPU state: %w", err)
+	}
+	manifest := whpSnapshotManifest{
+		Format:        "ccx3-whp-snapshot-v0",
+		Partial:       true,
+		CapturedAt:    time.Now().UTC().Format(time.RFC3339Nano),
+		TriggerBase:   s.base,
+		TriggerValue:  value,
+		MemoryBase:    amd64vm.MemoryBase,
+		MemorySize:    uint64(len(s.mem)),
+		MemoryFile:    "memory.bin",
+		CapturedVCPU:  0,
+		VCPURegisters: snapshotWHPRegisters(vm),
+		VCPUStates:    states,
+		Devices:       snapshotWHPDeviceStates(platform),
+		Platform:      snapshotWHPPlatform(platform),
+		Note:          "WHP Linux checkpoint captured after guest init configured non-unique state and before vsock ready.",
+	}
+	if manifest.VCPURegisters == nil {
+		return fmt.Errorf("capture WHP vCPU registers")
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
+		return fmt.Errorf("write snapshot manifest: %w", err)
+	}
+	return nil
+}
+
+func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if err := emitManagedBootStatus(onEvent, "restoring VM snapshot"); err != nil {
+		return nil, err
+	}
+	manifest, memPath, err := loadWHPSnapshot(snapshotPath)
+	if err != nil {
+		return nil, err
+	}
+	if memoryMB == 0 {
+		memoryMB = manifest.MemorySize >> 20
+	}
+	backend := virtio.NewSimpleVsockBackend()
+	listener, err := backend.Listen(vmruntime.ControlPort)
+	if err != nil {
+		return nil, fmt.Errorf("listen vsock control: %w", err)
+	}
+	vsock := virtio.NewVsock(amd64vm.VsockBase, amd64vm.VsockSize, amd64vm.VsockIRQ, vmruntime.GuestCID, backend)
+	connCh := make(chan virtio.VsockConn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+
+	var bootWriter *vmruntime.BootEventWriter
+	var serialWriter io.Writer
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = bootWriter
+	}
+	vm, platform, serialOut, err := restoreManagedVMFromSnapshot(manifest, memPath, memoryMB, dmesg, fsdevs, vsock, netdev, serialWriter)
+	if err != nil {
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error, 1)
+	go func() {
+		err := runManagedExecVM(runCtx, vm, platform, serialOut)
+		platform.Close()
+		vm.Close()
+		doneCh <- err
+	}()
+
+	var control virtio.VsockConn
+	select {
+	case err := <-acceptErrCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+	case err := <-doneCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(fmt.Errorf("%w (%s)", ctx.Err(), platform.Summary()), serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		if ctx.Err() != nil {
+			err = fmt.Errorf("%w (%s)", err, platform.Summary())
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	return &ManagedSession{
+		cancel:     cancel,
+		doneCh:     doneCh,
+		control:    control,
+		listener:   listener,
+		vsock:      vsock,
+		bootWriter: bootWriter,
+		transcript: controlTranscript,
+		serialOut:  serialOut,
+		platform:   platform,
+		dmesg:      dmesg,
+	}, nil
+}
+
+func restoreManagedVMFromSnapshot(manifest whpSnapshotManifest, memPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
+	memorySize := amd64vm.MemorySizeBytes(memoryMB)
+	if manifest.MemorySize != 0 && manifest.MemorySize != memorySize {
+		return nil, nil, nil, fmt.Errorf("snapshot memory size %d does not match requested VM memory %d", manifest.MemorySize, memorySize)
+	}
+	mem, err := virtualMapFile(memPath, uintptr(memorySize))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("map snapshot memory: %w", err)
+	}
+	vm, err := newVMWithAllocation(memorySize, true, mem)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	serialOut := vmruntime.NewSerialTranscript()
+	if serialWriter == nil {
+		serialWriter = serialOut
+	} else {
+		serialWriter = io.MultiWriter(serialOut, serialWriter)
+	}
+	platform := newRestoredBootPlatform(vm, serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter))
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			fsdev.Async = false
+			platform.AttachFS(fsdev)
+		}
+	}
+	if vsock != nil {
+		platform.AttachVsock(vsock)
+	}
+	if netdev != nil {
+		platform.AttachNet(netdev)
+	}
+	rng := virtio.NewRNG(amd64vm.RNGBase, amd64vm.RNGSize, amd64vm.RNGIRQ)
+	platform.AttachRNG(rng)
+	restoreWHPPlatform(platform, manifest.Platform)
+	if err := restoreWHPDeviceStates(manifest.Devices, platform); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	platform.deassertDeviceIRQs()
+	if err := restoreWHPPreStateRegisters(vm, manifest.VCPURegisters); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	if err := restoreWHPStates(vm, manifest.VCPUStates); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	if err := restoreWHPRegisters(vm, manifest.VCPURegisters); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	platform.resampleDeviceIRQs()
+	if err := vm.EnableEmulation(platform); err != nil {
+		platform.Close()
+		_ = vm.Close()
+		return nil, nil, serialOut, fmt.Errorf("enable emulation: %w", err)
+	}
+	return vm, platform, serialOut, nil
+}
+
+func loadWHPSnapshot(path string) (whpSnapshotManifest, string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return whpSnapshotManifest{}, "", fmt.Errorf("snapshot path is required")
+	}
+	manifestPath := path
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		manifestPath = filepath.Join(path, "manifest.json")
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return whpSnapshotManifest{}, "", fmt.Errorf("read snapshot manifest: %w", err)
+	}
+	var manifest whpSnapshotManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return whpSnapshotManifest{}, "", fmt.Errorf("decode snapshot manifest: %w", err)
+	}
+	if manifest.Format != "ccx3-whp-snapshot-v0" {
+		return whpSnapshotManifest{}, "", fmt.Errorf("unsupported WHP snapshot format %q", manifest.Format)
+	}
+	memPath := manifest.MemoryFile
+	if !filepath.IsAbs(memPath) {
+		memPath = filepath.Join(filepath.Dir(manifestPath), memPath)
+	}
+	info, err := os.Stat(memPath)
+	if err != nil {
+		return whpSnapshotManifest{}, "", fmt.Errorf("stat snapshot memory: %w", err)
+	}
+	if info.Size() <= 0 {
+		return whpSnapshotManifest{}, "", fmt.Errorf("snapshot memory is empty")
+	}
+	if manifest.MemorySize != 0 && uint64(info.Size()) != manifest.MemorySize {
+		return whpSnapshotManifest{}, "", fmt.Errorf("snapshot memory size = %d, want %d", info.Size(), manifest.MemorySize)
+	}
+	return manifest, memPath, nil
+}
+
+func snapshotWHPRegisters(vm *VM) map[string]snapshotRegister {
+	names := whpSnapshotRegisterNames()
+	values := make([]registerValue, len(names))
+	if err := getVirtualProcessorRegisters(vm.part, 0, names, values); err != nil {
+		return nil
+	}
+	out := make(map[string]snapshotRegister, len(names))
+	for i, name := range names {
+		out[whpRegisterName(name)] = snapshotRegister{Low64: values[i].raw.Low64, High64: values[i].raw.High64}
+	}
+	for _, name := range whpOptionalSnapshotRegisterNames() {
+		value, ok := snapshotOptionalWHPRegister(vm, name)
+		if ok {
+			out[whpRegisterName(name)] = value
+		}
+	}
+	return out
+}
+
+func snapshotOptionalWHPRegister(vm *VM, name registerName) (snapshotRegister, bool) {
+	values := make([]registerValue, 1)
+	if err := getVirtualProcessorRegisters(vm.part, 0, []registerName{name}, values); err != nil {
+		return snapshotRegister{}, false
+	}
+	return snapshotRegister{Low64: values[0].raw.Low64, High64: values[0].raw.High64}, true
+}
+
+func restoreWHPPreStateRegisters(vm *VM, regs map[string]snapshotRegister) error {
+	names := make([]registerName, 0, len(regs))
+	values := make([]registerValue, 0, len(regs))
+	for _, name := range whpSnapshotPreStateRegisterNames() {
+		state, ok := regs[whpRegisterName(name)]
+		if !ok {
+			continue
+		}
+		names = append(names, name)
+		values = append(values, registerValue{raw: uint128{Low64: state.Low64, High64: state.High64}})
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("snapshot contains no pre-state WHP vCPU registers")
+	}
+	return setVirtualProcessorRegisters(vm.part, 0, names, values)
+}
+
+func restoreWHPRegisters(vm *VM, regs map[string]snapshotRegister) error {
+	names := make([]registerName, 0, len(regs))
+	values := make([]registerValue, 0, len(regs))
+	for _, name := range whpSnapshotRegisterRestoreNames() {
+		state, ok := regs[whpRegisterName(name)]
+		if !ok {
+			continue
+		}
+		names = append(names, name)
+		values = append(values, registerValue{raw: uint128{Low64: state.Low64, High64: state.High64}})
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("snapshot contains no WHP vCPU registers")
+	}
+	if err := setVirtualProcessorRegisters(vm.part, 0, names, values); err != nil {
+		return err
+	}
+	return verifyRestoredWHPRegisters(vm, regs)
+}
+
+func snapshotWHPStates(vm *VM) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(whpSnapshotStateTypes()))
+	for _, spec := range whpSnapshotStateTypes() {
+		state, err := getVirtualProcessorState(vm.part, 0, spec.stateType)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", spec.key, err)
+		}
+		out[spec.key] = state
+	}
+	return out, nil
+}
+
+func restoreWHPStates(vm *VM, states map[string][]byte) error {
+	if len(states) == 0 {
+		return fmt.Errorf("snapshot contains no WHP vCPU saved state")
+	}
+	for _, spec := range whpSnapshotStateTypes() {
+		state, ok := states[spec.key]
+		if !ok {
+			return fmt.Errorf("snapshot missing WHP vCPU state %q", spec.key)
+		}
+		if err := setVirtualProcessorState(vm.part, 0, spec.stateType, state); err != nil {
+			return fmt.Errorf("restore WHP vCPU state %s: %w", spec.key, err)
+		}
+	}
+	return nil
+}
+
+type whpSnapshotStateType struct {
+	key       string
+	stateType virtualProcessorStateType
+}
+
+func whpSnapshotStateTypes() []whpSnapshotStateType {
+	return []whpSnapshotStateType{
+		{key: "local_apic", stateType: virtualProcessorStateTypeInterruptControllerState2},
+		{key: "xsave", stateType: virtualProcessorStateTypeXsaveState},
+	}
+}
+
+func verifyRestoredWHPRegisters(vm *VM, regs map[string]snapshotRegister) error {
+	critical := []registerName{registerRip, registerRsp, registerRflags, registerCr0, registerCr3, registerCr4, registerEfer, registerIdtr, registerGdtr}
+	values := make([]registerValue, len(critical))
+	if err := getVirtualProcessorRegisters(vm.part, 0, critical, values); err != nil {
+		return fmt.Errorf("read restored WHP vCPU registers: %w", err)
+	}
+	for i, name := range critical {
+		key := whpRegisterName(name)
+		want, ok := regs[key]
+		if !ok {
+			continue
+		}
+		if got := values[i].raw.Low64; got != want.Low64 {
+			return fmt.Errorf("restore WHP register %s = %#x, want %#x", key, got, want.Low64)
+		}
+	}
+	return nil
+}
+
+func whpSnapshotRegisterRestoreNames() []registerName {
+	return []registerName{
+		registerCr3, registerCr4, registerCr0, registerCr2, registerCr8, registerEfer, registerXCr0,
+		registerXss, registerUCet, registerSCet, registerSsp,
+		registerPl0Ssp, registerPl1Ssp, registerPl2Ssp, registerPl3Ssp, registerInterruptSsp,
+		registerTscDeadline, registerTscAdjust, registerXfd, registerXfdErr,
+		registerPat, registerApicBase,
+		registerSysenterCs, registerSysenterEip, registerSysenterEsp,
+		registerStar, registerLstar, registerCstar, registerSfmask,
+		registerKernelGsBase,
+		registerGdtr, registerIdtr,
+		registerEs, registerCs, registerSs, registerDs, registerFs, registerGs, registerLdtr, registerTr,
+		registerRax, registerRcx, registerRdx, registerRbx,
+		registerRsp, registerRbp, registerRsi, registerRdi,
+		registerR8, registerR9, registerR10, registerR11,
+		registerR12, registerR13, registerR14, registerR15,
+		registerRip, registerRflags,
+		registerTsc,
+		registerPendingInterruption, registerDeliverabilityNotifications, registerInternalActivityState,
+	}
+}
+
+func whpSnapshotPreStateRegisterNames() []registerName {
+	return []registerName{
+		registerCr0, registerCr4, registerXCr0, registerXss,
+		registerEfer, registerPat,
+	}
+}
+
+func whpSnapshotRegisterNames() []registerName {
+	return []registerName{
+		registerRax, registerRcx, registerRdx, registerRbx,
+		registerRsp, registerRbp, registerRsi, registerRdi,
+		registerR8, registerR9, registerR10, registerR11,
+		registerR12, registerR13, registerR14, registerR15,
+		registerRip, registerRflags,
+		registerEs, registerCs, registerSs, registerDs, registerFs, registerGs, registerLdtr, registerTr,
+		registerIdtr, registerGdtr,
+		registerCr0, registerCr2, registerCr3, registerCr4, registerCr8, registerXCr0,
+		registerTsc, registerEfer, registerKernelGsBase, registerApicBase, registerPat,
+		registerSysenterCs, registerSysenterEip, registerSysenterEsp,
+		registerStar, registerLstar, registerCstar, registerSfmask,
+		registerPendingInterruption, registerDeliverabilityNotifications, registerInternalActivityState,
+	}
+}
+
+func whpOptionalSnapshotRegisterNames() []registerName {
+	return []registerName{
+		registerXss, registerUCet, registerSCet, registerSsp,
+		registerPl0Ssp, registerPl1Ssp, registerPl2Ssp, registerPl3Ssp, registerInterruptSsp,
+		registerTscDeadline, registerTscAdjust, registerXfd, registerXfdErr,
+	}
+}
+
+func whpRegisterName(name registerName) string {
+	if name >= registerXmm0 && name <= registerXmm15 {
+		return fmt.Sprintf("xmm%d", int(name-registerXmm0))
+	}
+	if name >= registerFpMmx0 && name <= registerFpMmx7 {
+		return fmt.Sprintf("fp_mmx%d", int(name-registerFpMmx0))
+	}
+	switch name {
+	case registerRax:
+		return "rax"
+	case registerRcx:
+		return "rcx"
+	case registerRdx:
+		return "rdx"
+	case registerRbx:
+		return "rbx"
+	case registerRsp:
+		return "rsp"
+	case registerRbp:
+		return "rbp"
+	case registerRsi:
+		return "rsi"
+	case registerRdi:
+		return "rdi"
+	case registerR8:
+		return "r8"
+	case registerR9:
+		return "r9"
+	case registerR10:
+		return "r10"
+	case registerR11:
+		return "r11"
+	case registerR12:
+		return "r12"
+	case registerR13:
+		return "r13"
+	case registerR14:
+		return "r14"
+	case registerR15:
+		return "r15"
+	case registerRip:
+		return "rip"
+	case registerRflags:
+		return "rflags"
+	case registerEs:
+		return "es"
+	case registerCs:
+		return "cs"
+	case registerSs:
+		return "ss"
+	case registerDs:
+		return "ds"
+	case registerFs:
+		return "fs"
+	case registerGs:
+		return "gs"
+	case registerLdtr:
+		return "ldtr"
+	case registerTr:
+		return "tr"
+	case registerIdtr:
+		return "idtr"
+	case registerGdtr:
+		return "gdtr"
+	case registerCr0:
+		return "cr0"
+	case registerCr2:
+		return "cr2"
+	case registerCr3:
+		return "cr3"
+	case registerCr4:
+		return "cr4"
+	case registerCr8:
+		return "cr8"
+	case registerXCr0:
+		return "xcr0"
+	case registerFpControlStatus:
+		return "fp_control_status"
+	case registerXmmControlStatus:
+		return "xmm_control_status"
+	case registerTsc:
+		return "tsc"
+	case registerEfer:
+		return "efer"
+	case registerKernelGsBase:
+		return "kernel_gs_base"
+	case registerApicBase:
+		return "apic_base"
+	case registerPat:
+		return "pat"
+	case registerSysenterCs:
+		return "sysenter_cs"
+	case registerSysenterEip:
+		return "sysenter_eip"
+	case registerSysenterEsp:
+		return "sysenter_esp"
+	case registerStar:
+		return "star"
+	case registerLstar:
+		return "lstar"
+	case registerCstar:
+		return "cstar"
+	case registerSfmask:
+		return "sfmask"
+	case registerXss:
+		return "xss"
+	case registerUCet:
+		return "u_cet"
+	case registerSCet:
+		return "s_cet"
+	case registerSsp:
+		return "ssp"
+	case registerPl0Ssp:
+		return "pl0_ssp"
+	case registerPl1Ssp:
+		return "pl1_ssp"
+	case registerPl2Ssp:
+		return "pl2_ssp"
+	case registerPl3Ssp:
+		return "pl3_ssp"
+	case registerInterruptSsp:
+		return "interrupt_ssp"
+	case registerTscDeadline:
+		return "tsc_deadline"
+	case registerTscAdjust:
+		return "tsc_adjust"
+	case registerXfd:
+		return "xfd"
+	case registerXfdErr:
+		return "xfd_err"
+	case registerPendingInterruption:
+		return "pending_interruption"
+	case registerDeliverabilityNotifications:
+		return "deliverability_notifications"
+	case registerInternalActivityState:
+		return "internal_activity_state"
+	default:
+		return "reg_" + strconv.FormatUint(uint64(name), 16)
+	}
+}
+
+func snapshotWHPDeviceStates(platform *bootPlatform) map[string]virtio.MMIOState {
+	out := make(map[string]virtio.MMIOState)
+	if platform == nil {
+		return out
+	}
+	if platform.rng != nil {
+		out["rng"] = platform.rng.SnapshotState()
+	}
+	if platform.vsock != nil {
+		out["vsock"] = platform.vsock.SnapshotState()
+	}
+	if platform.netdev != nil {
+		out["net"] = platform.netdev.SnapshotState()
+	}
+	for _, fsdev := range platform.fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		out[whpFSDeviceStateKey(fsdev)] = fsdev.SnapshotState()
+	}
+	return out
+}
+
+func restoreWHPDeviceStates(states map[string]virtio.MMIOState, platform *bootPlatform) error {
+	if platform == nil {
+		return nil
+	}
+	if state, ok := states["rng"]; ok && platform.rng != nil {
+		if err := platform.rng.RestoreState(state); err != nil {
+			return fmt.Errorf("restore rng state: %w", err)
+		}
+	}
+	if state, ok := states["vsock"]; ok && platform.vsock != nil {
+		if err := platform.vsock.RestoreState(state); err != nil {
+			return fmt.Errorf("restore vsock state: %w", err)
+		}
+	}
+	if state, ok := states["net"]; ok && platform.netdev != nil {
+		if err := platform.netdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore net state: %w", err)
+		}
+	}
+	for _, fsdev := range platform.fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		state, ok := states[whpFSDeviceStateKey(fsdev)]
+		if !ok {
+			return fmt.Errorf("snapshot missing state for fs device %#x", fsdev.Base)
+		}
+		if err := fsdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore fs device %#x state: %w", fsdev.Base, err)
+		}
+	}
+	return nil
+}
+
+func whpFSDeviceStateKey(fsdev *virtio.FS) string {
+	return fmt.Sprintf("fs:%x", fsdev.Base)
+}
+
+func snapshotWHPPlatform(p *bootPlatform) whpSnapshotPlatformManifest {
+	if p == nil {
+		return whpSnapshotPlatformManifest{}
+	}
+	return whpSnapshotPlatformManifest{
+		PIC:    p.pic.SnapshotState(),
+		PIT:    p.pit.SnapshotState(),
+		IOAPIC: p.ioapic.SnapshotState(),
+		HPET:   p.hpet.SnapshotState(),
+	}
+}
+
+func restoreWHPPlatform(p *bootPlatform, state whpSnapshotPlatformManifest) {
+	if p == nil {
+		return
+	}
+	p.pic.RestoreState(state.PIC)
+	p.pit.RestoreState(state.PIT)
+	p.ioapic.RestoreState(state.IOAPIC)
+	p.hpet.RestoreState(state.HPET)
+}

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -65,36 +65,58 @@ func newBootVM(memorySize uint64) (*VM, error) {
 }
 
 func newVM(memorySize uint64, localAPIC bool) (*VM, error) {
+	return newVMWithAllocation(memorySize, localAPIC, nil)
+}
+
+func newVMWithAllocation(memorySize uint64, localAPIC bool, mem *allocation) (*VM, error) {
 	if memorySize == 0 {
 		return nil, fmt.Errorf("memory size must be non-zero")
 	}
+	cleanupMem := func() {
+		if mem != nil {
+			_ = mem.free()
+			mem = nil
+		}
+	}
 	part, err := createPartition()
 	if err != nil {
+		cleanupMem()
 		return nil, fmt.Errorf("create partition: %w", err)
 	}
 	vm := &VM{part: part}
 	if err := setPartitionProperty(part, partitionPropertyCodeProcessorCount, uint32(1)); err != nil {
+		cleanupMem()
 		_ = vm.Close()
 		return nil, fmt.Errorf("set processor count: %w", err)
 	}
 	if err := setPartitionProperty(part, partitionPropertyCodeExtendedVMExits, uint64(1<<1)); err != nil {
+		cleanupMem()
 		_ = vm.Close()
 		return nil, fmt.Errorf("set extended VM exits: %w", err)
 	}
 	if localAPIC {
 		if err := setPartitionProperty(part, partitionPropertyCodeLocalAPICEmulationMode, localAPICEmulationModeXAPIC); err != nil {
+			cleanupMem()
 			_ = vm.Close()
 			return nil, fmt.Errorf("set local APIC emulation mode: %w", err)
 		}
 	}
 	if err := setupPartition(part); err != nil {
+		cleanupMem()
 		_ = vm.Close()
 		return nil, fmt.Errorf("setup partition: %w", err)
 	}
-	mem, err := virtualAlloc(uintptr(memorySize))
-	if err != nil {
+	if mem == nil {
+		var err error
+		mem, err = virtualAlloc(uintptr(memorySize))
+		if err != nil {
+			_ = vm.Close()
+			return nil, fmt.Errorf("allocate guest memory: %w", err)
+		}
+	} else if uint64(mem.size) < memorySize {
+		_ = mem.free()
 		_ = vm.Close()
-		return nil, fmt.Errorf("allocate guest memory: %w", err)
+		return nil, fmt.Errorf("guest memory allocation size %d is smaller than VM memory %d", mem.size, memorySize)
 	}
 	vm.mem = mem
 	vm.memSize = memorySize
@@ -553,6 +575,25 @@ func (v *VM) SetPendingInterruption(vector uint8) error {
 	names := []registerName{registerPendingInterruption}
 	values := []registerValue{uint64RegisterValue(value)}
 	return setVirtualProcessorRegisters(v.part, 0, names, values)
+}
+
+func (v *VM) canSetPendingInterruption(vector uint8) (bool, error) {
+	if v == nil || v.part == 0 {
+		return false, nil
+	}
+	names := []registerName{
+		registerPendingInterruption,
+		registerCr8,
+	}
+	values := make([]registerValue, len(names))
+	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+		return false, err
+	}
+	if values[0].uint64() != 0 {
+		return false, nil
+	}
+	priority := vector >> 4
+	return priority == 0 || priority > uint8(values[1].uint64()), nil
 }
 
 func (v *VM) haltedAndInterruptible(vector uint8) (bool, error) {

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -2596,6 +2596,15 @@ func (f *FS) updateIRQLocked() error {
 	return f.irq.SetIRQ(f.IRQ, level)
 }
 
+func (f *FS) IRQAsserted() bool {
+	if f == nil {
+		return false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.interruptStatus != 0 || f.irqHigh
+}
+
 func (f *FS) Summary() string {
 	if f == nil {
 		return "virtio-fs=<nil>"

--- a/internal/virtio/rng.go
+++ b/internal/virtio/rng.go
@@ -317,6 +317,15 @@ func (r *RNG) updateIRQLocked() error {
 	return r.irq.SetIRQ(r.IRQ, level)
 }
 
+func (r *RNG) IRQAsserted() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.interruptStatus != 0 || r.irqHigh
+}
+
 func (r *RNG) setQueueAddr(target *uint64, value uint32, low bool) {
 	if r.queueSel != rngQueue {
 		return

--- a/internal/virtio/vsock.go
+++ b/internal/virtio/vsock.go
@@ -307,6 +307,25 @@ func (v *Vsock) Summary() string {
 	)
 }
 
+func (v *Vsock) IRQAsserted() bool {
+	if v == nil {
+		return false
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.interruptStatus != 0 || v.irqHigh
+}
+
+func (v *Vsock) Kick() error {
+	if v == nil {
+		return nil
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.interruptStatus |= vsockInterruptVring
+	return v.updateIRQLocked()
+}
+
 func (v *Vsock) processTXLocked() error {
 	q := &v.queues[vsockQueueTX]
 	if !q.ready || q.size == 0 || v.mem == nil {

--- a/internal/vm/backend_windows_amd64.go
+++ b/internal/vm/backend_windows_amd64.go
@@ -50,16 +50,13 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if inst, ok, err := b.startBuiltinGuestStream(ctx, req, onEvent); ok || err != nil {
 		return inst, err
 	}
-	if b == nil || b.kernel == nil || b.images == nil {
+	if b == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
 	if req.CPUs > 1 {
 		return nil, fmt.Errorf("windows amd64 runtime currently supports only 1 CPU")
 	}
-	kernel, err := b.kernel.ReadKernel()
-	if err != nil {
-		return nil, err
-	}
+	restoreSnapshot := strings.TrimSpace(req.RestoreSnapshot)
 	image, err := b.images.Open(req.Image)
 	if err != nil {
 		return nil, err
@@ -68,10 +65,6 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		return nil, err
 	}
 	image = withWindowsRuntimeMountDirs(image)
-	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(), windowsRuntimeModuleMap())
-	if err != nil {
-		return nil, err
-	}
 	network, err := newWindowsAMD64NetworkRuntime(req.Network)
 	if err != nil {
 		return nil, err
@@ -90,19 +83,60 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
-	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "amd64")
-	if err != nil {
-		return nil, fmt.Errorf("build guest init: %w", err)
-	}
 	workDir := image.Config.WorkingDir
 	if workDir == "" {
 		workDir = "/"
+	}
+	if restoreSnapshot != "" {
+		started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+			Profile: managedguest.LinuxProfile,
+			Host:    whp.Host{},
+			Spec:    windowsLinuxMachineSpec(req.MemoryMB, req.CPUs, req.Dmesg),
+			Attachments: whp.LinuxManagedAttachments{
+				FSDevices:       fsdevs,
+				NetDevice:       windowsNetworkDevice(network),
+				SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+				RestoreSnapshot: restoreSnapshot,
+			},
+		}, onEvent)
+		if err != nil {
+			if network != nil {
+				_ = network.Close()
+			}
+			return nil, err
+		}
+		return &windowsInstance{
+			managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(image.Config.Env), workDir),
+			image:               image,
+			rootFS:              rootFS,
+			fsdevs:              fsdevs,
+			network:             network,
+			dmesg:               req.Dmesg,
+		}, nil
+	}
+	if b.kernel == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	kernel, err := b.kernel.ReadKernel()
+	if err != nil {
+		return nil, err
+	}
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(), windowsRuntimeModuleMap())
+	if err != nil {
+		return nil, err
+	}
+	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "amd64")
+	if err != nil {
+		return nil, fmt.Errorf("build guest init: %w", err)
 	}
 	initCfg := windowsGuestInitConfig(modules, true)
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
 	initCfg.WorkDir = workDir
 	initCfg.Network = windowsNetworkGuestInitConfig(network)
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
@@ -116,8 +150,10 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 			Initrd: initrd,
 		},
 		Attachments: whp.LinuxManagedAttachments{
-			FSDevices: fsdevs,
-			NetDevice: windowsNetworkDevice(network),
+			FSDevices:       fsdevs,
+			NetDevice:       windowsNetworkDevice(network),
+			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
 	}, onEvent)
 	if err != nil {
@@ -141,7 +177,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if inst, ok, err := b.startBuiltinGuestBlankStream(ctx, req, onEvent); ok || err != nil {
 		return inst, err
 	}
-	if b == nil || b.kernel == nil || b.images == nil {
+	if b == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
 	if req.CPUs > 1 {
@@ -149,26 +185,20 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	if strings.TrimSpace(req.Image) != "" {
 		return b.StartStream(ctx, client.CreateInstanceRequest{
-			ID:             req.ID,
-			Image:          req.Image,
-			InitSystem:     req.InitSystem,
-			Kernel:         req.Kernel,
-			Network:        req.Network,
-			KernelModules:  append([]string(nil), req.KernelModules...),
-			MemoryMB:       req.MemoryMB,
-			CPUs:           req.CPUs,
-			NestedVirt:     req.NestedVirt,
-			Dmesg:          req.Dmesg,
-			TimeoutSeconds: req.TimeoutSeconds,
+			ID:              req.ID,
+			Image:           req.Image,
+			InitSystem:      req.InitSystem,
+			Kernel:          req.Kernel,
+			Network:         req.Network,
+			KernelModules:   append([]string(nil), req.KernelModules...),
+			MemoryMB:        req.MemoryMB,
+			CPUs:            req.CPUs,
+			NestedVirt:      req.NestedVirt,
+			Dmesg:           req.Dmesg,
+			SnapshotDir:     req.SnapshotDir,
+			RestoreSnapshot: req.RestoreSnapshot,
+			TimeoutSeconds:  req.TimeoutSeconds,
 		}, onEvent)
-	}
-	kernel, err := b.kernel.ReadKernel()
-	if err != nil {
-		return nil, err
-	}
-	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(), windowsRuntimeModuleMap())
-	if err != nil {
-		return nil, err
 	}
 	network, err := newWindowsAMD64NetworkRuntime(req.Network)
 	if err != nil {
@@ -188,6 +218,44 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if err != nil {
 		return nil, err
 	}
+	restoreSnapshot := strings.TrimSpace(req.RestoreSnapshot)
+	if restoreSnapshot != "" {
+		started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+			Profile: managedguest.LinuxProfile,
+			Host:    whp.Host{},
+			Spec:    windowsLinuxMachineSpec(req.MemoryMB, req.CPUs, req.Dmesg),
+			Attachments: whp.LinuxManagedAttachments{
+				FSDevices:       fsdevs,
+				NetDevice:       windowsNetworkDevice(network),
+				SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+				RestoreSnapshot: restoreSnapshot,
+			},
+		}, onEvent)
+		if err != nil {
+			if network != nil {
+				_ = network.Close()
+			}
+			return nil, err
+		}
+		return &windowsInstance{
+			managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(nil), "/"),
+			rootFS:              rootFS,
+			fsdevs:              fsdevs,
+			network:             network,
+			dmesg:               req.Dmesg,
+		}, nil
+	}
+	if b.kernel == nil {
+		return nil, fmt.Errorf("runtime backend is not configured")
+	}
+	kernel, err := b.kernel.ReadKernel()
+	if err != nil {
+		return nil, err
+	}
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(), windowsRuntimeModuleMap())
+	if err != nil {
+		return nil, err
+	}
 	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "amd64")
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
@@ -197,6 +265,9 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	initCfg.Env = vmruntime.WithDefaultEnv(nil)
 	initCfg.WorkDir = "/"
 	initCfg.Network = windowsNetworkGuestInitConfig(network)
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
@@ -210,8 +281,10 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Initrd: initrd,
 		},
 		Attachments: whp.LinuxManagedAttachments{
-			FSDevices: fsdevs,
-			NetDevice: windowsNetworkDevice(network),
+			FSDevices:       fsdevs,
+			NetDevice:       windowsNetworkDevice(network),
+			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
 	}, onEvent)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds Windows WHP startup snapshot support for Linux managed guests so a prepared VM can be captured after non-unique guest initialization and restored for fast command execution.

Key pieces:
- Adds a Windows `tinyboot` snapshot/restore harness.
- Captures/restores WHP vCPU registers, local APIC saved state, XSAVE state, and virtio device/platform state.
- Wires snapshot/restore through the Windows managed runtime backend.
- Replaces the earlier risky kernel-argument shortcuts with real WHP state restore. In particular, restore now captures `XSS` and CET shadow-stack related registers and restores the XSAVE control context before applying WHP `XsaveState`.
- Uses a serial snapshot marker instead of `/dev/mem`/`iomem=relaxed` for the guest trigger.

## Root Cause

The `noxsave` workaround was hiding incomplete restore of Linux's XSAVE supervisor state. On Windows WHP, Linux could boot with an xstate mask including CET supervisor bits (`0x1807`), but restore did not preserve the matching `IA32_XSS`/CET vCPU state before applying the XSAVE blob. That produced the FPU restore panic. The PR captures those WHP registers when supported and restores the XSAVE controls before `WHvSetVirtualProcessorState(XsaveState)`.

`nolapic_timer` is no longer needed because WHP local APIC state is now captured and restored via `WHvGetVirtualProcessorState` / `WHvSetVirtualProcessorState`.

## Validation

- `git diff --check`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/hv/whp -o /tmp/whp.test.exe`
- `GOOS=windows GOARCH=amd64 go test -c ./cmd/tinyboot -o /tmp/tinyboot.test.exe`
- `go test ./internal/cmd/init`
- `go test ./...`
- Windows WHP fresh snapshot capture with no `noxsave`, `nolapic_timer`, `noxsaves`, `clearcpuid`, or `iomem=relaxed`: `5.754s`
- Windows WHP restore from that snapshot, 1 warmup + 5 measured runs with `/bin/echo repeat-ok`: all passed
  - Average restored boot: `78ms`
  - Average exec: `211ms`
- Snapshot manifest confirmed `xcr0=7`, `xss=6144`, plus `xsave` and `local_apic` saved state present.