### PR TITLE
[codex] Add Windows arm64 startup snapshots

### DIFF
--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -1127,25 +1127,41 @@ func triggerSnapshotMMIO(base uint64) error {
 	if base == 0 {
 		return nil
 	}
-	writeConsole("__CCX3_SNAPSHOT__\n")
+	const snapshotMagic = 0x43535833534e4150
 	pageSize := unix.Getpagesize()
 	pageBase := base & ^uint64(pageSize-1)
 	pageOff := int(base - pageBase)
+	if err := ensureDeviceNode("/dev/mem", unix.S_IFCHR|0o600, int(unix.Mkdev(1, 1))); err != nil {
+		writeConsole("__CCX3_SNAPSHOT__\n")
+		return fmt.Errorf("create /dev/mem: %w", err)
+	}
 	mem, err := os.OpenFile("/dev/mem", os.O_RDWR|unix.O_SYNC, 0)
 	if err != nil {
+		writeConsole("__CCX3_SNAPSHOT__\n")
 		return fmt.Errorf("open /dev/mem: %w", err)
 	}
 	defer mem.Close()
 	mapped, err := unix.Mmap(int(mem.Fd()), int64(pageBase), pageSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
 	if err != nil {
-		return fmt.Errorf("mmap snapshot mmio: %w", err)
+		writeConsole("__CCX3_SNAPSHOT__\n")
+		return fmt.Errorf("map snapshot MMIO: %w", err)
 	}
 	defer unix.Munmap(mapped)
 	if pageOff+8 > len(mapped) {
 		return fmt.Errorf("snapshot mmio offset %#x outside mapped page", pageOff)
 	}
-	*(*uint64)(unsafe.Pointer(&mapped[pageOff])) = 0x43535833534e4150
+	*(*uint64)(unsafe.Pointer(&mapped[pageOff])) = snapshotMagic
+	writeConsole("__CCX3_SNAPSHOT__\n")
 	return nil
+}
+
+func ensureDeviceNode(path string, mode uint32, dev int) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return unix.Mknod(path, mode, dev)
 }
 
 func seedEntropyFromHostRNG(size int) error {

--- a/internal/hv/whp/bindings_windows_arm64.go
+++ b/internal/hv/whp/bindings_windows_arm64.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -25,6 +27,8 @@ var (
 	procWHvRunVirtualProcessor          = winhvplatform.NewProc("WHvRunVirtualProcessor")
 	procWHvGetVirtualProcessorRegisters = winhvplatform.NewProc("WHvGetVirtualProcessorRegisters")
 	procWHvSetVirtualProcessorRegisters = winhvplatform.NewProc("WHvSetVirtualProcessorRegisters")
+	procWHvGetVirtualProcessorState     = winhvplatform.NewProc("WHvGetVirtualProcessorState")
+	procWHvSetVirtualProcessorState     = winhvplatform.NewProc("WHvSetVirtualProcessorState")
 	procWHvCancelRunVirtualProcessor    = winhvplatform.NewProc("WHvCancelRunVirtualProcessor")
 	procWHvRequestInterrupt             = winhvplatform.NewProc("WHvRequestInterrupt")
 	procWHvAdviseGpaRange               = winhvplatform.NewProc("WHvAdviseGpaRange")
@@ -135,21 +139,67 @@ type adviseGPARangePopulateOptions struct {
 }
 
 type registerName uint32
+type virtualProcessorStateType uint32
 
 const (
-	registerX0     registerName = 0x00020000
-	registerX1     registerName = 0x00020001
-	registerX2     registerName = 0x00020002
-	registerX3     registerName = 0x00020003
-	registerX28    registerName = 0x0002001c
-	registerFP     registerName = 0x0002001d
-	registerLR     registerName = 0x0002001e
-	registerSP     registerName = 0x0002001f
-	registerSPEL0  registerName = 0x00020020
-	registerSPEL1  registerName = 0x00020021
-	registerPC     registerName = 0x00020022
-	registerPSTATE registerName = 0x00020023
-	registerGICR   registerName = 0x00063000
+	virtualProcessorStateTypeArm64InterruptControllerState virtualProcessorStateType = 0x80000000
+	virtualProcessorStateTypeArm64GlobalInterruptState     virtualProcessorStateType = 0xc0000006
+)
+
+const (
+	registerX0          registerName = 0x00020000
+	registerX1          registerName = 0x00020001
+	registerX2          registerName = 0x00020002
+	registerX3          registerName = 0x00020003
+	registerX28         registerName = 0x0002001c
+	registerFP          registerName = 0x0002001d
+	registerLR          registerName = 0x0002001e
+	registerSP          registerName = 0x0002001f
+	registerSPEL0       registerName = 0x00020020
+	registerSPEL1       registerName = 0x00020021
+	registerPC          registerName = 0x00020022
+	registerPSTATE      registerName = 0x00020023
+	registerCurrentEL   registerName = 0x00021003
+	registerDAIF        registerName = 0x00021004
+	registerDIT         registerName = 0x00021005
+	registerNZCV        registerName = 0x00021006
+	registerPAN         registerName = 0x00021007
+	registerSPSEL       registerName = 0x00021008
+	registerSSBS        registerName = 0x00021009
+	registerTCO         registerName = 0x0002100a
+	registerUAO         registerName = 0x0002100b
+	registerQ0          registerName = 0x00030000
+	registerELREL1      registerName = 0x00040015
+	registerFPCR        registerName = 0x00040012
+	registerFPSR        registerName = 0x00040013
+	registerSPSREL1     registerName = 0x00040014
+	registerACTLREL1    registerName = 0x00040003
+	registerCPACREL1    registerName = 0x00040004
+	registerCSSELREL1   registerName = 0x00040035
+	registerESREL1      registerName = 0x00040008
+	registerFAREL1      registerName = 0x00040009
+	registerMAIREL1     registerName = 0x0004000b
+	registerPAREL1      registerName = 0x0004000a
+	registerSCTLREL1    registerName = 0x00040002
+	registerTCREL1      registerName = 0x00040007
+	registerTPIDREL0    registerName = 0x00040011
+	registerTPIDREL1    registerName = 0x0004000e
+	registerTPIDRROEL0  registerName = 0x00040010
+	registerTTBR0EL1    registerName = 0x00040005
+	registerTTBR1EL1    registerName = 0x00040006
+	registerVBAREL1     registerName = 0x0004000c
+	registerCNTKCTLEL1  registerName = 0x00058008
+	registerCNTVCTLEL0  registerName = 0x0005800e
+	registerCNTVCVALEL0 registerName = 0x0005800f
+	registerCNTVCTEL0   registerName = 0x00058011
+	registerGICR        registerName = 0x00063000
+
+	registerInternalActivityState      registerName = 0x00000004
+	registerPendingEvent0              registerName = 0x00010004
+	registerPendingEvent1              registerName = 0x00010005
+	registerDeliverabilityNotification registerName = 0x00010006
+	registerPendingEvent2              registerName = 0x00010008
+	registerPendingEvent3              registerName = 0x00010009
 )
 
 func registerX(index int) registerName {
@@ -282,8 +332,9 @@ func (c *runVPExitContext) memoryAccess() *memoryAccessContext {
 }
 
 type allocation struct {
-	addr uintptr
-	size uintptr
+	addr    uintptr
+	size    uintptr
+	mapping windows.Handle
 }
 
 func virtualAlloc(size uintptr) (*allocation, error) {
@@ -302,6 +353,40 @@ func virtualAlloc(size uintptr) (*allocation, error) {
 	return &allocation{addr: ptr, size: size}, nil
 }
 
+func virtualMapFile(path string, size uintptr) (*allocation, error) {
+	if size == 0 {
+		return nil, fmt.Errorf("memory mapping size must be non-zero")
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ|windows.GENERIC_EXECUTE,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(file)
+
+	mapping, err := windows.CreateFileMapping(file, nil, windows.PAGE_EXECUTE_WRITECOPY, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_COPY|windows.FILE_MAP_EXECUTE, 0, 0, size)
+	if err != nil {
+		_ = windows.CloseHandle(mapping)
+		return nil, err
+	}
+	return &allocation{addr: addr, size: size, mapping: mapping}, nil
+}
+
 func (a *allocation) bytes() []byte {
 	return unsafe.Slice((*byte)(unsafe.Pointer(a.addr)), int(a.size))
 }
@@ -309,6 +394,19 @@ func (a *allocation) bytes() []byte {
 func (a *allocation) free() error {
 	if a == nil || a.addr == 0 {
 		return nil
+	}
+	if a.mapping != 0 {
+		var first error
+		if err := windows.UnmapViewOfFile(a.addr); err != nil && first == nil {
+			first = err
+		}
+		if err := windows.CloseHandle(a.mapping); err != nil && first == nil {
+			first = err
+		}
+		a.addr = 0
+		a.size = 0
+		a.mapping = 0
+		return first
 	}
 	const memRelease = 0x8000
 	r1, _, err := procVirtualFree.Call(a.addr, 0, memRelease)
@@ -429,6 +527,59 @@ func setVirtualProcessorRegisters(part partitionHandle, vpIndex uint32, names []
 	runtime.KeepAlive(names)
 	runtime.KeepAlive(values)
 	runtime.KeepAlive(backing)
+	return err
+}
+
+func getVirtualProcessorState(part partitionHandle, vpIndex uint32, stateType virtualProcessorStateType) ([]byte, error) {
+	var written uint32
+	probe := []byte{0}
+	err := callGetVirtualProcessorState(part, vpIndex, stateType, probe, &written)
+	if err == nil {
+		return probe[:written], nil
+	}
+	if written == 0 {
+		return nil, err
+	}
+	buf := make([]byte, written)
+	if err := callGetVirtualProcessorState(part, vpIndex, stateType, buf, &written); err != nil {
+		return nil, err
+	}
+	return buf[:written], nil
+}
+
+func callGetVirtualProcessorState(part partitionHandle, vpIndex uint32, stateType virtualProcessorStateType, buf []byte, written *uint32) error {
+	if len(buf) == 0 {
+		return fmt.Errorf("virtual processor state buffer is empty")
+	}
+	r1, _, callErr := procWHvGetVirtualProcessorState.Call(
+		uintptr(part),
+		uintptr(vpIndex),
+		uintptr(stateType),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		uintptr(unsafe.Pointer(written)),
+	)
+	if callErr != syscall.Errno(0) && r1 == 0 {
+		return callErr
+	}
+	runtime.KeepAlive(buf)
+	runtime.KeepAlive(written)
+	return hresult(int32(r1)).Err()
+}
+
+func setVirtualProcessorState(part partitionHandle, vpIndex uint32, stateType virtualProcessorStateType, buf []byte) error {
+	if len(buf) == 0 {
+		return fmt.Errorf("virtual processor state buffer is empty")
+	}
+	err := callHRESULT(
+		procWHvSetVirtualProcessorState,
+		uintptr(part),
+		uintptr(vpIndex),
+		uintptr(stateType),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+	)
+	runtime.KeepAlive(buf)
 	return err
 }
 

--- a/internal/hv/whp/boot_windows_arm64.go
+++ b/internal/hv/whp/boot_windows_arm64.go
@@ -281,7 +281,7 @@ func handleBootMMIO(vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *v
 	return fmt.Errorf("unhandled mmio addr=%#x len=%d write=%v", mmio.Addr, mmio.Len, mmio.Write)
 }
 
-func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut fmt.Stringer, sampler *whpPCSampler) error {
+func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialOut fmt.Stringer, snapshot *snapshotTrigger, sampler *whpPCSampler) error {
 	if sampler != nil {
 		defer sampler.dump("final")
 	}
@@ -334,6 +334,9 @@ func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs
 		case runVPExitReasonCanceled:
 			canceledExits++
 		}
+		if err := snapshot.captureIfPending(vm, fsdevs, vsock, rng, netdev); err != nil {
+			return err
+		}
 		if trace {
 			if !now.Before(nextTrace) {
 				_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux run +%s: exits=%d mmio=%d canceled=%d serial=%d uart=%d fs=%d vsock=%d rng=%d net=%d gic=%d\n",
@@ -343,8 +346,24 @@ func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs
 				}
 			}
 		}
-		if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit, &stats); err != nil {
-			return err
+		handled := false
+		if exit.Reason == runVPExitReasonUnmappedGPA || exit.Reason == runVPExitReasonGPAIntercept {
+			snapshotWrite := snapshot != nil && snapshot.contains(exit.MMIO.Addr, int(exit.MMIO.Len)) && exit.MMIO.Write && mmioValue(exit.MMIO) == snapshotTriggerMagic
+			var err error
+			handled, err = snapshot.handleMMIO(vm, exit.MMIO)
+			if err != nil {
+				return err
+			}
+			if handled && snapshotWrite {
+				if err := snapshot.requestHostCapture(vm); err != nil {
+					return err
+				}
+			}
+		}
+		if !handled {
+			if err := handleArm64Exit(vm, uart, fsdevs, vsock, rng, netdev, exit, &stats); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/internal/hv/whp/host_windows_arm64.go
+++ b/internal/hv/whp/host_windows_arm64.go
@@ -19,16 +19,20 @@ import (
 type Host struct{}
 
 type LinuxManagedMachine struct {
-	Spec      machine.Spec
-	Kernel    []byte
-	Initrd    []byte
-	FSDevices []*virtio.FS
-	NetDevice *virtio.Net
+	Spec            machine.Spec
+	Kernel          []byte
+	Initrd          []byte
+	FSDevices       []*virtio.FS
+	NetDevice       *virtio.Net
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 type LinuxManagedAttachments struct {
-	FSDevices []*virtio.FS
-	NetDevice *virtio.Net
+	FSDevices       []*virtio.FS
+	NetDevice       *virtio.Net
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 type BSDManagedAttachments struct {
@@ -106,17 +110,23 @@ func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEven
 		return nil, fmt.Errorf("whp linux managed attachments have type %T", req.Attachments)
 	}
 	return Host{}.StartLinuxManaged(ctx, LinuxManagedMachine{
-		Spec:      req.Spec,
-		Kernel:    req.Artifact.Kernel,
-		Initrd:    req.Artifact.Initrd,
-		FSDevices: attachments.FSDevices,
-		NetDevice: attachments.NetDevice,
+		Spec:            req.Spec,
+		Kernel:          req.Artifact.Kernel,
+		Initrd:          req.Artifact.Initrd,
+		FSDevices:       attachments.FSDevices,
+		NetDevice:       attachments.NetDevice,
+		SnapshotDir:     attachments.SnapshotDir,
+		RestoreSnapshot: attachments.RestoreSnapshot,
 	}, onEvent)
 }
 
 func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
 	machine = normalizeLinuxManagedMachine(machine)
-	return StartManagedSessionWithNet(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, onEvent)
+	opts := ManagedSessionOptions{
+		SnapshotDir:     strings.TrimSpace(machine.SnapshotDir),
+		RestoreSnapshot: strings.TrimSpace(machine.RestoreSnapshot),
+	}
+	return StartManagedSessionWithNetOptions(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, opts, onEvent)
 }
 
 func normalizeLinuxManagedMachine(machine LinuxManagedMachine) LinuxManagedMachine {

--- a/internal/hv/whp/session_windows_arm64.go
+++ b/internal/hv/whp/session_windows_arm64.go
@@ -37,9 +37,16 @@ type ManagedSession struct {
 	transcript *vmruntime.SerialTranscript
 	serialOut  *vmruntime.SerialTranscript
 	cleanup    func()
+	waitOnce   sync.Once
+	waitErr    error
 	sendMu     sync.Mutex
 	nextID     atomic.Uint64
 	dmesg      bool
+}
+
+type ManagedSessionOptions struct {
+	SnapshotDir     string
+	RestoreSnapshot string
 }
 
 func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
@@ -47,6 +54,13 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 }
 
 func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithNetOptions(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, netdev, ManagedSessionOptions{}, onEvent)
+}
+
+func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if snapshotPath := strings.TrimSpace(opts.RestoreSnapshot); snapshotPath != "" {
+		return StartManagedSessionFromSnapshot(ctx, snapshotPath, memoryMB, dmesg, fsdevs, netdev, onEvent)
+	}
 	trace := os.Getenv("CC_WHP_ARM64_TIMING") != "" || os.Getenv("CC_WHP_BSD_TIMING") != ""
 	startTime := time.Now()
 	if trace {
@@ -82,6 +96,7 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = io.MultiWriter(serialOut, bootWriter)
 	}
+	snapshot := newSnapshotTrigger(opts.SnapshotDir, nil)
 	prepareStart := time.Now()
 	vm, uart, _, err := prepareArm64VM(kernel, initrd, memoryMB, dmesg, dmesg, fsdevs, vsock, rng, netdev, serialWriter)
 	if err != nil {
@@ -92,6 +107,14 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 		}
 		return nil, err
 	}
+	if snapshot != nil {
+		snapshot.mem = vm.Memory()
+		for _, fsdev := range fsdevs {
+			if fsdev != nil {
+				fsdev.Async = false
+			}
+		}
+	}
 	if trace {
 		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: vm prepared took=%s\n", time.Since(startTime).Round(time.Millisecond), time.Since(prepareStart).Round(time.Millisecond))
 	}
@@ -99,9 +122,17 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 	runCtx, cancel := context.WithCancel(context.Background())
 	doneCh := make(chan error, 1)
 	go func() {
-		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut, newWHPPCSampler("linux", kernel))
+		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut, snapshot, newWHPPCSampler("linux", kernel))
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: run loop stopped err=%v\n", time.Since(startTime).Round(time.Millisecond), err)
+		}
 		closeFSDevices(fsdevs)
-		err = errors.Join(err, vm.Close())
+		closeStart := time.Now()
+		closeErr := vm.Close()
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 linux +%s: vm close took=%s err=%v\n", time.Since(startTime).Round(time.Millisecond), time.Since(closeStart).Round(time.Millisecond), closeErr)
+		}
+		err = errors.Join(err, closeErr)
 		doneCh <- err
 	}()
 	if trace {
@@ -162,6 +193,18 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 			_ = bootWriter.Close()
 		}
 		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if snapshot != nil {
+		if err := snapshot.wait(ctx); err != nil {
+			cancel()
+			_ = control.Close()
+			_ = listener.Close()
+			vsock.Close()
+			if bootWriter != nil {
+				_ = bootWriter.Close()
+			}
+			return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+		}
 	}
 	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
 		cancel()
@@ -316,12 +359,10 @@ func (s *ManagedSession) waitDone() error {
 	if s == nil || s.doneCh == nil {
 		return nil
 	}
-	err := <-s.doneCh
-	select {
-	case s.doneCh <- err:
-	default:
-	}
-	return err
+	s.waitOnce.Do(func() {
+		s.waitErr = <-s.doneCh
+	})
+	return s.waitErr
 }
 
 func (s *ManagedSession) waitDoneTimeout(timeout time.Duration) error {
@@ -330,12 +371,12 @@ func (s *ManagedSession) waitDoneTimeout(timeout time.Duration) error {
 	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.waitDone()
+	}()
 	select {
-	case err := <-s.doneCh:
-		select {
-		case s.doneCh <- err:
-		default:
-		}
+	case err := <-errCh:
 		return err
 	case <-timer.C:
 		return fmt.Errorf("timed out waiting for managed session to stop")

--- a/internal/hv/whp/snapshot_windows_arm64.go
+++ b/internal/hv/whp/snapshot_windows_arm64.go
@@ -1,0 +1,896 @@
+//go:build windows && arm64
+
+package whp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const (
+	snapshotTriggerMagic        = 0x43535833534e4150
+	snapshotTriggerSerialMarker = "__CCX3_SNAPSHOT__"
+)
+
+type snapshotTrigger struct {
+	base uint64
+	size uint64
+	dir  string
+	mem  []byte
+
+	mu      sync.Mutex
+	pending bool
+	value   uint64
+	once    sync.Once
+	err     error
+	done    chan struct{}
+}
+
+type whpArm64SnapshotManifest struct {
+	Format       string                      `json:"format"`
+	Partial      bool                        `json:"partial"`
+	CapturedAt   string                      `json:"captured_at"`
+	TriggerBase  uint64                      `json:"trigger_base"`
+	TriggerValue uint64                      `json:"trigger_value"`
+	MemoryBase   uint64                      `json:"memory_base"`
+	MemorySize   uint64                      `json:"memory_size"`
+	MemoryFile   string                      `json:"memory_file"`
+	CapturedVCPU int                         `json:"captured_vcpu"`
+	Registers    map[string]snapshotRegister `json:"registers"`
+	States       map[string][]byte           `json:"states,omitempty"`
+	Devices      map[string]virtio.MMIOState `json:"devices,omitempty"`
+	Note         string                      `json:"note"`
+}
+
+type snapshotRegister struct {
+	Low64  uint64 `json:"low64"`
+	High64 uint64 `json:"high64,omitempty"`
+}
+
+func newSnapshotTrigger(dir string, mem []byte) *snapshotTrigger {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	return &snapshotTrigger{
+		base: arm64vm.SnapshotBase,
+		size: arm64vm.SnapshotSize,
+		dir:  dir,
+		mem:  mem,
+		done: make(chan struct{}),
+	}
+}
+
+func newSnapshotResumeTrigger() *snapshotTrigger {
+	return &snapshotTrigger{
+		base: arm64vm.SnapshotBase,
+		size: arm64vm.SnapshotSize,
+	}
+}
+
+func (s *snapshotTrigger) contains(addr uint64, size int) bool {
+	return s != nil && size > 0 && addr >= s.base && addr+uint64(size) <= s.base+s.size
+}
+
+func (s *snapshotTrigger) handleMMIO(vm *VM, mmio MMIOExit) (bool, error) {
+	if !s.contains(mmio.Addr, int(mmio.Len)) {
+		return false, nil
+	}
+	if mmio.Write {
+		return true, vm.CompleteMMIOWrite(mmio)
+	}
+	return true, vm.CompleteMMIORead(mmio, snapshotTriggerMagic)
+}
+
+func (s *snapshotTrigger) markWrite(value uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.pending = true
+	s.value = value
+	s.mu.Unlock()
+}
+
+func (s *snapshotTrigger) takePending() (uint64, bool) {
+	if s == nil {
+		return 0, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.pending {
+		return 0, false
+	}
+	s.pending = false
+	return s.value, true
+}
+
+func (s *snapshotTrigger) wrapSerialWriter(w io.Writer) io.Writer {
+	if s == nil {
+		return w
+	}
+	return &snapshotSerialWriter{dst: w, trigger: s}
+}
+
+type snapshotSerialWriter struct {
+	dst     io.Writer
+	trigger *snapshotTrigger
+	recent  string
+}
+
+func (w *snapshotSerialWriter) Write(data []byte) (int, error) {
+	if w.trigger != nil && len(data) != 0 {
+		w.recent += string(data)
+		if len(w.recent) > len(snapshotTriggerSerialMarker)*2 {
+			w.recent = w.recent[len(w.recent)-len(snapshotTriggerSerialMarker)*2:]
+		}
+		if strings.Contains(w.recent, snapshotTriggerSerialMarker) {
+			w.trigger.markWrite(snapshotTriggerMagic)
+			w.recent = ""
+		}
+	}
+	if w.dst == nil {
+		return len(data), nil
+	}
+	return w.dst.Write(data)
+}
+
+func (s *snapshotTrigger) captureIfPending(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net) error {
+	if s == nil {
+		return nil
+	}
+	value, ok := s.takePending()
+	if !ok {
+		return nil
+	}
+	s.once.Do(func() {
+		s.err = s.capture(vm, fsdevs, vsock, rng, netdev, value)
+		if s.done != nil {
+			close(s.done)
+		}
+	})
+	if s.err != nil {
+		return fmt.Errorf("capture WHP arm64 snapshot: %w", s.err)
+	}
+	return nil
+}
+
+func (s *snapshotTrigger) captureNow(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, value uint64) error {
+	if s == nil || s.dir == "" {
+		return nil
+	}
+	s.once.Do(func() {
+		s.err = s.capture(vm, fsdevs, vsock, rng, netdev, value)
+		if s.done != nil {
+			close(s.done)
+		}
+	})
+	if s.err != nil {
+		return fmt.Errorf("capture WHP arm64 snapshot: %w", s.err)
+	}
+	return nil
+}
+
+func (s *snapshotTrigger) requestHostCapture(vm *VM) error {
+	if s == nil || s.dir == "" {
+		return nil
+	}
+	s.markWrite(snapshotTriggerMagic)
+	return vm.CancelRun()
+}
+
+func (s *snapshotTrigger) wait(ctx context.Context) error {
+	if s == nil || s.dir == "" {
+		return nil
+	}
+	select {
+	case <-s.done:
+		if s.err != nil {
+			return fmt.Errorf("capture WHP arm64 snapshot: %w", s.err)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *snapshotTrigger) fail(err error) {
+	if s == nil || err == nil {
+		return
+	}
+	s.once.Do(func() {
+		s.err = err
+		if s.done != nil {
+			close(s.done)
+		}
+	})
+}
+
+func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, value uint64) error {
+	if s == nil || strings.TrimSpace(s.dir) == "" {
+		return nil
+	}
+	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create snapshot dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
+		return fmt.Errorf("write snapshot memory: %w", err)
+	}
+	states, err := snapshotArm64WHPStates(vm)
+	if err != nil {
+		return fmt.Errorf("capture WHP arm64 vCPU state: %w", err)
+	}
+	manifest := whpArm64SnapshotManifest{
+		Format:       "ccx3-whp-arm64-snapshot-v0",
+		Partial:      true,
+		CapturedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		TriggerBase:  s.base,
+		TriggerValue: value,
+		MemoryBase:   arm64vm.MemoryBase,
+		MemorySize:   uint64(len(s.mem)),
+		MemoryFile:   "memory.bin",
+		CapturedVCPU: 0,
+		Registers:    snapshotArm64WHPRegisters(vm),
+		States:       states,
+		Devices:      snapshotArm64WHPDeviceStates(fsdevs, vsock, rng, netdev),
+		Note:         "WHP arm64 Linux checkpoint captured after guest init configured non-unique state and before vsock ready.",
+	}
+	if len(manifest.Registers) == 0 {
+		return fmt.Errorf("capture WHP arm64 vCPU registers")
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
+		return fmt.Errorf("write snapshot manifest: %w", err)
+	}
+	return nil
+}
+
+func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != ""
+	startTime := time.Now()
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot session +0s: starting restore session\n")
+	}
+	if err := emitManagedBootStatus(onEvent, "restoring VM snapshot"); err != nil {
+		return nil, err
+	}
+	manifest, memPath, err := loadArm64WHPSnapshot(snapshotPath)
+	if err != nil {
+		return nil, err
+	}
+	if memoryMB == 0 {
+		memoryMB = manifest.MemorySize >> 20
+	}
+	backend := virtio.NewSimpleVsockBackend()
+	listener, err := backend.Listen(vmruntime.ControlPort)
+	if err != nil {
+		return nil, fmt.Errorf("listen vsock control: %w", err)
+	}
+	vsock := virtio.NewVsock(arm64vm.VsockBase, arm64vm.VsockSize, arm64vm.VsockIRQ, vmruntime.GuestCID, backend)
+	rng := virtio.NewRNG(arm64vm.RNGBase, arm64vm.RNGSize, arm64vm.RNGIRQ)
+	connCh := make(chan virtio.VsockConn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+
+	var bootWriter *vmruntime.BootEventWriter
+	var serialWriter io.Writer
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = bootWriter
+	}
+	vm, uart, serialOut, err := restoreArm64ManagedVMFromSnapshot(manifest, memPath, memoryMB, dmesg, fsdevs, vsock, rng, netdev, serialWriter)
+	if err != nil {
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error, 1)
+	go func() {
+		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, netdev, serialOut, newSnapshotResumeTrigger(), newWHPPCSampler("linux-restore", nil))
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot session +%s: run loop stopped err=%v\n", time.Since(startTime).Round(time.Millisecond), err)
+		}
+		closeFSDevices(fsdevs)
+		closeStart := time.Now()
+		closeErr := vm.Close()
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot session +%s: vm close took=%s err=%v\n", time.Since(startTime).Round(time.Millisecond), time.Since(closeStart).Round(time.Millisecond), closeErr)
+		}
+		err = errors.Join(err, closeErr)
+		doneCh <- err
+	}()
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot session +%s: run loop started\n", time.Since(startTime).Round(time.Millisecond))
+	}
+
+	var control virtio.VsockConn
+	select {
+	case err := <-acceptErrCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case conn := <-connCh:
+		control = conn
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot session +%s: control connected\n", time.Since(startTime).Round(time.Millisecond))
+		}
+	case err := <-doneCh:
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	case <-ctx.Done():
+		cancel()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(ctx.Err(), serialOut.String(), controlTranscript.String())
+	}
+
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
+	}
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot session +%s: ready marker received\n", time.Since(startTime).Round(time.Millisecond))
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+
+	return &ManagedSession{cancel: cancel, doneCh: doneCh, control: control, listener: listener, vsock: vsock, bootWriter: bootWriter, transcript: controlTranscript, serialOut: serialOut, dmesg: dmesg}, nil
+}
+
+func restoreArm64ManagedVMFromSnapshot(manifest whpArm64SnapshotManifest, memPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net, serialWriter io.Writer) (*VM, *serial.UART8250, *vmruntime.SerialTranscript, error) {
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != ""
+	traceStart := time.Now()
+	traceRestore := func(format string, args ...any) {
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 snapshot restore +%s: %s\n", time.Since(traceStart).Round(time.Millisecond), fmt.Sprintf(format, args...))
+		}
+	}
+	traceRestore("manifest registers=%d states=%s devices=%d", len(manifest.Registers), snapshotArm64StateSummary(manifest.States), len(manifest.Devices))
+	memorySize := arm64vm.MemorySizeBytes(memoryMB)
+	if manifest.MemorySize != 0 && manifest.MemorySize != memorySize {
+		return nil, nil, nil, fmt.Errorf("snapshot memory size %d does not match requested VM memory %d", manifest.MemorySize, memorySize)
+	}
+	mem, err := loadArm64SnapshotMemory(memPath, memorySize)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("load snapshot memory: %w", err)
+	}
+	traceRestore("loaded memory bytes=%d", memorySize)
+	vm, err := newVMWithAllocation(memorySize, arm64vm.MemoryBase, VMOptions{CNTVOverflowInterrupt: linuxWHPCNTVOverflowInterrupt}, mem)
+	if err != nil {
+		_ = mem.free()
+		return nil, nil, nil, err
+	}
+	traceRestore("created VM")
+
+	serialOut := vmruntime.NewSerialTranscript()
+	if serialWriter == nil {
+		serialWriter = serialOut
+	} else {
+		serialWriter = io.MultiWriter(serialOut, serialWriter)
+	}
+	uart := serial.NewUART8250(arm64vm.DefaultUARTBase, arm64vm.DefaultUARTRegShift, serialWriter)
+	uart.AttachIRQ(vm, arm64vm.UARTSPI)
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			fsdev.Async = false
+			fsdev.Attach(vm, vm)
+		}
+	}
+	if vsock != nil {
+		vsock.Attach(vm, vm)
+	}
+	if rng != nil {
+		rng.Attach(vm, vm)
+	}
+	if netdev != nil {
+		netdev.Attach(vm, vm)
+	}
+	if err := restoreArm64WHPDeviceStates(manifest.Devices, fsdevs, vsock, rng, netdev); err != nil {
+		closeFSDevices(fsdevs)
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	traceRestore("restored devices")
+	if err := restoreArm64WHPPreStateRegisters(vm, manifest.Registers); err != nil {
+		closeFSDevices(fsdevs)
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	traceRestore("restored pre-state registers")
+	if err := restoreArm64WHPStates(vm, manifest.States); err != nil {
+		closeFSDevices(fsdevs)
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	traceRestore("restored WHP state")
+	if err := restoreArm64WHPRegisters(vm, manifest.Registers); err != nil {
+		closeFSDevices(fsdevs)
+		_ = vm.Close()
+		return nil, nil, serialOut, err
+	}
+	traceRestore("restored registers pc=%#x pstate=%#x", manifest.Registers["pc"].Low64, manifest.Registers["pstate"].Low64)
+	return vm, uart, serialOut, nil
+}
+
+func loadArm64SnapshotMemory(path string, size uint64) (*allocation, error) {
+	mem, err := virtualAlloc(uintptr(size))
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		_ = mem.free()
+		return nil, err
+	}
+	defer file.Close()
+	if _, err := io.ReadFull(file, mem.bytes()); err != nil {
+		_ = mem.free()
+		return nil, err
+	}
+	return mem, nil
+}
+
+func snapshotArm64StateSummary(states map[string][]byte) string {
+	if len(states) == 0 {
+		return "none"
+	}
+	keys := make([]string, 0, len(states))
+	for key, state := range states {
+		keys = append(keys, fmt.Sprintf("%s:%d", key, len(state)))
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+func loadArm64WHPSnapshot(path string) (whpArm64SnapshotManifest, string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("snapshot path is required")
+	}
+	manifestPath := path
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		manifestPath = filepath.Join(path, "manifest.json")
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("read snapshot manifest: %w", err)
+	}
+	var manifest whpArm64SnapshotManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("decode snapshot manifest: %w", err)
+	}
+	if manifest.Format != "ccx3-whp-arm64-snapshot-v0" {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("unsupported WHP arm64 snapshot format %q", manifest.Format)
+	}
+	memPath := manifest.MemoryFile
+	if !filepath.IsAbs(memPath) {
+		memPath = filepath.Join(filepath.Dir(manifestPath), memPath)
+	}
+	info, err := os.Stat(memPath)
+	if err != nil {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("stat snapshot memory: %w", err)
+	}
+	if info.Size() <= 0 {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("snapshot memory is empty")
+	}
+	if manifest.MemorySize != 0 && uint64(info.Size()) != manifest.MemorySize {
+		return whpArm64SnapshotManifest{}, "", fmt.Errorf("snapshot memory size = %d, want %d", info.Size(), manifest.MemorySize)
+	}
+	return manifest, memPath, nil
+}
+
+func snapshotArm64WHPRegisters(vm *VM) map[string]snapshotRegister {
+	names := whpArm64SnapshotRegisterNames()
+	values := make([]registerValue, len(names))
+	if err := getVirtualProcessorRegisters(vm.part, 0, names, values); err == nil {
+		out := make(map[string]snapshotRegister, len(names))
+		for i, name := range names {
+			out[whpArm64RegisterName(name)] = snapshotRegister{Low64: values[i].raw.Low64, High64: values[i].raw.High64}
+		}
+		return out
+	}
+	out := make(map[string]snapshotRegister, len(names))
+	for _, name := range names {
+		value, ok := snapshotArm64OptionalWHPRegister(vm, name)
+		if !ok {
+			continue
+		}
+		out[whpArm64RegisterName(name)] = value
+	}
+	return out
+}
+
+func snapshotArm64OptionalWHPRegister(vm *VM, name registerName) (snapshotRegister, bool) {
+	values := make([]registerValue, 1)
+	if err := getVirtualProcessorRegisters(vm.part, 0, []registerName{name}, values); err != nil {
+		return snapshotRegister{}, false
+	}
+	return snapshotRegister{Low64: values[0].raw.Low64, High64: values[0].raw.High64}, true
+}
+
+func restoreArm64WHPPreStateRegisters(vm *VM, regs map[string]snapshotRegister) error {
+	if len(regs) == 0 {
+		return fmt.Errorf("snapshot contains no WHP arm64 vCPU registers")
+	}
+	return restoreArm64WHPRegisterSet(vm, regs, whpArm64SnapshotPreStateRegisterNames())
+}
+
+func restoreArm64WHPRegisters(vm *VM, regs map[string]snapshotRegister) error {
+	if len(regs) == 0 {
+		return fmt.Errorf("snapshot contains no WHP arm64 vCPU registers")
+	}
+	if err := restoreArm64WHPRegisterSet(vm, regs, whpArm64SnapshotRegisterRestoreNames()); err != nil {
+		return err
+	}
+	return verifyRestoredArm64WHPRegisters(vm, regs)
+}
+
+func restoreArm64WHPRegisterSet(vm *VM, regs map[string]snapshotRegister, names []registerName) error {
+	setNames := make([]registerName, 0, len(names))
+	values := make([]registerValue, 0, len(names))
+	for _, name := range names {
+		state, ok := regs[whpArm64RegisterName(name)]
+		if !ok {
+			continue
+		}
+		setNames = append(setNames, name)
+		values = append(values, registerValue{raw: uint128{Low64: state.Low64, High64: state.High64}})
+	}
+	if len(setNames) == 0 {
+		return nil
+	}
+	if err := setVirtualProcessorRegisters(vm.part, 0, setNames, values); err != nil {
+		return fmt.Errorf("restore WHP arm64 registers: %w", err)
+	}
+	return nil
+}
+
+func snapshotArm64WHPStates(vm *VM) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(whpArm64SnapshotStateTypes()))
+	for _, spec := range whpArm64SnapshotStateTypes() {
+		state, err := getVirtualProcessorState(vm.part, spec.vpIndex, spec.stateType)
+		if err != nil {
+			if spec.required {
+				return nil, fmt.Errorf("%s: %w", spec.key, err)
+			}
+			continue
+		}
+		out[spec.key] = state
+	}
+	return out, nil
+}
+
+func restoreArm64WHPStates(vm *VM, states map[string][]byte) error {
+	for _, spec := range whpArm64SnapshotStateTypes() {
+		state, ok := states[spec.key]
+		if !ok {
+			if spec.required {
+				return fmt.Errorf("snapshot missing WHP arm64 state %q", spec.key)
+			}
+			continue
+		}
+		if err := setVirtualProcessorState(vm.part, spec.vpIndex, spec.stateType, state); err != nil {
+			return fmt.Errorf("restore WHP arm64 state %s: %w", spec.key, err)
+		}
+	}
+	return nil
+}
+
+type whpArm64SnapshotStateType struct {
+	key       string
+	stateType virtualProcessorStateType
+	vpIndex   uint32
+	required  bool
+}
+
+func whpArm64SnapshotStateTypes() []whpArm64SnapshotStateType {
+	return []whpArm64SnapshotStateType{
+		{key: "interrupt_controller", stateType: virtualProcessorStateTypeArm64InterruptControllerState, vpIndex: 0, required: true},
+		{key: "global_interrupt_controller", stateType: virtualProcessorStateTypeArm64GlobalInterruptState, vpIndex: 0xffffffff, required: false},
+	}
+}
+
+func verifyRestoredArm64WHPRegisters(vm *VM, regs map[string]snapshotRegister) error {
+	for _, name := range []registerName{registerPC, registerPSTATE, registerSPEL1, registerSCTLREL1, registerTTBR0EL1, registerTTBR1EL1, registerTCREL1} {
+		key := whpArm64RegisterName(name)
+		want, ok := regs[key]
+		if !ok {
+			continue
+		}
+		got, ok := snapshotArm64OptionalWHPRegister(vm, name)
+		if !ok {
+			return fmt.Errorf("read restored WHP arm64 register %s", key)
+		}
+		if got.Low64 != want.Low64 || got.High64 != want.High64 {
+			return fmt.Errorf("restore WHP arm64 register %s = %#x:%#x, want %#x:%#x", key, got.High64, got.Low64, want.High64, want.Low64)
+		}
+	}
+	return nil
+}
+
+func whpArm64SnapshotRegisterNames() []registerName {
+	names := make([]registerName, 0, 96)
+	for i := 0; i <= 30; i++ {
+		names = append(names, registerX(i))
+	}
+	for i := 0; i <= 31; i++ {
+		names = append(names, registerName(uint32(registerQ0)+uint32(i)))
+	}
+	names = append(names,
+		registerSP, registerSPEL0, registerSPEL1, registerPC, registerPSTATE,
+		registerCurrentEL, registerDAIF, registerDIT, registerNZCV, registerPAN,
+		registerSPSEL, registerSSBS, registerTCO, registerUAO,
+		registerELREL1, registerSPSREL1, registerFPCR, registerFPSR,
+		registerACTLREL1, registerCPACREL1, registerCSSELREL1,
+		registerESREL1, registerFAREL1, registerMAIREL1, registerPAREL1,
+		registerSCTLREL1, registerTCREL1,
+		registerTPIDREL0, registerTPIDREL1, registerTPIDRROEL0,
+		registerTTBR0EL1, registerTTBR1EL1, registerVBAREL1,
+		registerCNTKCTLEL1, registerCNTVCTLEL0, registerCNTVCVALEL0, registerCNTVCTEL0,
+		registerGICR,
+		registerInternalActivityState, registerPendingEvent0, registerPendingEvent1,
+		registerDeliverabilityNotification, registerPendingEvent2, registerPendingEvent3,
+	)
+	return names
+}
+
+func whpArm64SnapshotPreStateRegisterNames() []registerName {
+	return []registerName{
+		registerPSTATE, registerCurrentEL, registerDAIF, registerPAN, registerSPSEL,
+		registerSCTLREL1, registerTCREL1, registerMAIREL1,
+		registerTTBR0EL1, registerTTBR1EL1, registerVBAREL1,
+		registerCNTKCTLEL1, registerCNTVCTLEL0, registerCNTVCVALEL0,
+		registerGICR,
+		registerInternalActivityState, registerPendingEvent0, registerPendingEvent1,
+		registerDeliverabilityNotification, registerPendingEvent2, registerPendingEvent3,
+	}
+}
+
+func whpArm64SnapshotRegisterRestoreNames() []registerName {
+	names := make([]registerName, 0, len(whpArm64SnapshotRegisterNames()))
+	for _, name := range whpArm64SnapshotRegisterNames() {
+		switch name {
+		case registerCNTVCTEL0:
+			continue
+		default:
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func whpArm64RegisterName(name registerName) string {
+	if name >= registerX0 && name <= registerLR {
+		switch name {
+		case registerFP:
+			return "fp"
+		case registerLR:
+			return "lr"
+		default:
+			return "x" + strconv.FormatUint(uint64(name-registerX0), 10)
+		}
+	}
+	if name >= registerQ0 && name <= registerQ0+31 {
+		return "q" + strconv.FormatUint(uint64(name-registerQ0), 10)
+	}
+	switch name {
+	case registerSP:
+		return "sp"
+	case registerSPEL0:
+		return "sp_el0"
+	case registerSPEL1:
+		return "sp_el1"
+	case registerPC:
+		return "pc"
+	case registerPSTATE:
+		return "pstate"
+	case registerCurrentEL:
+		return "current_el"
+	case registerDAIF:
+		return "daif"
+	case registerDIT:
+		return "dit"
+	case registerNZCV:
+		return "nzcv"
+	case registerPAN:
+		return "pan"
+	case registerSPSEL:
+		return "spsel"
+	case registerSSBS:
+		return "ssbs"
+	case registerTCO:
+		return "tco"
+	case registerUAO:
+		return "uao"
+	case registerELREL1:
+		return "elr_el1"
+	case registerSPSREL1:
+		return "spsr_el1"
+	case registerFPCR:
+		return "fpcr"
+	case registerFPSR:
+		return "fpsr"
+	case registerACTLREL1:
+		return "actlr_el1"
+	case registerCPACREL1:
+		return "cpacr_el1"
+	case registerCSSELREL1:
+		return "csselr_el1"
+	case registerESREL1:
+		return "esr_el1"
+	case registerFAREL1:
+		return "far_el1"
+	case registerMAIREL1:
+		return "mair_el1"
+	case registerPAREL1:
+		return "par_el1"
+	case registerSCTLREL1:
+		return "sctlr_el1"
+	case registerTCREL1:
+		return "tcr_el1"
+	case registerTPIDREL0:
+		return "tpidr_el0"
+	case registerTPIDREL1:
+		return "tpidr_el1"
+	case registerTPIDRROEL0:
+		return "tpidrro_el0"
+	case registerTTBR0EL1:
+		return "ttbr0_el1"
+	case registerTTBR1EL1:
+		return "ttbr1_el1"
+	case registerVBAREL1:
+		return "vbar_el1"
+	case registerCNTKCTLEL1:
+		return "cntkctl_el1"
+	case registerCNTVCTLEL0:
+		return "cntv_ctl_el0"
+	case registerCNTVCVALEL0:
+		return "cntv_cval_el0"
+	case registerCNTVCTEL0:
+		return "cntvct_el0"
+	case registerGICR:
+		return "gicr_base_gpa"
+	case registerInternalActivityState:
+		return "internal_activity_state"
+	case registerPendingEvent0:
+		return "pending_event0"
+	case registerPendingEvent1:
+		return "pending_event1"
+	case registerDeliverabilityNotification:
+		return "deliverability_notifications"
+	case registerPendingEvent2:
+		return "pending_event2"
+	case registerPendingEvent3:
+		return "pending_event3"
+	default:
+		return "reg_" + strconv.FormatUint(uint64(name), 16)
+	}
+}
+
+func snapshotArm64WHPDeviceStates(fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net) map[string]virtio.MMIOState {
+	out := make(map[string]virtio.MMIOState)
+	if rng != nil {
+		out["rng"] = rng.SnapshotState()
+	}
+	if vsock != nil {
+		out["vsock"] = vsock.SnapshotState()
+	}
+	if netdev != nil {
+		out["net"] = netdev.SnapshotState()
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		out[whpArm64FSDeviceStateKey(fsdev)] = fsdev.SnapshotState()
+	}
+	return out
+}
+
+func restoreArm64WHPDeviceStates(states map[string]virtio.MMIOState, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, netdev *virtio.Net) error {
+	if state, ok := states["rng"]; ok && rng != nil {
+		if err := rng.RestoreState(state); err != nil {
+			return fmt.Errorf("restore rng state: %w", err)
+		}
+	}
+	if state, ok := states["vsock"]; ok && vsock != nil {
+		if err := vsock.RestoreState(state); err != nil {
+			return fmt.Errorf("restore vsock state: %w", err)
+		}
+	}
+	if state, ok := states["net"]; ok && netdev != nil {
+		if err := netdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore net state: %w", err)
+		}
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		key := whpArm64FSDeviceStateKey(fsdev)
+		state, ok := states[key]
+		if !ok {
+			return fmt.Errorf("snapshot missing state for fs device %#x", fsdev.Base)
+		}
+		if err := fsdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore fs device %#x state: %w", fsdev.Base, err)
+		}
+	}
+	return nil
+}
+
+func whpArm64FSDeviceStateKey(fsdev *virtio.FS) string {
+	return fmt.Sprintf("fs:%x", fsdev.Base)
+}

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync/atomic"
-	"time"
 	"unsafe"
 )
 
@@ -166,7 +165,6 @@ func (v *VM) Close() error {
 			first = err
 		}
 		v.part = 0
-		time.Sleep(3 * time.Second)
 	}
 	return first
 }

--- a/internal/hv/whp/vm_windows_arm64.go
+++ b/internal/hv/whp/vm_windows_arm64.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"time"
 	"unsafe"
 
@@ -87,19 +88,37 @@ func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
 }
 
 func NewVMWithOptions(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM, error) {
+	return newVMWithAllocation(memorySize, memoryBase, opts, nil)
+}
+
+func newVMWithAllocation(memorySize uint64, memoryBase uint64, opts VMOptions, mem *allocation) (*VM, error) {
 	if memorySize == 0 {
 		return nil, fmt.Errorf("memory size must be non-zero")
 	}
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != ""
+	createStart := time.Now()
+	traceStep := func(name string, start time.Time, err error) {
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 vm create +%s: %s took=%s err=%v\n", time.Since(createStart).Round(time.Millisecond), name, time.Since(start).Round(time.Millisecond), err)
+		}
+	}
+	stepStart := time.Now()
 	part, err := createPartition()
+	traceStep("create partition", stepStart, err)
 	if err != nil {
 		return nil, fmt.Errorf("create partition: %w", err)
 	}
 	vm := &VM{part: part, memGPA: memoryBase}
+	stepStart = time.Now()
 	if err := setPartitionProperty(part, partitionPropertyCodeProcessorCount, uint32(1)); err != nil {
+		traceStep("set processor count", stepStart, err)
 		_ = vm.Close()
 		return nil, fmt.Errorf("set processor count: %w", err)
 	}
+	traceStep("set processor count", stepStart, nil)
+	stepStart = time.Now()
 	opts, err = normalizeVMOptions(opts)
+	traceStep("normalize options", stepStart, err)
 	if err != nil {
 		_ = vm.Close()
 		return nil, err
@@ -114,35 +133,65 @@ func NewVMWithOptions(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM
 			GICPPIPerformanceMonitors: defaultPMUInterrupt,
 		},
 	}
+	stepStart = time.Now()
 	if err := setPartitionProperty(part, partitionPropertyCodeArm64ICParameters, ic); err != nil {
+		traceStep("set interrupt controller parameters", stepStart, err)
 		_ = vm.Close()
 		return nil, fmt.Errorf("set arm64 interrupt controller parameters: %w", err)
 	}
+	traceStep("set interrupt controller parameters", stepStart, nil)
+	stepStart = time.Now()
 	if err := setupPartition(part); err != nil {
+		traceStep("setup partition", stepStart, err)
 		_ = vm.Close()
 		return nil, fmt.Errorf("setup partition: %w", err)
 	}
-	mem, err := virtualAlloc(uintptr(memorySize))
-	if err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("allocate guest memory: %w", err)
+	traceStep("setup partition", stepStart, nil)
+	blankMemory := mem == nil
+	if mem == nil {
+		var err error
+		stepStart = time.Now()
+		mem, err = virtualAlloc(uintptr(memorySize))
+		traceStep("allocate guest memory", stepStart, err)
+		if err != nil {
+			_ = vm.Close()
+			return nil, fmt.Errorf("allocate guest memory: %w", err)
+		}
 	}
 	vm.mem = mem
 	vm.memSize = memorySize
-	vm.preTouchGuestMemory()
+	if blankMemory {
+		stepStart = time.Now()
+		vm.preTouchGuestMemory()
+		traceStep("pre-touch guest memory", stepStart, nil)
+	}
+	stepStart = time.Now()
 	if err := mapGPARange(part, unsafe.Pointer(mem.addr), memoryBase, memorySize, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
+		traceStep("map guest memory", stepStart, err)
 		_ = vm.Close()
 		return nil, fmt.Errorf("map guest memory: %w", err)
 	}
+	traceStep("map guest memory", stepStart, nil)
+	stepStart = time.Now()
 	vm.populateGuestMemory()
+	traceStep("populate guest memory", stepStart, nil)
+	stepStart = time.Now()
 	if err := createVirtualProcessor(part, 0); err != nil {
+		traceStep("create virtual processor", stepStart, err)
 		_ = vm.Close()
 		return nil, fmt.Errorf("create virtual processor: %w", err)
 	}
+	traceStep("create virtual processor", stepStart, nil)
 	vm.vcpuCreated = true
+	stepStart = time.Now()
 	if err := vm.setRegister(registerGICR, arm64vm.GICRedistributorMin); err != nil {
+		traceStep("set gic redistributor base", stepStart, err)
 		_ = vm.Close()
 		return nil, fmt.Errorf("set gic redistributor base: %w", err)
+	}
+	traceStep("set gic redistributor base", stepStart, nil)
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 vm create +%s: total\n", time.Since(createStart).Round(time.Millisecond))
 	}
 	return vm, nil
 }
@@ -188,31 +237,52 @@ func (v *VM) Close() error {
 	if v == nil {
 		return nil
 	}
+	trace := os.Getenv("CC_WHP_ARM64_TIMING") != ""
+	closeStart := time.Now()
+	traceStep := func(name string, start time.Time, err error) {
+		if trace {
+			_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 vm close +%s: %s took=%s err=%v\n", time.Since(closeStart).Round(time.Millisecond), name, time.Since(start).Round(time.Millisecond), err)
+		}
+	}
 	var first error
 	if v.part != 0 && v.vcpuCreated {
+		stepStart := time.Now()
 		_ = cancelRunVirtualProcessor(v.part, 0)
-		if err := deleteVirtualProcessor(v.part, 0); err != nil && first == nil {
+		err := deleteVirtualProcessor(v.part, 0)
+		traceStep("delete virtual processor", stepStart, err)
+		if err != nil && first == nil {
 			first = err
 		}
 		v.vcpuCreated = false
 	}
 	if v.part != 0 && v.mem != nil {
-		if err := unmapGPARange(v.part, v.memGPA, v.memSize); err != nil && first == nil {
+		stepStart := time.Now()
+		err := unmapGPARange(v.part, v.memGPA, v.memSize)
+		traceStep("unmap guest memory", stepStart, err)
+		if err != nil && first == nil {
 			first = err
 		}
 	}
 	if v.mem != nil {
-		if err := v.mem.free(); err != nil && first == nil {
+		stepStart := time.Now()
+		err := v.mem.free()
+		traceStep("free guest memory", stepStart, err)
+		if err != nil && first == nil {
 			first = err
 		}
 		v.mem = nil
 	}
 	if v.part != 0 {
-		if err := deletePartition(v.part); err != nil && first == nil {
+		stepStart := time.Now()
+		err := deletePartition(v.part)
+		traceStep("delete partition", stepStart, err)
+		if err != nil && first == nil {
 			first = err
 		}
 		v.part = 0
-		time.Sleep(3 * time.Second)
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 vm close +%s: total err=%v\n", time.Since(closeStart).Round(time.Millisecond), first)
 	}
 	return first
 }

--- a/internal/vm/backend_windows_arm64.go
+++ b/internal/vm/backend_windows_arm64.go
@@ -68,13 +68,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if req.CPUs > 1 {
 		return nil, fmt.Errorf("windows arm64 runtime currently supports only 1 CPU")
 	}
-	kernel, err := b.kernel.ReadKernel()
-	if err != nil {
-		return nil, err
-	}
-	if trace {
-		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: kernel read bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(kernel))
-	}
+	restoreSnapshot := strings.TrimSpace(req.RestoreSnapshot)
 	image, err := b.images.Open(req.Image)
 	if err != nil {
 		return nil, err
@@ -86,13 +80,6 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		return nil, err
 	}
 	image = withWindowsRuntimeMountDirs(image)
-	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(image), windowsRuntimeModuleMap())
-	if err != nil {
-		return nil, err
-	}
-	if trace {
-		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: planned modules=%d\n", time.Since(startTime).Round(time.Millisecond), len(modules))
-	}
 	qemuX8664, err := PrepareAMD64Emulator(ctx, image, b.kernel.ExtractPackageFile)
 	if err != nil {
 		return nil, err
@@ -122,6 +109,41 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if trace {
 		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: fs devices built=%d\n", time.Since(startTime).Round(time.Millisecond), len(fsdevs))
 	}
+	workDir := image.Config.WorkingDir
+	if workDir == "" {
+		workDir = "/"
+	}
+	if restoreSnapshot != "" {
+		started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+			Profile: managedguest.LinuxProfile,
+			Host:    whp.Host{},
+			Spec:    windowsLinuxMachineSpec(req.MemoryMB, req.CPUs, req.Dmesg),
+			Attachments: whp.LinuxManagedAttachments{
+				FSDevices:       fsdevs,
+				NetDevice:       windowsNetworkDevice(network),
+				SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+				RestoreSnapshot: restoreSnapshot,
+			},
+		}, onEvent)
+		if err != nil {
+			return nil, err
+		}
+		return &windowsInstance{
+			managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(image.Config.Env), workDir),
+			image:               image,
+			rootFS:              rootFS,
+			fsdevs:              fsdevs,
+			network:             network,
+			dmesg:               req.Dmesg,
+		}, nil
+	}
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(image), windowsRuntimeModuleMap())
+	if err != nil {
+		return nil, err
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: planned modules=%d\n", time.Since(startTime).Round(time.Millisecond), len(modules))
+	}
 	initBin, err := guestinit.BuildForArch(ctx, b.guestInitCache, "arm64")
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
@@ -129,9 +151,12 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if trace {
 		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: guest init bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(initBin))
 	}
-	workDir := image.Config.WorkingDir
-	if workDir == "" {
-		workDir = "/"
+	kernel, err := b.kernel.ReadKernel()
+	if err != nil {
+		return nil, err
+	}
+	if trace {
+		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: kernel read bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(kernel))
 	}
 	initCfg := windowsGuestInitConfig(modules, true)
 	initCfg.RootFSTag = vmruntime.RootFSTag
@@ -141,6 +166,9 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
 	initCfg.WorkDir = workDir
 	initCfg.Network = windowsNetworkGuestInitConfig(network)
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = arm64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
@@ -157,8 +185,10 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 			Initrd: initrd,
 		},
 		Attachments: whp.LinuxManagedAttachments{
-			FSDevices: fsdevs,
-			NetDevice: windowsNetworkDevice(network),
+			FSDevices:       fsdevs,
+			NetDevice:       windowsNetworkDevice(network),
+			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
 	}, onEvent)
 	if err != nil {
@@ -180,29 +210,23 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
 	if strings.TrimSpace(req.Image) != "" {
 		return b.StartStream(ctx, client.CreateInstanceRequest{
-			ID:             req.ID,
-			Image:          req.Image,
-			InitSystem:     req.InitSystem,
-			Kernel:         req.Kernel,
-			Network:        req.Network,
-			KernelModules:  append([]string(nil), req.KernelModules...),
-			MemoryMB:       req.MemoryMB,
-			CPUs:           req.CPUs,
-			NestedVirt:     req.NestedVirt,
-			Dmesg:          req.Dmesg,
-			TimeoutSeconds: req.TimeoutSeconds,
+			ID:              req.ID,
+			Image:           req.Image,
+			InitSystem:      req.InitSystem,
+			Kernel:          req.Kernel,
+			Network:         req.Network,
+			KernelModules:   append([]string(nil), req.KernelModules...),
+			MemoryMB:        req.MemoryMB,
+			CPUs:            req.CPUs,
+			NestedVirt:      req.NestedVirt,
+			Dmesg:           req.Dmesg,
+			SnapshotDir:     req.SnapshotDir,
+			RestoreSnapshot: req.RestoreSnapshot,
+			TimeoutSeconds:  req.TimeoutSeconds,
 		}, onEvent)
 	}
 	if b == nil || b.kernel == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
-	}
-	kernel, err := b.kernel.ReadKernel()
-	if err != nil {
-		return nil, err
-	}
-	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(nil), windowsRuntimeModuleMap())
-	if err != nil {
-		return nil, err
 	}
 	network, err := newWindowsARM64NetworkRuntime(req.Network)
 	if err != nil {
@@ -210,6 +234,38 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	rootFSBackend := virtio.NewImageFS(blankWindowsRuntimeRootFS(), "")
 	fsdevs, rootFS, err := arm64vm.BuildFSDevices(vmruntime.RunRequest{RootFS: rootFSBackend}, nil)
+	if err != nil {
+		return nil, err
+	}
+	restoreSnapshot := strings.TrimSpace(req.RestoreSnapshot)
+	if restoreSnapshot != "" {
+		started, err := (managedruntime.Service{}).Start(ctx, managedruntime.StartRequest{
+			Profile: managedguest.LinuxProfile,
+			Host:    whp.Host{},
+			Spec:    windowsLinuxMachineSpec(req.MemoryMB, req.CPUs, req.Dmesg),
+			Attachments: whp.LinuxManagedAttachments{
+				FSDevices:       fsdevs,
+				NetDevice:       windowsNetworkDevice(network),
+				SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+				RestoreSnapshot: restoreSnapshot,
+			},
+		}, onEvent)
+		if err != nil {
+			return nil, err
+		}
+		return &windowsInstance{
+			managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(nil), "/"),
+			rootFS:              rootFS,
+			fsdevs:              fsdevs,
+			network:             network,
+			dmesg:               req.Dmesg,
+		}, nil
+	}
+	kernel, err := b.kernel.ReadKernel()
+	if err != nil {
+		return nil, err
+	}
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(nil), windowsRuntimeModuleMap())
 	if err != nil {
 		return nil, err
 	}
@@ -222,6 +278,9 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	initCfg.Env = vmruntime.WithDefaultEnv(nil)
 	initCfg.WorkDir = "/"
 	initCfg.Network = windowsNetworkGuestInitConfig(network)
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = arm64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
@@ -235,8 +294,10 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Initrd: initrd,
 		},
 		Attachments: whp.LinuxManagedAttachments{
-			FSDevices: fsdevs,
-			NetDevice: windowsNetworkDevice(network),
+			FSDevices:       fsdevs,
+			NetDevice:       windowsNetworkDevice(network),
+			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
+			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
 	}, onEvent)
 	if err != nil {

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -356,6 +356,48 @@ func TestRuntimeBootsPersistentLinuxAndExecsCommands(t *testing.T) {
 	requireGuestOutput(t, second.Output, "42", "persisted")
 }
 
+func TestRuntimeRestoresLinuxFromStartupSnapshotOnWindowsARM64(t *testing.T) {
+	if runtime.GOOS != "windows" || runtime.GOARCH != "arm64" {
+		t.Skip("Windows arm64 WHP startup snapshots are host-specific")
+	}
+	env := newRuntimeBootEnv(t)
+	snapshotRoot := t.TempDir()
+	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{
+		SnapshotDir: snapshotRoot,
+	})
+	if err := inst.Close(); err != nil {
+		t.Fatalf("close snapshot capture instance: %v", err)
+	}
+	snapshotPath := requireSingleStartupSnapshot(t, snapshotRoot)
+	restored := startRuntimeInstance(t, env, client.CreateInstanceRequest{
+		RestoreSnapshot: snapshotPath,
+	})
+	t.Cleanup(func() { _ = restored.Close() })
+	resp := execInRuntime(t, restored, []string{"sh", "-lc", "printf 'snapshot-restored:'; uname -m"})
+	requireGuestOutput(t, resp.Output, "snapshot-restored:")
+}
+
+func requireSingleStartupSnapshot(t *testing.T, root string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "snapshot-*"))
+	if err != nil {
+		t.Fatalf("glob startup snapshots: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("snapshot count = %d, want 1 under %s", len(matches), root)
+	}
+	for _, name := range []string{"manifest.json", "memory.bin"} {
+		info, err := os.Stat(filepath.Join(matches[0], name))
+		if err != nil {
+			t.Fatalf("stat snapshot %s: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("snapshot %s is empty", name)
+		}
+	}
+	return matches[0]
+}
+
 func TestRuntimePersistentLinuxStreamsStdin(t *testing.T) {
 	env := newRuntimeBootEnv(t)
 	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{})


### PR DESCRIPTION
## Summary

Adds startup snapshot capture and restore support for Linux guests on Windows arm64 WHP.

This includes:

- WHP arm64 snapshot manifest, memory, register, device, and interrupt-controller state capture/restore.
- Guest-init snapshot trigger wiring for Windows arm64 Linux startup snapshots.
- Restore-side backend fast path that avoids rebuilding unused cold-boot inputs.
- WHP arm64 VM creation support for preloaded snapshot memory.
- Removal of the fixed 3 second WHP close sleep, replacing it with normal teardown.
- Timing hooks under `CC_WHP_ARM64_TIMING` for startup/restore diagnosis.

## Root Cause / Notes

The slow path was not kernel boot alone. On Windows arm64 WHP, lazily faulting file-backed guest memory during restore is much slower than copying snapshot memory into private memory and explicitly populating the GPA range before running the VP. Teardown was also artificially delayed by a fixed sleep; the remaining teardown cost is primarily WHP GPA unmap/free work.

## Validation

- `git diff --check`
- `powershell.exe ... go test ./internal/hv/whp ./internal/vm -count=1 -timeout 10m` initially failed because guest-init payloads were not embedded in that build mode.
- Generated guest-init payloads using the repository CI build commands.
- `powershell.exe ... go test -tags embed_guestinit ./internal/hv/whp ./internal/vm -count=1 -timeout 10m`
- `powershell.exe ... go test -tags embed_guestinit ./... -count=1 -timeout 40m`