### PR TITLE
[codex] add linux amd64 startup snapshots

### DIFF
--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -1128,6 +1128,23 @@ func triggerSnapshotMMIO(base uint64) error {
 		return nil
 	}
 	writeConsole("__CCX3_SNAPSHOT__\n")
+	pageSize := unix.Getpagesize()
+	pageBase := base & ^uint64(pageSize-1)
+	pageOff := int(base - pageBase)
+	mem, err := os.OpenFile("/dev/mem", os.O_RDWR|unix.O_SYNC, 0)
+	if err != nil {
+		return fmt.Errorf("open /dev/mem: %w", err)
+	}
+	defer mem.Close()
+	mapped, err := unix.Mmap(int(mem.Fd()), int64(pageBase), pageSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		return fmt.Errorf("mmap snapshot mmio: %w", err)
+	}
+	defer unix.Munmap(mapped)
+	if pageOff+8 > len(mapped) {
+		return fmt.Errorf("snapshot mmio offset %#x outside mapped page", pageOff)
+	}
+	*(*uint64)(unsafe.Pointer(&mapped[pageOff])) = 0x43535833534e4150
 	return nil
 }
 

--- a/internal/hv/kvm/abi_linux_amd64.go
+++ b/internal/hv/kvm/abi_linux_amd64.go
@@ -85,6 +85,126 @@ type kvmMSRs1 struct {
 	Entry kvmMSREntry
 }
 
+type kvmFPU struct {
+	FPR        [8][16]byte
+	FCW        uint16
+	FSW        uint16
+	FTWX       uint8
+	Pad1       uint8
+	LastOpcode uint16
+	LastIP     uint64
+	LastDP     uint64
+	XMM        [16][16]byte
+	MXCSR      uint32
+	Pad2       uint32
+}
+
+type kvmLAPICState struct {
+	Regs [1024]byte
+}
+
+type kvmMPState struct {
+	MPState uint32
+}
+
+type kvmVCPUEvents struct {
+	Exception struct {
+		Injected     uint8
+		Nr           uint8
+		HasErrorCode uint8
+		Pending      uint8
+		ErrorCode    uint32
+	}
+	Interrupt struct {
+		Injected uint8
+		Nr       uint8
+		Soft     uint8
+		Shadow   uint8
+	}
+	NMI struct {
+		Injected uint8
+		Pending  uint8
+		Masked   uint8
+		Pad      uint8
+	}
+	SIPIVector uint32
+	Flags      uint32
+	SMI        struct {
+		SMM          uint8
+		Pending      uint8
+		SMMInsideNMI uint8
+		LatchedInit  uint8
+	}
+	TripleFault struct {
+		Pending uint8
+	}
+	Reserved            [26]byte
+	ExceptionHasPayload uint8
+	ExceptionPayload    uint64
+}
+
+type kvmDebugRegs struct {
+	DB       [4]uint64
+	DR6      uint64
+	DR7      uint64
+	Flags    uint64
+	Reserved [9]uint64
+}
+
+type kvmXSAVE struct {
+	Region [1024]uint32
+}
+
+type kvmXCR struct {
+	XCR      uint32
+	Reserved uint32
+	Value    uint64
+}
+
+type kvmXCRS struct {
+	NrXCRs  uint32
+	Flags   uint32
+	XCRs    [16]kvmXCR
+	Padding [16]uint64
+}
+
+type kvmIRQChip struct {
+	ChipID uint32
+	Pad    uint32
+	Chip   [512]byte
+}
+
+type kvmPITChannelState struct {
+	Count         uint32
+	LatchedCount  uint16
+	CountLatched  uint8
+	StatusLatched uint8
+	Status        uint8
+	ReadState     uint8
+	WriteState    uint8
+	WriteLatch    uint8
+	RWMode        uint8
+	Mode          uint8
+	BCD           uint8
+	Gate          uint8
+	CountLoadTime int64
+}
+
+type kvmPITState2 struct {
+	Channels [3]kvmPITChannelState
+	Flags    uint32
+	Reserved [9]uint32
+}
+
+type kvmClockData struct {
+	Clock    uint64
+	Flags    uint32
+	Pad0     uint32
+	Realtime uint64
+	HostTSC  uint64
+	Pad      [4]uint32
+}
+
 type kvmRegs struct {
 	Rax    uint64
 	Rbx    uint64

--- a/internal/hv/kvm/bindings_linux_amd64.go
+++ b/internal/hv/kvm/bindings_linux_amd64.go
@@ -24,14 +24,35 @@ const (
 	kvmCreateVCPU          = 0xae41
 	kvmSetTssAddr          = 0xae47
 	kvmCreateIrqchip       = 0xae60
+	kvmGetIRQChip          = 0xc208ae62
+	kvmSetIRQChip          = 0x8208ae63
 	kvmCreatePit2          = 0x4040ae77
+	kvmSetClock            = 0x4030ae7b
+	kvmGetClock            = 0x8030ae7c
 	kvmRun                 = 0xae80
 	kvmGetRegs             = 0x8090ae81
 	kvmSetRegs             = 0x4090ae82
 	kvmGetSregs            = 0x8138ae83
 	kvmSetSregs            = 0x4138ae84
+	kvmGetMSRS             = 0xc008ae88
 	kvmSetMSRS             = 0x4008ae89
+	kvmGetFPU              = 0x81a0ae8c
+	kvmSetFPU              = 0x41a0ae8d
+	kvmGetLAPIC            = 0x8400ae8e
+	kvmSetLAPIC            = 0x4400ae8f
 	kvmSetCpuid2           = 0x4008ae90
+	kvmGetMPState          = 0x8004ae98
+	kvmSetMPState          = 0x4004ae99
+	kvmGetVCPUEvents       = 0x8040ae9f
+	kvmGetPIT2             = 0x8070ae9f
+	kvmSetVCPUEvents       = 0x4040aea0
+	kvmSetPIT2             = 0x4070aea0
+	kvmGetDebugRegs        = 0x8080aea1
+	kvmSetDebugRegs        = 0x4080aea2
+	kvmGetXSAVE            = 0x9000aea4
+	kvmSetXSAVE            = 0x5000aea5
+	kvmGetXCRS             = 0x8188aea6
+	kvmSetXCRS             = 0x4188aea7
 	kvmGetTSCKHz           = 0xaea3
 )
 
@@ -128,6 +149,39 @@ func createPIT(vmFd int) error {
 	return err
 }
 
+func getIRQChip(vmFd int, chipID uint32) (kvmIRQChip, error) {
+	chip := kvmIRQChip{ChipID: chipID}
+	_, err := ioctlWithRetry(uintptr(vmFd), uint64(kvmGetIRQChip), uintptr(unsafe.Pointer(&chip)))
+	return chip, err
+}
+
+func setIRQChip(vmFd int, chip *kvmIRQChip) error {
+	_, err := ioctlWithRetry(uintptr(vmFd), uint64(kvmSetIRQChip), uintptr(unsafe.Pointer(chip)))
+	return err
+}
+
+func getPIT2(vmFd int) (kvmPITState2, error) {
+	var state kvmPITState2
+	_, err := ioctlWithRetry(uintptr(vmFd), uint64(kvmGetPIT2), uintptr(unsafe.Pointer(&state)))
+	return state, err
+}
+
+func setPIT2(vmFd int, state *kvmPITState2) error {
+	_, err := ioctlWithRetry(uintptr(vmFd), uint64(kvmSetPIT2), uintptr(unsafe.Pointer(state)))
+	return err
+}
+
+func getClock(vmFd int) (kvmClockData, error) {
+	var clock kvmClockData
+	_, err := ioctlWithRetry(uintptr(vmFd), uint64(kvmGetClock), uintptr(unsafe.Pointer(&clock)))
+	return clock, err
+}
+
+func setClock(vmFd int, clock *kvmClockData) error {
+	_, err := ioctlWithRetry(uintptr(vmFd), uint64(kvmSetClock), uintptr(unsafe.Pointer(clock)))
+	return err
+}
+
 func getSupportedCPUID(kvmFd int) (*kvmCPUID2, error) {
 	size := unsafe.Sizeof(kvmCPUID2{}) + unsafe.Sizeof(kvmCPUIDEntry2{})*cpuidMaxEntries
 	buf := make([]byte, size)
@@ -155,6 +209,23 @@ func getVCPUTSCKHz(vcpuFd int) (uint32, error) {
 	return uint32(value), nil
 }
 
+func getVCPUMSR(vcpuFd int, index uint32) (uint64, error) {
+	msrs := kvmMSRs1{
+		NMSRs: 1,
+		Entry: kvmMSREntry{
+			Index: index,
+		},
+	}
+	ret, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetMSRS), uintptr(unsafe.Pointer(&msrs)))
+	if err != nil {
+		return 0, err
+	}
+	if ret != 1 {
+		return 0, unix.EIO
+	}
+	return msrs.Entry.Data, nil
+}
+
 func setVCPUMSR(vcpuFd int, index uint32, value uint64) error {
 	msrs := kvmMSRs1{
 		NMSRs: 1,
@@ -171,6 +242,97 @@ func setVCPUMSR(vcpuFd int, index uint32, value uint64) error {
 		return unix.EIO
 	}
 	return nil
+}
+
+func getFPU(vcpuFd int) (kvmFPU, error) {
+	var fpu kvmFPU
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetFPU), uintptr(unsafe.Pointer(&fpu))); err != nil {
+		return kvmFPU{}, err
+	}
+	return fpu, nil
+}
+
+func setFPU(vcpuFd int, fpu *kvmFPU) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetFPU), uintptr(unsafe.Pointer(fpu)))
+	return err
+}
+
+func getLAPIC(vcpuFd int) (kvmLAPICState, error) {
+	var lapic kvmLAPICState
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetLAPIC), uintptr(unsafe.Pointer(&lapic))); err != nil {
+		return kvmLAPICState{}, err
+	}
+	return lapic, nil
+}
+
+func setLAPIC(vcpuFd int, lapic *kvmLAPICState) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetLAPIC), uintptr(unsafe.Pointer(lapic)))
+	return err
+}
+
+func getMPState(vcpuFd int) (kvmMPState, error) {
+	var state kvmMPState
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetMPState), uintptr(unsafe.Pointer(&state))); err != nil {
+		return kvmMPState{}, err
+	}
+	return state, nil
+}
+
+func setMPState(vcpuFd int, state *kvmMPState) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetMPState), uintptr(unsafe.Pointer(state)))
+	return err
+}
+
+func getVCPUEvents(vcpuFd int) (kvmVCPUEvents, error) {
+	var events kvmVCPUEvents
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetVCPUEvents), uintptr(unsafe.Pointer(&events))); err != nil {
+		return kvmVCPUEvents{}, err
+	}
+	return events, nil
+}
+
+func setVCPUEvents(vcpuFd int, events *kvmVCPUEvents) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetVCPUEvents), uintptr(unsafe.Pointer(events)))
+	return err
+}
+
+func getDebugRegs(vcpuFd int) (kvmDebugRegs, error) {
+	var regs kvmDebugRegs
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetDebugRegs), uintptr(unsafe.Pointer(&regs))); err != nil {
+		return kvmDebugRegs{}, err
+	}
+	return regs, nil
+}
+
+func setDebugRegs(vcpuFd int, regs *kvmDebugRegs) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetDebugRegs), uintptr(unsafe.Pointer(regs)))
+	return err
+}
+
+func getXSAVE(vcpuFd int) (kvmXSAVE, error) {
+	var xsave kvmXSAVE
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetXSAVE), uintptr(unsafe.Pointer(&xsave))); err != nil {
+		return kvmXSAVE{}, err
+	}
+	return xsave, nil
+}
+
+func setXSAVE(vcpuFd int, xsave *kvmXSAVE) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetXSAVE), uintptr(unsafe.Pointer(xsave)))
+	return err
+}
+
+func getXCRS(vcpuFd int) (kvmXCRS, error) {
+	var xcrs kvmXCRS
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetXCRS), uintptr(unsafe.Pointer(&xcrs))); err != nil {
+		return kvmXCRS{}, err
+	}
+	return xcrs, nil
+}
+
+func setXCRS(vcpuFd int, xcrs *kvmXCRS) error {
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetXCRS), uintptr(unsafe.Pointer(xcrs)))
+	return err
 }
 
 func setCPUIDTopology(cpuid *kvmCPUID2, id, cpus int) {

--- a/internal/hv/kvm/exec_linux_amd64.go
+++ b/internal/hv/kvm/exec_linux_amd64.go
@@ -197,15 +197,39 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 }
 
 func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut *vmruntime.SerialTranscript) error {
+	return runManagedExecVMWithSnapshot(ctx, vm, uart, fsdevs, vsock, rng, netdev, serialOut, nil)
+}
+
+func runManagedExecVMWithSnapshot(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut *vmruntime.SerialTranscript, snapshot *snapshotTrigger) error {
 	if vm != nil && len(vm.vcpus) > 1 {
+		if snapshot != nil {
+			return fmt.Errorf("KVM startup snapshots currently support only one vCPU")
+		}
 		return runManagedExecVMMulti(ctx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
 	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	vm.SetVCPUTID(0, unix.Gettid())
+	defer vm.SetVCPUTID(0, 0)
+	cancelDone := make(chan struct{})
+	defer close(cancelDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			vm.RequestImmediateExit()
+		case <-cancelDone:
+		}
+	}()
+
 	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := vm.Run(&exit); err != nil {
+		if err := vm.RunVCPUInterruptible(0, &exit); err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
 			return fmt.Errorf("run step %d: %w", step, err)
 		}
 		switch exit.Reason {
@@ -214,6 +238,11 @@ func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs
 				return err
 			}
 		case ExitMMIO:
+			if handled, err := snapshot.handleMMIO(vm, exit.MMIO); err != nil {
+				return err
+			} else if handled {
+				break
+			}
 			if err := handleBootMMIO(vm, fsdevs, vsock, rng, netdev, exit.MMIO); err != nil {
 				return err
 			}
@@ -224,6 +253,9 @@ func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs
 		default:
 			pc, _ := vm.GetPC()
 			return fmt.Errorf("unexpected exit reason %d at pc=%#x\nserial:\n%s", exit.Reason, pc, serialOut.String())
+		}
+		if err := snapshot.captureIfPending(vm, fsdevs, vsock, rng, netdev); err != nil {
+			return err
 		}
 	}
 }
@@ -248,15 +280,12 @@ func runManagedExecVMMulti(ctx context.Context, vm *VM, uart *serial.UART8250, f
 				if err := runCtx.Err(); err != nil {
 					return
 				}
-				err := error(nil)
-				if sampler.Enabled() {
-					err = vm.RunVCPUInterruptible(index, &exit)
-				} else {
-					err = vm.RunVCPU(index, &exit)
-				}
+				err := vm.RunVCPUInterruptible(index, &exit)
 				if err != nil {
-					if sampler.Enabled() && errors.Is(err, unix.EINTR) {
-						sampler.Record(vm.VCPURegisters(index))
+					if errors.Is(err, unix.EINTR) {
+						if sampler.Enabled() {
+							sampler.Record(vm.VCPURegisters(index))
+						}
 						continue
 					}
 					reportRunErr(errCh, cancel, fmt.Errorf("run vcpu %d: %w", index, err))
@@ -277,7 +306,7 @@ func runManagedExecVMMulti(ctx context.Context, vm *VM, uart *serial.UART8250, f
 	}
 	defer func() {
 		cancel()
-		_ = vm.CancelRun()
+		vm.RequestImmediateExit()
 		wg.Wait()
 	}()
 

--- a/internal/hv/kvm/host_linux_amd64.go
+++ b/internal/hv/kvm/host_linux_amd64.go
@@ -19,16 +19,20 @@ import (
 type Host struct{}
 
 type LinuxManagedMachine struct {
-	Spec      machine.Spec
-	Kernel    []byte
-	Initrd    []byte
-	FSDevices []*virtio.FS
-	NetDevice *virtio.Net
+	Spec            machine.Spec
+	Kernel          []byte
+	Initrd          []byte
+	FSDevices       []*virtio.FS
+	NetDevice       *virtio.Net
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 type LinuxManagedAttachments struct {
-	FSDevices []*virtio.FS
-	NetDevice *virtio.Net
+	FSDevices       []*virtio.FS
+	NetDevice       *virtio.Net
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 type BSDManagedAttachments struct {
@@ -67,11 +71,13 @@ func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEven
 		return nil, fmt.Errorf("kvm linux managed attachments have type %T", req.Attachments)
 	}
 	return Host{}.StartLinuxManaged(ctx, LinuxManagedMachine{
-		Spec:      req.Spec,
-		Kernel:    req.Artifact.Kernel,
-		Initrd:    req.Artifact.Initrd,
-		FSDevices: attachments.FSDevices,
-		NetDevice: attachments.NetDevice,
+		Spec:            req.Spec,
+		Kernel:          req.Artifact.Kernel,
+		Initrd:          req.Artifact.Initrd,
+		FSDevices:       attachments.FSDevices,
+		NetDevice:       attachments.NetDevice,
+		SnapshotDir:     strings.TrimSpace(attachments.SnapshotDir),
+		RestoreSnapshot: strings.TrimSpace(attachments.RestoreSnapshot),
 	}, onEvent)
 }
 
@@ -146,7 +152,7 @@ func bsdManagedAttachments(value any) (BSDManagedAttachments, error) {
 
 func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
 	machine = normalizeLinuxManagedMachine(machine)
-	return StartManagedSessionWithNet(
+	return StartManagedSessionWithNetOptions(
 		ctx,
 		machine.Kernel,
 		machine.Initrd,
@@ -155,6 +161,10 @@ func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, 
 		machine.Spec.Dmesg,
 		machine.FSDevices,
 		machine.NetDevice,
+		ManagedSessionOptions{
+			SnapshotDir:     strings.TrimSpace(machine.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(machine.RestoreSnapshot),
+		},
 		onEvent,
 	)
 }

--- a/internal/hv/kvm/session_linux_amd64.go
+++ b/internal/hv/kvm/session_linux_amd64.go
@@ -32,6 +32,12 @@ type ManagedSession struct {
 	sendMu     sync.Mutex
 	nextID     atomic.Uint64
 	dmesg      bool
+	inlineExec bool
+}
+
+type ManagedSessionOptions struct {
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
@@ -39,6 +45,18 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 }
 
 func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithNetOptions(ctx, kernel, initrd, memoryMB, cpus, dmesg, fsdevs, netdev, ManagedSessionOptions{}, onEvent)
+}
+
+func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if strings.TrimSpace(opts.SnapshotDir) != "" || strings.TrimSpace(opts.RestoreSnapshot) != "" {
+		if cpus > 1 {
+			return nil, fmt.Errorf("KVM startup snapshots currently support only one vCPU")
+		}
+	}
+	if snapshotPath := strings.TrimSpace(opts.RestoreSnapshot); snapshotPath != "" {
+		return StartManagedSessionFromSnapshot(ctx, snapshotPath, memoryMB, dmesg, fsdevs, netdev, onEvent)
+	}
 	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
 		return nil, err
 	}
@@ -84,6 +102,8 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = io.MultiWriter(serialOut, bootWriter)
 	}
+	snapshot := newSnapshotTrigger(opts.SnapshotDir, mem)
+	serialWriter = snapshot.wrapSerialWriter(serialWriter)
 	uart := serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter)
 	for _, fsdev := range fsdevs {
 		if fsdev != nil {
@@ -131,7 +151,7 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 	runCtx, cancel := context.WithCancel(context.Background())
 	done := newSessionDone()
 	go func() {
-		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
+		err := runManagedExecVMWithSnapshot(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut, snapshot)
 		closeVMWithFS(vm, fsdevs)
 		done.finish(err)
 	}()
@@ -222,11 +242,19 @@ func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (clie
 	}
 	id := strconv.FormatUint(s.nextID.Add(1), 10)
 	start := s.transcript.Len()
-	s.sendMu.Lock()
-	err := managedagent.SendExec(s.control, id, req)
-	s.sendMu.Unlock()
-	if err != nil {
-		return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+	if s.inlineExec {
+		execReq := req
+		execReq.Kind = "exec_inline"
+		if err := s.sendExecMessage(managedagent.ExecRequest(id, execReq)); err != nil {
+			return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+		}
+	} else {
+		s.sendMu.Lock()
+		err := managedagent.SendExec(s.control, id, req)
+		s.sendMu.Unlock()
+		if err != nil {
+			return client.ExecResponse{}, transcriptError(err, s.serialOut.String(), s.transcript.String())
+		}
 	}
 	segment, err := s.waitForTranscript(ctx, start, func(text string) bool {
 		_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, s.dmesg)

--- a/internal/hv/kvm/snapshot_linux_amd64.go
+++ b/internal/hv/kvm/snapshot_linux_amd64.go
@@ -1,0 +1,742 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/amd64vm"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const (
+	snapshotTriggerMagic        = 0x43535833534e4150
+	snapshotTriggerSerialMarker = "__CCX3_SNAPSHOT__"
+)
+
+var kvmSnapshotMSRs = []uint32{
+	ia32TSCMSR,
+	ia32BIOSSignIDMSR,
+	ia32MiscEnableMSR,
+	ia32TSCAuxMSR,
+	0x00000174, // IA32_SYSENTER_CS
+	0x00000175, // IA32_SYSENTER_ESP
+	0x00000176, // IA32_SYSENTER_EIP
+	0x00000277, // IA32_PAT
+	0xc0000080, // IA32_EFER
+	0xc0000081, // IA32_STAR
+	0xc0000082, // IA32_LSTAR
+	0xc0000083, // IA32_CSTAR
+	0xc0000084, // IA32_FMASK
+	0xc0000100, // IA32_FS_BASE
+	0xc0000101, // IA32_GS_BASE
+	0xc0000102, // IA32_KERNEL_GS_BASE
+}
+
+type snapshotTrigger struct {
+	base uint64
+	size uint64
+	dir  string
+	mem  []byte
+
+	mu      sync.Mutex
+	pending bool
+	value   uint64
+	once    sync.Once
+	err     error
+}
+
+type kvmSnapshotManifest struct {
+	Format       string                      `json:"format"`
+	Partial      bool                        `json:"partial"`
+	CapturedAt   string                      `json:"captured_at"`
+	TriggerBase  uint64                      `json:"trigger_base"`
+	TriggerValue uint64                      `json:"trigger_value"`
+	MemoryBase   uint64                      `json:"memory_base"`
+	MemorySize   uint64                      `json:"memory_size"`
+	MemoryFile   string                      `json:"memory_file"`
+	NumCPUs      int                         `json:"num_cpus"`
+	CapturedVCPU int                         `json:"captured_vcpu"`
+	VCPU         kvmSnapshotVCPU             `json:"vcpu"`
+	IRQChips     []kvmIRQChip                `json:"irq_chips,omitempty"`
+	PIT          kvmPITState2                `json:"pit"`
+	Clock        kvmClockData                `json:"clock"`
+	Devices      map[string]virtio.MMIOState `json:"devices,omitempty"`
+	Note         string                      `json:"note"`
+}
+
+type kvmSnapshotVCPU struct {
+	Regs      kvmRegs       `json:"regs"`
+	SRegs     kvmSRegs      `json:"sregs"`
+	MSRs      []kvmMSREntry `json:"msrs,omitempty"`
+	FPU       kvmFPU        `json:"fpu"`
+	LAPIC     kvmLAPICState `json:"lapic"`
+	MPState   kvmMPState    `json:"mp_state"`
+	Events    kvmVCPUEvents `json:"events"`
+	DebugRegs kvmDebugRegs  `json:"debug_regs"`
+	XSAVE     kvmXSAVE      `json:"xsave"`
+	XCRS      kvmXCRS       `json:"xcrs"`
+}
+
+func newSnapshotTrigger(dir string, mem []byte) *snapshotTrigger {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	return &snapshotTrigger{
+		base: amd64vm.SnapshotBase,
+		size: amd64vm.SnapshotSize,
+		dir:  dir,
+		mem:  mem,
+	}
+}
+
+func (s *snapshotTrigger) contains(addr uint64, size int) bool {
+	return s != nil && size > 0 && addr >= s.base && addr+uint64(size) <= s.base+s.size
+}
+
+func (s *snapshotTrigger) handleMMIO(vm *VM, mmio MMIOExit) (bool, error) {
+	if !s.contains(mmio.Addr, int(mmio.Len)) {
+		return false, nil
+	}
+	if mmio.Write {
+		s.markWrite(mmioValue(mmio))
+		return true, nil
+	}
+	vm.CompleteMMIORead(snapshotTriggerMagic, mmio.Len)
+	return true, nil
+}
+
+func (s *snapshotTrigger) markWrite(value uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.pending = true
+	s.value = value
+	s.mu.Unlock()
+}
+
+func (s *snapshotTrigger) takePending() (uint64, bool) {
+	if s == nil {
+		return 0, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.pending {
+		return 0, false
+	}
+	s.pending = false
+	return s.value, true
+}
+
+func (s *snapshotTrigger) wrapSerialWriter(w io.Writer) io.Writer {
+	if s == nil {
+		return w
+	}
+	return &snapshotSerialWriter{dst: w, trigger: s}
+}
+
+type snapshotSerialWriter struct {
+	dst     io.Writer
+	trigger *snapshotTrigger
+	recent  string
+}
+
+func (w *snapshotSerialWriter) Write(data []byte) (int, error) {
+	if w.trigger != nil && len(data) != 0 {
+		w.recent += string(data)
+		if len(w.recent) > len(snapshotTriggerSerialMarker)*2 {
+			w.recent = w.recent[len(w.recent)-len(snapshotTriggerSerialMarker)*2:]
+		}
+		if strings.Contains(w.recent, snapshotTriggerSerialMarker) {
+			w.trigger.markWrite(snapshotTriggerMagic)
+			w.recent = ""
+		}
+	}
+	if w.dst == nil {
+		return len(data), nil
+	}
+	return w.dst.Write(data)
+}
+
+func (s *snapshotTrigger) captureIfPending(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net) error {
+	if s == nil {
+		return nil
+	}
+	value, ok := s.takePending()
+	if !ok {
+		return nil
+	}
+	s.once.Do(func() {
+		s.err = s.capture(vm, fsdevs, vsock, rng, netdev, value)
+	})
+	if s.err != nil {
+		return fmt.Errorf("capture KVM snapshot: %w", s.err)
+	}
+	return nil
+}
+
+func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, value uint64) error {
+	if s == nil || strings.TrimSpace(s.dir) == "" {
+		return nil
+	}
+	if vm == nil || len(vm.vcpus) != 1 {
+		return fmt.Errorf("KVM startup snapshots require exactly one vCPU")
+	}
+	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create snapshot dir: %w", err)
+	}
+	if err := writeSparseFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
+		return fmt.Errorf("write snapshot memory: %w", err)
+	}
+	vcpu, err := snapshotKVMVCPU(vm, 0)
+	if err != nil {
+		return err
+	}
+	irqChips, err := snapshotKVMIRQChips(vm.vmfd)
+	if err != nil {
+		return err
+	}
+	pit, err := getPIT2(vm.vmfd)
+	if err != nil {
+		return fmt.Errorf("capture KVM pit: %w", err)
+	}
+	clock, err := getClock(vm.vmfd)
+	if err != nil {
+		return fmt.Errorf("capture KVM clock: %w", err)
+	}
+	manifest := kvmSnapshotManifest{
+		Format:       "ccx3-kvm-snapshot-v0",
+		Partial:      true,
+		CapturedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		TriggerBase:  s.base,
+		TriggerValue: value,
+		MemoryBase:   amd64vm.MemoryBase,
+		MemorySize:   uint64(len(s.mem)),
+		MemoryFile:   "memory.bin",
+		NumCPUs:      len(vm.vcpus),
+		CapturedVCPU: 0,
+		VCPU:         vcpu,
+		IRQChips:     irqChips,
+		PIT:          pit,
+		Clock:        clock,
+		Devices:      snapshotKVMDeviceStates(fsdevs, vsock, rng, netdev),
+		Note:         "KVM Linux checkpoint captured after guest init configured non-unique state and before vsock ready.",
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
+		return fmt.Errorf("write snapshot manifest: %w", err)
+	}
+	return nil
+}
+
+func writeSparseFile(path string, data []byte, perm os.FileMode) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	const chunkSize = 4096
+	for off := 0; off < len(data); {
+		end := off + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[off:end]
+		if !allZero(chunk) {
+			if _, err := file.WriteAt(chunk, int64(off)); err != nil {
+				return err
+			}
+		}
+		off = end
+	}
+	if err := file.Truncate(int64(len(data))); err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func allZero(data []byte) bool {
+	for _, b := range data {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if err := emitManagedBootStatus(onEvent, "restoring VM snapshot"); err != nil {
+		return nil, err
+	}
+	manifest, memPath, err := loadKVMSnapshot(snapshotPath)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.NumCPUs > 1 {
+		return nil, fmt.Errorf("KVM startup snapshots currently support only one vCPU, snapshot has %d", manifest.NumCPUs)
+	}
+	if memoryMB == 0 {
+		memoryMB = manifest.MemorySize >> 20
+	}
+	backend := virtio.NewSimpleVsockBackend()
+	listener, err := backend.Listen(vmruntime.ControlPort)
+	if err != nil {
+		return nil, fmt.Errorf("listen vsock control: %w", err)
+	}
+	vsock := virtio.NewVsock(amd64vm.VsockBase, amd64vm.VsockSize, amd64vm.VsockIRQ, vmruntime.GuestCID, backend)
+	connCh := make(chan virtio.VsockConn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+
+	var bootWriter *vmruntime.BootEventWriter
+	var serialWriter io.Writer
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = bootWriter
+	}
+	vm, uart, rng, serialOut, err := restoreManagedVMFromSnapshot(manifest, memPath, memoryMB, dmesg, fsdevs, vsock, netdev, serialWriter)
+	if err != nil {
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := newSessionDone()
+	go func() {
+		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut)
+		closeVMWithFS(vm, fsdevs)
+		done.finish(err)
+	}()
+
+	var control virtio.VsockConn
+	select {
+	case err := <-acceptErrCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+	case <-done.done():
+		err := done.result()
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(ctx.Err(), serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	}
+
+	return &ManagedSession{
+		cancel:     cancel,
+		done:       done,
+		control:    control,
+		listener:   listener,
+		vsock:      vsock,
+		bootWriter: bootWriter,
+		cleanup: func() {
+			_ = vm.CancelRun()
+		},
+		transcript: controlTranscript,
+		serialOut:  serialOut,
+		dmesg:      dmesg,
+		inlineExec: true,
+	}, nil
+}
+
+func restoreManagedVMFromSnapshot(manifest kvmSnapshotManifest, memPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, serialWriter io.Writer) (*VM, *serial.UART8250, *virtio.RNG, *vmruntime.SerialTranscript, error) {
+	memorySize := amd64vm.MemorySizeBytes(memoryMB)
+	if manifest.MemorySize != 0 && manifest.MemorySize != memorySize {
+		return nil, nil, nil, nil, fmt.Errorf("snapshot memory size %d does not match requested VM memory %d", manifest.MemorySize, memorySize)
+	}
+	vm, err := NewVMWithCPUs(1)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	mem, err := mmapSnapshotMemory(memPath, memorySize)
+	if err != nil {
+		_ = vm.Close()
+		return nil, nil, nil, nil, err
+	}
+	if err := mapAMD64GuestMemoryBytes(vm, memoryMB, mem); err != nil {
+		_ = unix.Munmap(mem)
+		_ = vm.Close()
+		return nil, nil, nil, nil, err
+	}
+
+	serialOut := vmruntime.NewSerialTranscript()
+	if serialWriter == nil {
+		serialWriter = serialOut
+	} else {
+		serialWriter = io.MultiWriter(serialOut, serialWriter)
+	}
+	rng := virtio.NewRNG(amd64vm.RNGBase, amd64vm.RNGSize, amd64vm.RNGIRQ)
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			fsdev.Attach(vm, vm)
+		}
+	}
+	if vsock != nil {
+		vsock.Attach(vm, vm)
+	}
+	rng.Attach(vm, vm)
+	if netdev != nil {
+		netdev.Attach(vm, vm)
+	}
+	if err := restoreKVMDeviceStates(manifest.Devices, fsdevs, vsock, rng, netdev); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		return nil, nil, nil, serialOut, err
+	}
+	if err := restoreKVMIRQChips(vm.vmfd, manifest.IRQChips); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		return nil, nil, nil, serialOut, err
+	}
+	if err := setPIT2(vm.vmfd, &manifest.PIT); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		return nil, nil, nil, serialOut, fmt.Errorf("restore KVM pit: %w", err)
+	}
+	if err := setClock(vm.vmfd, &manifest.Clock); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		return nil, nil, nil, serialOut, fmt.Errorf("restore KVM clock: %w", err)
+	}
+	if err := restoreKVMVCPU(vm, 0, manifest.VCPU); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		return nil, nil, nil, serialOut, err
+	}
+	uart := serial.NewUART8250(amd64vm.COM1Base, 0, serialWriter)
+	return vm, uart, rng, serialOut, nil
+}
+
+func loadKVMSnapshot(path string) (kvmSnapshotManifest, string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("snapshot path is required")
+	}
+	manifestPath := path
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		manifestPath = filepath.Join(path, "manifest.json")
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("read snapshot manifest: %w", err)
+	}
+	var manifest kvmSnapshotManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("decode snapshot manifest: %w", err)
+	}
+	if manifest.Format != "ccx3-kvm-snapshot-v0" {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("unsupported KVM snapshot format %q", manifest.Format)
+	}
+	memPath := manifest.MemoryFile
+	if !filepath.IsAbs(memPath) {
+		memPath = filepath.Join(filepath.Dir(manifestPath), memPath)
+	}
+	info, err := os.Stat(memPath)
+	if err != nil {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("stat snapshot memory: %w", err)
+	}
+	if info.Size() <= 0 {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("snapshot memory is empty")
+	}
+	if manifest.MemorySize != 0 && uint64(info.Size()) != manifest.MemorySize {
+		return kvmSnapshotManifest{}, "", fmt.Errorf("snapshot memory size = %d, want %d", info.Size(), manifest.MemorySize)
+	}
+	return manifest, memPath, nil
+}
+
+func mmapSnapshotMemory(path string, size uint64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open snapshot memory: %w", err)
+	}
+	defer file.Close()
+	mem, err := unix.Mmap(int(file.Fd()), 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE)
+	if err != nil {
+		return nil, fmt.Errorf("mmap snapshot memory: %w", err)
+	}
+	return mem, nil
+}
+
+func snapshotKVMVCPU(vm *VM, index int) (kvmSnapshotVCPU, error) {
+	vcpu, err := kvmVCPU(vm, index)
+	if err != nil {
+		return kvmSnapshotVCPU{}, err
+	}
+	regs, err := getRegs(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM regs: %w", err)
+	}
+	sregs, err := getSRegs(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM sregs: %w", err)
+	}
+	fpu, err := getFPU(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM fpu: %w", err)
+	}
+	lapic, err := getLAPIC(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM lapic: %w", err)
+	}
+	mpState, err := getMPState(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM mp state: %w", err)
+	}
+	events, err := getVCPUEvents(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM vcpu events: %w", err)
+	}
+	debugRegs, err := getDebugRegs(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM debug regs: %w", err)
+	}
+	xsave, err := getXSAVE(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM xsave: %w", err)
+	}
+	xcrs, err := getXCRS(vcpu.fd)
+	if err != nil {
+		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM xcrs: %w", err)
+	}
+	return kvmSnapshotVCPU{
+		Regs:      regs,
+		SRegs:     sregs,
+		MSRs:      snapshotKVMMSRs(vcpu.fd),
+		FPU:       fpu,
+		LAPIC:     lapic,
+		MPState:   mpState,
+		Events:    events,
+		DebugRegs: debugRegs,
+		XSAVE:     xsave,
+		XCRS:      xcrs,
+	}, nil
+}
+
+func restoreKVMVCPU(vm *VM, index int, state kvmSnapshotVCPU) error {
+	vcpu, err := kvmVCPU(vm, index)
+	if err != nil {
+		return err
+	}
+	if err := setSRegs(vcpu.fd, &state.SRegs); err != nil {
+		return fmt.Errorf("restore KVM sregs: %w", err)
+	}
+	if err := restoreKVMMSRs(vcpu.fd, state.MSRs); err != nil {
+		return err
+	}
+	if err := setFPU(vcpu.fd, &state.FPU); err != nil {
+		return fmt.Errorf("restore KVM fpu: %w", err)
+	}
+	if err := setXCRS(vcpu.fd, &state.XCRS); err != nil {
+		return fmt.Errorf("restore KVM xcrs: %w", err)
+	}
+	if err := setXSAVE(vcpu.fd, &state.XSAVE); err != nil {
+		return fmt.Errorf("restore KVM xsave: %w", err)
+	}
+	if err := setLAPIC(vcpu.fd, &state.LAPIC); err != nil {
+		return fmt.Errorf("restore KVM lapic: %w", err)
+	}
+	if err := setMPState(vcpu.fd, &state.MPState); err != nil {
+		return fmt.Errorf("restore KVM mp state: %w", err)
+	}
+	if err := setVCPUEvents(vcpu.fd, &state.Events); err != nil {
+		return fmt.Errorf("restore KVM vcpu events: %w", err)
+	}
+	if err := setDebugRegs(vcpu.fd, &state.DebugRegs); err != nil {
+		return fmt.Errorf("restore KVM debug regs: %w", err)
+	}
+	if err := setRegs(vcpu.fd, &state.Regs); err != nil {
+		return fmt.Errorf("restore KVM regs: %w", err)
+	}
+	return nil
+}
+
+func kvmVCPU(vm *VM, index int) (*VCPU, error) {
+	if vm == nil || index < 0 || index >= len(vm.vcpus) {
+		return nil, fmt.Errorf("vcpu %d out of range", index)
+	}
+	vcpu := vm.vcpus[index]
+	if vcpu == nil || vcpu.fd < 0 {
+		return nil, fmt.Errorf("vcpu %d is closed", index)
+	}
+	return vcpu, nil
+}
+
+func snapshotKVMMSRs(vcpuFd int) []kvmMSREntry {
+	out := make([]kvmMSREntry, 0, len(kvmSnapshotMSRs))
+	for _, index := range kvmSnapshotMSRs {
+		value, err := getVCPUMSR(vcpuFd, index)
+		if err != nil {
+			continue
+		}
+		out = append(out, kvmMSREntry{Index: index, Data: value})
+	}
+	return out
+}
+
+func restoreKVMMSRs(vcpuFd int, entries []kvmMSREntry) error {
+	for _, entry := range entries {
+		if err := setVCPUMSR(vcpuFd, entry.Index, entry.Data); err != nil {
+			return fmt.Errorf("restore KVM msr %s: %w", strconv.FormatUint(uint64(entry.Index), 16), err)
+		}
+	}
+	return nil
+}
+
+func snapshotKVMIRQChips(vmFd int) ([]kvmIRQChip, error) {
+	const kvmNrIRQChips = 3
+	chips := make([]kvmIRQChip, 0, kvmNrIRQChips)
+	for chipID := uint32(0); chipID < kvmNrIRQChips; chipID++ {
+		chip, err := getIRQChip(vmFd, chipID)
+		if err != nil {
+			return nil, fmt.Errorf("capture KVM irqchip %d: %w", chipID, err)
+		}
+		chips = append(chips, chip)
+	}
+	return chips, nil
+}
+
+func restoreKVMIRQChips(vmFd int, chips []kvmIRQChip) error {
+	for i := range chips {
+		chip := chips[i]
+		if err := setIRQChip(vmFd, &chip); err != nil {
+			return fmt.Errorf("restore KVM irqchip %d: %w", chip.ChipID, err)
+		}
+	}
+	return nil
+}
+
+func snapshotKVMDeviceStates(fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net) map[string]virtio.MMIOState {
+	out := map[string]virtio.MMIOState{}
+	if rng != nil {
+		out["rng"] = rng.SnapshotState()
+	}
+	if vsock != nil {
+		out["vsock"] = vsock.SnapshotState()
+	}
+	if netdev != nil {
+		out["net"] = netdev.SnapshotState()
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		out[kvmFSDeviceStateKey(fsdev)] = fsdev.SnapshotState()
+	}
+	return out
+}
+
+func restoreKVMDeviceStates(states map[string]virtio.MMIOState, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net) error {
+	if state, ok := states["rng"]; ok && rng != nil {
+		if err := rng.RestoreState(state); err != nil {
+			return fmt.Errorf("restore rng state: %w", err)
+		}
+	}
+	if state, ok := states["vsock"]; ok && vsock != nil {
+		if err := vsock.RestoreState(state); err != nil {
+			return fmt.Errorf("restore vsock state: %w", err)
+		}
+	}
+	if state, ok := states["net"]; ok && netdev != nil {
+		if err := netdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore net state: %w", err)
+		}
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		key := kvmFSDeviceStateKey(fsdev)
+		state, ok := states[key]
+		if !ok {
+			return fmt.Errorf("snapshot missing state for fs device %#x", fsdev.Base)
+		}
+		if err := fsdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore fs device %#x state: %w", fsdev.Base, err)
+		}
+	}
+	return nil
+}
+
+func kvmFSDeviceStateKey(fsdev *virtio.FS) string {
+	if fsdev == nil {
+		return "fs@0"
+	}
+	return "fs@" + strconv.FormatUint(fsdev.Base, 16)
+}

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -205,12 +205,24 @@ func (v *VM) MapAnonymousMemorySlot(slot uint32, size uint64, guestPhysAddr uint
 }
 
 func mapAMD64GuestMemory(vm *VM, memoryMB uint64) ([]byte, error) {
-	lowSize := amd64vm.LowMemorySizeBytes(memoryMB)
-	highSize := amd64vm.HighMemorySizeBytes(memoryMB)
-	totalSize := lowSize + highSize
+	totalSize := amd64vm.MemorySizeBytes(memoryMB)
 	mem, err := unix.Mmap(-1, 0, int(totalSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANONYMOUS|unix.MAP_PRIVATE)
 	if err != nil {
 		return nil, fmt.Errorf("mmap guest memory: %w", err)
+	}
+	if err := mapAMD64GuestMemoryBytes(vm, memoryMB, mem); err != nil {
+		_ = unix.Munmap(mem)
+		return nil, err
+	}
+	return mem, nil
+}
+
+func mapAMD64GuestMemoryBytes(vm *VM, memoryMB uint64, mem []byte) error {
+	lowSize := amd64vm.LowMemorySizeBytes(memoryMB)
+	highSize := amd64vm.HighMemorySizeBytes(memoryMB)
+	totalSize := lowSize + highSize
+	if uint64(len(mem)) != totalSize {
+		return fmt.Errorf("guest memory size %d does not match requested VM memory %d", len(mem), totalSize)
 	}
 	lowRegion := kvmUserspaceMemoryRegion{
 		Slot:          0,
@@ -219,8 +231,7 @@ func mapAMD64GuestMemory(vm *VM, memoryMB uint64) ([]byte, error) {
 		UserspaceAddr: uint64(uintptr(unsafe.Pointer(&mem[0]))),
 	}
 	if err := setUserMemoryRegion(vm.vmfd, &lowRegion); err != nil {
-		_ = unix.Munmap(mem)
-		return nil, fmt.Errorf("set user memory region: %w", err)
+		return fmt.Errorf("set user memory region: %w", err)
 	}
 	vm.mem = mem
 	vm.lowMemLimit = lowSize
@@ -232,17 +243,16 @@ func mapAMD64GuestMemory(vm *VM, memoryMB uint64) ([]byte, error) {
 			UserspaceAddr: uint64(uintptr(unsafe.Pointer(&mem[lowSize]))),
 		}
 		if err := setUserMemoryRegion(vm.vmfd, &highRegion); err != nil {
-			_ = unix.Munmap(mem)
 			vm.mem = nil
 			vm.lowMemLimit = 0
-			return nil, fmt.Errorf("set user memory region: %w", err)
+			return fmt.Errorf("set user memory region: %w", err)
 		}
 		vm.regions = append(vm.regions, memoryMapping{
 			guestPhysAddr: amd64vm.HighMemoryBase,
 			mem:           mem[lowSize : lowSize+highSize],
 		})
 	}
-	return mem, nil
+	return nil
 }
 
 func (v *VM) Run(exit *Exit) error {

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -98,6 +98,9 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
 	initCfg.WorkDir = workDir
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
@@ -108,8 +111,10 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		Spec:     linuxManagedMachineSpec(req.ID, req.MemoryMB, req.CPUs, req.Dmesg, network),
 		Artifact: rootartifact.Artifact{Kernel: kernel, Initrd: initrd},
 		Attachments: kvm.LinuxManagedAttachments{
-			FSDevices: fsdevs,
-			NetDevice: networkDevice(network),
+			FSDevices:       fsdevs,
+			NetDevice:       networkDevice(network),
+			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
 	}, onEvent)
 	if err != nil {
@@ -146,17 +151,19 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	if strings.TrimSpace(req.Image) != "" {
 		return b.StartStream(ctx, client.CreateInstanceRequest{
-			ID:             req.ID,
-			Image:          req.Image,
-			InitSystem:     req.InitSystem,
-			Kernel:         req.Kernel,
-			Network:        req.Network,
-			KernelModules:  append([]string(nil), req.KernelModules...),
-			MemoryMB:       req.MemoryMB,
-			CPUs:           req.CPUs,
-			NestedVirt:     req.NestedVirt,
-			Dmesg:          req.Dmesg,
-			TimeoutSeconds: req.TimeoutSeconds,
+			ID:              req.ID,
+			Image:           req.Image,
+			InitSystem:      req.InitSystem,
+			Kernel:          req.Kernel,
+			Network:         req.Network,
+			KernelModules:   append([]string(nil), req.KernelModules...),
+			MemoryMB:        req.MemoryMB,
+			CPUs:            req.CPUs,
+			NestedVirt:      req.NestedVirt,
+			Dmesg:           req.Dmesg,
+			TimeoutSeconds:  req.TimeoutSeconds,
+			SnapshotDir:     req.SnapshotDir,
+			RestoreSnapshot: req.RestoreSnapshot,
 		}, onEvent)
 	}
 	if b == nil || b.kernel == nil || b.images == nil {
@@ -208,6 +215,9 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	initCfg.Env = vmruntime.WithDefaultEnv(nil)
 	initCfg.WorkDir = "/"
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
@@ -218,8 +228,10 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		Spec:     linuxManagedMachineSpec(req.ID, req.MemoryMB, req.CPUs, req.Dmesg, network),
 		Artifact: rootartifact.Artifact{Kernel: kernel, Initrd: initrd},
 		Attachments: kvm.LinuxManagedAttachments{
-			FSDevices: fsdevs,
-			NetDevice: networkDevice(network),
+			FSDevices:       fsdevs,
+			NetDevice:       networkDevice(network),
+			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
 	}, onEvent)
 	if err != nil {

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -367,6 +367,35 @@ func TestRuntimePersistentLinuxStreamsStdin(t *testing.T) {
 	requireGuestOutput(t, output, "line:alpha", "line:beta")
 }
 
+func TestRuntimeRestoresPersistentLinuxFromStartupSnapshot(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("linux/amd64 startup snapshots are implemented by the KVM amd64 backend")
+	}
+	env := newRuntimeBootEnv(t)
+	snapshotRoot := t.TempDir()
+
+	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{
+		SnapshotDir: snapshotRoot,
+		MemoryMB:    256,
+		CPUs:        1,
+	})
+	captureConsole := runtimeConsoleHistory(inst)
+	if err := inst.Close(); err != nil {
+		t.Fatalf("close snapshot capture instance: %v", err)
+	}
+
+	snapshotPath := singleSnapshotPath(t, snapshotRoot, captureConsole)
+	restored := startRuntimeInstance(t, env, client.CreateInstanceRequest{
+		RestoreSnapshot: snapshotPath,
+		MemoryMB:        256,
+		CPUs:            1,
+	})
+	defer restored.Close()
+
+	resp := execInRuntime(t, restored, []string{"sh", "-lc", "set -eu; printf 'restored-startup-snapshot\n'; cat /proc/sys/kernel/ostype"})
+	requireGuestOutput(t, resp.Output, "restored-startup-snapshot", "Linux")
+}
+
 func TestRuntimePersistentRejectsRuntimeMountConflicts(t *testing.T) {
 	env := newRuntimeBootEnv(t)
 	sourceA := t.TempDir()
@@ -928,6 +957,30 @@ func startRuntimeInstance(t *testing.T, env *runtimeBootEnv, req client.CreateIn
 		t.Fatalf("boot persistent Linux guest: %v", err)
 	}
 	return inst
+}
+
+func singleSnapshotPath(t *testing.T, root, console string) string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read snapshot root: %v", err)
+	}
+	var snapshots []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "snapshot-") {
+			snapshots = append(snapshots, filepath.Join(root, entry.Name()))
+		}
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("snapshot count = %d, want 1\nconsole:\n%s", len(snapshots), console)
+	}
+	if _, err := os.Stat(filepath.Join(snapshots[0], "manifest.json")); err != nil {
+		t.Fatalf("stat snapshot manifest: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(snapshots[0], "memory.bin")); err != nil {
+		t.Fatalf("stat snapshot memory: %v", err)
+	}
+	return snapshots[0]
 }
 
 func runInRuntimeInstance(t *testing.T, env *runtimeBootEnv, inst Instance, req client.RunRequest) client.ExecResponse {

--- a/internal/vmruntime/guestinit.go
+++ b/internal/vmruntime/guestinit.go
@@ -163,6 +163,7 @@ func BuildInitramfs(initPayload []byte, modules []alpine.Module, config GuestIni
 		{Path: "/ccx3", Mode: 0o755, Type: initramfs.TypeDirectory},
 		{Path: "/ccx3/modules", Mode: 0o755, Type: initramfs.TypeDirectory},
 		{Path: "/dev/console", Mode: 0o600, Type: initramfs.TypeCharDevice, DevMajor: 5, DevMinor: 1},
+		{Path: "/dev/mem", Mode: 0o600, Type: initramfs.TypeCharDevice, DevMajor: 1, DevMinor: 1},
 		{Path: "/dev/null", Mode: 0o666, Type: initramfs.TypeCharDevice, DevMajor: 1, DevMinor: 3},
 		{Path: "/dev/kmsg", Mode: 0o600, Type: initramfs.TypeCharDevice, DevMajor: 1, DevMinor: 11},
 		{Path: "/dev/loop0", Mode: 0o660, Type: initramfs.TypeBlockDevice, DevMajor: 7, DevMinor: 0},


### PR DESCRIPTION
## Summary

Adds startup snapshot capture and restore support for the linux/amd64 KVM backend.

This includes:
- capturing sparse guest memory plus KVM vCPU state, MSRs, FPU/LAPIC/XSAVE/XCRS, IRQ chip, PIT, clock, and virtio MMIO device state
- restoring managed linux/amd64 sessions from a captured snapshot
- wiring `SnapshotDir` and `RestoreSnapshot` through the linux/amd64 runtime backend
- triggering snapshot capture from guest init through the configured snapshot MMIO page
- making KVM managed run loops interruptible so session cleanup does not hang on cancellation
- adding an integration test that captures a persistent Linux runtime snapshot, restores it, and executes a command

Closes #31.

## Notes

Startup snapshots currently support one vCPU on linux/amd64. Multi-vCPU snapshot startup is rejected explicitly.

## Validation

```sh
go test ./internal/hv/kvm ./internal/vm ./internal/cmd/init ./internal/vmruntime ./internal/virtio ./internal/managed/...
```

A local timing smoke check showed restore-to-ready around 35-43ms versus cold persistent Linux ready around 371-387ms with 256MB/1 CPU on this machine.