### PR TITLE
[codex] add arm64 memory benchmarks

### DIFF
--- a/internal/hv/memory_benchmark_mmap_test.go
+++ b/internal/hv/memory_benchmark_mmap_test.go
@@ -1,0 +1,6 @@
+package hv
+
+type benchmarkGuestMapping interface {
+	Bytes() []byte
+	Close() error
+}

--- a/internal/hv/memory_benchmark_mmap_unix_test.go
+++ b/internal/hv/memory_benchmark_mmap_unix_test.go
@@ -1,0 +1,37 @@
+//go:build arm64 && (darwin || linux)
+
+package hv
+
+import (
+	"os"
+	"syscall"
+)
+
+type unixBenchmarkGuestMapping struct {
+	data []byte
+}
+
+func mapBenchmarkGuestFile(path string, size int) (benchmarkGuestMapping, error) {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := syscall.Mmap(int(file.Fd()), 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE)
+	if err != nil {
+		return nil, err
+	}
+	return unixBenchmarkGuestMapping{data: data}, nil
+}
+
+func (m unixBenchmarkGuestMapping) Bytes() []byte {
+	return m.data
+}
+
+func (m unixBenchmarkGuestMapping) Close() error {
+	if len(m.data) == 0 {
+		return nil
+	}
+	return syscall.Munmap(m.data)
+}

--- a/internal/hv/memory_benchmark_mmap_unsupported_test.go
+++ b/internal/hv/memory_benchmark_mmap_unsupported_test.go
@@ -1,0 +1,7 @@
+//go:build !(arm64 && (darwin || linux || windows))
+
+package hv
+
+func mapBenchmarkGuestFile(path string, size int) (benchmarkGuestMapping, error) {
+	return nil, errMemoryBenchmarkUnsupported
+}

--- a/internal/hv/memory_benchmark_mmap_windows_test.go
+++ b/internal/hv/memory_benchmark_mmap_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows && arm64
+
+package hv
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsBenchmarkGuestMapping struct {
+	addr    uintptr
+	size    int
+	mapping windows.Handle
+}
+
+func mapBenchmarkGuestFile(path string, size int) (benchmarkGuestMapping, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ|windows.GENERIC_WRITE|windows.GENERIC_EXECUTE,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(file)
+
+	mapping, err := windows.CreateFileMapping(file, nil, windows.PAGE_EXECUTE_WRITECOPY, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_COPY|windows.FILE_MAP_EXECUTE, 0, 0, uintptr(size))
+	if err != nil {
+		_ = windows.CloseHandle(mapping)
+		return nil, err
+	}
+	return windowsBenchmarkGuestMapping{addr: addr, size: size, mapping: mapping}, nil
+}
+
+func (m windowsBenchmarkGuestMapping) Bytes() []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(m.addr)), m.size)
+}
+
+func (m windowsBenchmarkGuestMapping) Close() error {
+	var first error
+	if m.addr != 0 {
+		if err := windows.UnmapViewOfFile(m.addr); err != nil && first == nil {
+			first = err
+		}
+	}
+	if m.mapping != 0 {
+		if err := windows.CloseHandle(m.mapping); err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
+}

--- a/internal/hv/memory_benchmark_test.go
+++ b/internal/hv/memory_benchmark_test.go
@@ -1,0 +1,367 @@
+package hv
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	memoryBenchmarkDataOff        = 0x10000
+	readMemoryBenchmarkSize       = 512 << 20
+	writeMemoryBenchmarkSize      = 64 << 20
+	writeMemoryBenchmarkHashOff   = memoryBenchmarkDataOff + writeMemoryBenchmarkSize
+	writeMemoryBenchmarkGuestSize = writeMemoryBenchmarkHashOff + 0x10000
+	memoryBenchmarkSeed           = 0xcbf29ce484222325
+)
+
+func BenchmarkArm64VMReadMemory(b *testing.B) {
+	dataSize := readMemoryBenchmarkSize - memoryBenchmarkDataOff - 0x10000
+	hashOff := memoryBenchmarkDataOff + dataSize
+	code := buildReadMemoryHashCode(
+		memoryBenchmarkBase+memoryBenchmarkDataOff,
+		dataSize,
+		memoryBenchmarkBase+uint64(hashOff),
+		memoryBenchmarkExitAddr,
+	)
+	image := make([]byte, readMemoryBenchmarkSize)
+	copy(image, code)
+	fillBenchmarkData(image[memoryBenchmarkDataOff:hashOff])
+	want := guestReadHash(image[memoryBenchmarkDataOff:hashOff])
+	tempDir := b.TempDir()
+	path := filepath.Join(tempDir, "guest-memory.bin")
+	if err := os.WriteFile(path, image, 0o600); err != nil {
+		b.Fatal(err)
+	}
+	image = nil
+	runtime.GC()
+
+	b.SetBytes(int64(dataSize))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mapping, err := mapBenchmarkGuestFile(path, readMemoryBenchmarkSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		vm := newMappedBenchmarkVM(b, mapping.Bytes())
+		if err := vm.RunUntilExit(); err != nil {
+			_ = vm.Close()
+			_ = mapping.Close()
+			b.Fatal(err)
+		}
+		got := binary.LittleEndian.Uint64(vm.memory[hashOff:])
+		if got != want {
+			_ = vm.Close()
+			_ = mapping.Close()
+			b.Fatalf("guest hash = %#x, want %#x", got, want)
+		}
+		if err := vm.Close(); err != nil {
+			_ = mapping.Close()
+			b.Fatal(err)
+		}
+		if err := mapping.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkArm64VMWriteMemory(b *testing.B) {
+	code := buildWriteMemoryRandomCode(
+		memoryBenchmarkBase+memoryBenchmarkDataOff,
+		writeMemoryBenchmarkSize,
+		memoryBenchmarkExitAddr,
+	)
+	want := guestHashWords(makeGuestRandomBytes(writeMemoryBenchmarkSize))
+
+	b.SetBytes(writeMemoryBenchmarkSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vm := newBenchmarkMicroVM(b, code)
+		if err := vm.RunUntilExit(); err != nil {
+			_ = vm.Close()
+			b.Fatal(err)
+		}
+		got := guestHashWords(vm.memory[memoryBenchmarkDataOff : memoryBenchmarkDataOff+writeMemoryBenchmarkSize])
+		if got != want {
+			_ = vm.Close()
+			b.Fatalf("host hash = %#x, want %#x", got, want)
+		}
+		if err := vm.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func newBenchmarkMicroVM(b *testing.B, code []byte) *memoryBenchmarkVM {
+	b.Helper()
+	vm, err := newAnonymousMemoryBenchmarkVM(writeMemoryBenchmarkGuestSize)
+	if errors.Is(err, errMemoryBenchmarkUnsupported) {
+		b.Skip(err)
+	}
+	if err != nil {
+		b.Fatal(err)
+	}
+	copy(vm.memory, code)
+	if err := vm.SetEntry(memoryBenchmarkBase, memoryBenchmarkBase+writeMemoryBenchmarkGuestSize); err != nil {
+		_ = vm.Close()
+		b.Fatal(err)
+	}
+	return vm
+}
+
+func newMappedBenchmarkVM(b *testing.B, mem []byte) *memoryBenchmarkVM {
+	b.Helper()
+	vm, err := newMappedMemoryBenchmarkVM(mem)
+	if errors.Is(err, errMemoryBenchmarkUnsupported) {
+		b.Skip(err)
+	}
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := vm.SetEntry(memoryBenchmarkBase, memoryBenchmarkBase+uint64(len(mem))); err != nil {
+		_ = vm.Close()
+		b.Fatal(err)
+	}
+	return vm
+}
+
+func fillBenchmarkData(data []byte) {
+	var x uint64 = memoryBenchmarkSeed
+	for off := 0; off < len(data); off += 8 {
+		x = xorshift64(x)
+		binary.LittleEndian.PutUint64(data[off:], x^uint64(off)*0x9e3779b185ebca87)
+	}
+}
+
+func makeGuestRandomBytes(size int) []byte {
+	data := make([]byte, size)
+	var x uint64 = memoryBenchmarkSeed
+	for off := 0; off < len(data); off += 8 {
+		x = xorshift64(x)
+		binary.LittleEndian.PutUint64(data[off:], x)
+	}
+	return data
+}
+
+func guestHashWords(data []byte) uint64 {
+	h := uint64(memoryBenchmarkSeed)
+	for off := 0; off < len(data); off += 8 {
+		h += binary.LittleEndian.Uint64(data[off:])
+		h += h << 10
+		h ^= h >> 6
+	}
+	h += h << 3
+	h ^= h >> 11
+	h += h << 15
+	return h
+}
+
+func guestReadHash(data []byte) uint64 {
+	h0 := uint64(memoryBenchmarkSeed)
+	h1 := uint64(memoryBenchmarkSeed ^ 0x9e3779b185ebca87)
+	h2 := uint64(memoryBenchmarkSeed ^ 0xc2b2ae3d27d4eb4f)
+	h3 := uint64(memoryBenchmarkSeed ^ 0x165667b19e3779f9)
+	for off := 0; off < len(data); off += 64 {
+		h0 += binary.LittleEndian.Uint64(data[off:])
+		h1 ^= binary.LittleEndian.Uint64(data[off+8:])
+		h2 += binary.LittleEndian.Uint64(data[off+16:])
+		h3 ^= binary.LittleEndian.Uint64(data[off+24:])
+		h0 += binary.LittleEndian.Uint64(data[off+32:])
+		h1 ^= binary.LittleEndian.Uint64(data[off+40:])
+		h2 += binary.LittleEndian.Uint64(data[off+48:])
+		h3 ^= binary.LittleEndian.Uint64(data[off+56:])
+	}
+	h := h0 + h1 + h2
+	h ^= h3
+	h += h << 3
+	h ^= h >> 11
+	h += h << 15
+	return h
+}
+
+func xorshift64(x uint64) uint64 {
+	x ^= x << 13
+	x ^= x >> 7
+	x ^= x << 17
+	return x
+}
+
+func buildReadMemoryHashCode(dataAddr uint64, dataSize int, hashAddr uint64, exitAddr uint64) []byte {
+	var a arm64Asm
+	a.mov64(0, dataAddr)
+	a.mov64(1, uint64(dataSize/64))
+	a.mov64(2, memoryBenchmarkSeed)
+	a.mov64(11, memoryBenchmarkSeed^0x9e3779b185ebca87)
+	a.mov64(12, memoryBenchmarkSeed^0xc2b2ae3d27d4eb4f)
+	a.mov64(13, memoryBenchmarkSeed^0x165667b19e3779f9)
+	a.label("loop")
+	a.cbz(1, "done")
+	a.emit(ldrx(3, 0, 0))
+	a.emit(ldrx(4, 0, 8))
+	a.emit(ldrx(5, 0, 16))
+	a.emit(ldrx(6, 0, 24))
+	a.emit(ldrx(7, 0, 32))
+	a.emit(ldrx(8, 0, 40))
+	a.emit(ldrx(9, 0, 48))
+	a.emit(ldrx(10, 0, 56))
+	a.emit(addImm(0, 0, 64))
+	a.emit(addRegShift(2, 2, 3, 0))
+	a.emit(eorRegShift(11, 11, 4, arm64ShiftLSL, 0))
+	a.emit(addRegShift(12, 12, 5, 0))
+	a.emit(eorRegShift(13, 13, 6, arm64ShiftLSL, 0))
+	a.emit(addRegShift(2, 2, 7, 0))
+	a.emit(eorRegShift(11, 11, 8, arm64ShiftLSL, 0))
+	a.emit(addRegShift(12, 12, 9, 0))
+	a.emit(eorRegShift(13, 13, 10, arm64ShiftLSL, 0))
+	a.emit(subImm(1, 1, 1))
+	a.b("loop")
+	a.label("done")
+	a.emit(addRegShift(2, 2, 11, 0))
+	a.emit(addRegShift(2, 2, 12, 0))
+	a.emit(eorRegShift(2, 2, 13, arm64ShiftLSL, 0))
+	a.emit(addRegShift(2, 2, 2, 3))
+	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSR, 11))
+	a.emit(addRegShift(2, 2, 2, 15))
+	a.mov64(4, hashAddr)
+	a.emit(strx(2, 4, 0))
+	a.mov64(5, exitAddr)
+	a.emit(strx(2, 5, 0))
+	return a.bytes()
+}
+
+func buildWriteMemoryRandomCode(dataAddr uint64, dataSize int, exitAddr uint64) []byte {
+	var a arm64Asm
+	a.mov64(0, dataAddr)
+	a.mov64(1, uint64(dataSize/8))
+	a.mov64(2, memoryBenchmarkSeed)
+	a.label("loop")
+	a.cbz(1, "done")
+	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSL, 13))
+	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSR, 7))
+	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSL, 17))
+	a.emit(strx(2, 0, 0))
+	a.emit(addImm(0, 0, 8))
+	a.emit(subImm(1, 1, 1))
+	a.b("loop")
+	a.label("done")
+	a.mov64(5, exitAddr)
+	a.emit(strx(2, 5, 0))
+	return a.bytes()
+}
+
+type arm64Asm struct {
+	insns  []uint32
+	labels map[string]int
+	fixups []arm64Fixup
+}
+
+type arm64Fixup struct {
+	at    int
+	label string
+	kind  arm64FixupKind
+	rt    uint32
+}
+
+type arm64FixupKind int
+
+const (
+	arm64FixupB arm64FixupKind = iota
+	arm64FixupCBZ
+)
+
+func (a *arm64Asm) emit(insn uint32) {
+	a.insns = append(a.insns, insn)
+}
+
+func (a *arm64Asm) label(name string) {
+	if a.labels == nil {
+		a.labels = make(map[string]int)
+	}
+	a.labels[name] = len(a.insns)
+}
+
+func (a *arm64Asm) b(label string) {
+	a.fixups = append(a.fixups, arm64Fixup{at: len(a.insns), label: label, kind: arm64FixupB})
+	a.emit(0)
+}
+
+func (a *arm64Asm) cbz(rt uint32, label string) {
+	a.fixups = append(a.fixups, arm64Fixup{at: len(a.insns), label: label, kind: arm64FixupCBZ, rt: rt})
+	a.emit(0)
+}
+
+func (a *arm64Asm) mov64(rd uint32, value uint64) {
+	a.emit(movz(rd, uint16(value), 0))
+	a.emit(movk(rd, uint16(value>>16), 1))
+	a.emit(movk(rd, uint16(value>>32), 2))
+	a.emit(movk(rd, uint16(value>>48), 3))
+}
+
+func (a *arm64Asm) bytes() []byte {
+	for _, fixup := range a.fixups {
+		target, ok := a.labels[fixup.label]
+		if !ok {
+			panic("missing arm64 label " + fixup.label)
+		}
+		off := target - fixup.at
+		switch fixup.kind {
+		case arm64FixupB:
+			a.insns[fixup.at] = branch(off)
+		case arm64FixupCBZ:
+			a.insns[fixup.at] = cbz(fixup.rt, off)
+		}
+	}
+	out := make([]byte, len(a.insns)*4)
+	for i, insn := range a.insns {
+		binary.LittleEndian.PutUint32(out[i*4:], insn)
+	}
+	return out
+}
+
+const (
+	arm64ShiftLSL uint32 = 0
+	arm64ShiftLSR uint32 = 1
+)
+
+func movz(rd uint32, imm uint16, hw uint32) uint32 {
+	return 0xd2800000 | ((hw & 0x3) << 21) | (uint32(imm) << 5) | (rd & 0x1f)
+}
+
+func movk(rd uint32, imm uint16, hw uint32) uint32 {
+	return 0xf2800000 | ((hw & 0x3) << 21) | (uint32(imm) << 5) | (rd & 0x1f)
+}
+
+func addImm(rd, rn, imm uint32) uint32 {
+	return 0x91000000 | ((imm & 0xfff) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
+}
+
+func subImm(rd, rn, imm uint32) uint32 {
+	return 0xd1000000 | ((imm & 0xfff) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
+}
+
+func addRegShift(rd, rn, rm, shift uint32) uint32 {
+	return 0x8b000000 | ((rm & 0x1f) << 16) | ((shift & 0x3f) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
+}
+
+func eorRegShift(rd, rn, rm, shiftType, shift uint32) uint32 {
+	return 0xca000000 | ((shiftType & 0x3) << 22) | ((rm & 0x1f) << 16) | ((shift & 0x3f) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
+}
+
+func ldrx(rt, rn, imm uint32) uint32 {
+	return 0xf9400000 | (((imm / 8) & 0xfff) << 10) | ((rn & 0x1f) << 5) | (rt & 0x1f)
+}
+
+func strx(rt, rn, imm uint32) uint32 {
+	return 0xf9000000 | (((imm / 8) & 0xfff) << 10) | ((rn & 0x1f) << 5) | (rt & 0x1f)
+}
+
+func branch(insnOffset int) uint32 {
+	return 0x14000000 | uint32(insnOffset)&0x03ffffff
+}
+
+func cbz(rt uint32, insnOffset int) uint32 {
+	return 0xb4000000 | (uint32(insnOffset)&0x7ffff)<<5 | (rt & 0x1f)
+}

--- a/internal/hv/memory_benchmark_test.go
+++ b/internal/hv/memory_benchmark_test.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	memoryBenchmarkDataOff        = 0x10000
+	memoryBenchmarkPageTablesOff  = 0x4000
+	memoryBenchmarkPageTablesSize = 5 * 0x1000
 	readMemoryBenchmarkSize       = 512 << 20
 	writeMemoryBenchmarkSize      = 64 << 20
 	writeMemoryBenchmarkHashOff   = memoryBenchmarkDataOff + writeMemoryBenchmarkSize
@@ -41,17 +43,21 @@ func BenchmarkArm64VMReadMemory(b *testing.B) {
 
 	b.SetBytes(int64(dataSize))
 	b.ResetTimer()
+	b.StopTimer()
 	for i := 0; i < b.N; i++ {
 		mapping, err := mapBenchmarkGuestFile(path, readMemoryBenchmarkSize)
 		if err != nil {
 			b.Fatal(err)
 		}
 		vm := newMappedBenchmarkVM(b, mapping.Bytes())
+		b.StartTimer()
 		if err := vm.RunUntilExit(); err != nil {
+			b.StopTimer()
 			_ = vm.Close()
 			_ = mapping.Close()
 			b.Fatal(err)
 		}
+		b.StopTimer()
 		got := binary.LittleEndian.Uint64(vm.memory[hashOff:])
 		if got != want {
 			_ = vm.Close()
@@ -78,12 +84,16 @@ func BenchmarkArm64VMWriteMemory(b *testing.B) {
 
 	b.SetBytes(writeMemoryBenchmarkSize)
 	b.ResetTimer()
+	b.StopTimer()
 	for i := 0; i < b.N; i++ {
 		vm := newBenchmarkMicroVM(b, code)
+		b.StartTimer()
 		if err := vm.RunUntilExit(); err != nil {
+			b.StopTimer()
 			_ = vm.Close()
 			b.Fatal(err)
 		}
+		b.StopTimer()
 		got := guestHashWords(vm.memory[memoryBenchmarkDataOff : memoryBenchmarkDataOff+writeMemoryBenchmarkSize])
 		if got != want {
 			_ = vm.Close()
@@ -104,6 +114,7 @@ func newBenchmarkMicroVM(b *testing.B, code []byte) *memoryBenchmarkVM {
 	if err != nil {
 		b.Fatal(err)
 	}
+	installBenchmarkIdentityMap(b, vm.memory)
 	copy(vm.memory, code)
 	if err := vm.SetEntry(memoryBenchmarkBase, memoryBenchmarkBase+writeMemoryBenchmarkGuestSize); err != nil {
 		_ = vm.Close()
@@ -121,6 +132,7 @@ func newMappedBenchmarkVM(b *testing.B, mem []byte) *memoryBenchmarkVM {
 	if err != nil {
 		b.Fatal(err)
 	}
+	installBenchmarkIdentityMap(b, vm.memory)
 	if err := vm.SetEntry(memoryBenchmarkBase, memoryBenchmarkBase+uint64(len(mem))); err != nil {
 		_ = vm.Close()
 		b.Fatal(err)
@@ -189,33 +201,53 @@ func xorshift64(x uint64) uint64 {
 	return x
 }
 
+func installBenchmarkIdentityMap(b *testing.B, mem []byte) {
+	b.Helper()
+	if len(mem) < memoryBenchmarkPageTablesOff+memoryBenchmarkPageTablesSize {
+		b.Fatalf("guest memory too small for benchmark page tables")
+	}
+	// WHP/arm64 is pathologically slow for this benchmark with stage-1 MMU
+	// disabled, so install a small 4GiB identity map with Normal WB blocks.
+	tables := mem[memoryBenchmarkPageTablesOff : memoryBenchmarkPageTablesOff+memoryBenchmarkPageTablesSize]
+	clear(tables)
+	l1 := tables[:0x1000]
+	l2s := tables[0x1000:]
+	const (
+		tableDescriptor = 0x3
+		blockDescriptor = 0x1 |
+			(3 << 8) | // Inner shareable.
+			(1 << 10) // Access flag.
+	)
+	for l1i := uint64(0); l1i < 4; l1i++ {
+		l2GPA := memoryBenchmarkBase + uint64(memoryBenchmarkPageTablesOff) + 0x1000 + l1i*0x1000
+		binary.LittleEndian.PutUint64(l1[l1i*8:], l2GPA|tableDescriptor)
+		l2 := l2s[l1i*0x1000 : (l1i+1)*0x1000]
+		for l2i := uint64(0); l2i < 512; l2i++ {
+			pa := (l1i << 30) | (l2i << 21)
+			binary.LittleEndian.PutUint64(l2[l2i*8:], pa|blockDescriptor)
+		}
+	}
+}
+
 func buildReadMemoryHashCode(dataAddr uint64, dataSize int, hashAddr uint64, exitAddr uint64) []byte {
 	var a arm64Asm
+	emitEnableBenchmarkMMU(&a)
 	a.mov64(0, dataAddr)
-	a.mov64(1, uint64(dataSize/64))
+	a.mov64(1, uint64(dataSize/256))
 	a.mov64(2, memoryBenchmarkSeed)
 	a.mov64(11, memoryBenchmarkSeed^0x9e3779b185ebca87)
 	a.mov64(12, memoryBenchmarkSeed^0xc2b2ae3d27d4eb4f)
 	a.mov64(13, memoryBenchmarkSeed^0x165667b19e3779f9)
 	a.label("loop")
 	a.cbz(1, "done")
-	a.emit(ldrx(3, 0, 0))
-	a.emit(ldrx(4, 0, 8))
-	a.emit(ldrx(5, 0, 16))
-	a.emit(ldrx(6, 0, 24))
-	a.emit(ldrx(7, 0, 32))
-	a.emit(ldrx(8, 0, 40))
-	a.emit(ldrx(9, 0, 48))
-	a.emit(ldrx(10, 0, 56))
-	a.emit(addImm(0, 0, 64))
-	a.emit(addRegShift(2, 2, 3, 0))
-	a.emit(eorRegShift(11, 11, 4, arm64ShiftLSL, 0))
-	a.emit(addRegShift(12, 12, 5, 0))
-	a.emit(eorRegShift(13, 13, 6, arm64ShiftLSL, 0))
-	a.emit(addRegShift(2, 2, 7, 0))
-	a.emit(eorRegShift(11, 11, 8, arm64ShiftLSL, 0))
-	a.emit(addRegShift(12, 12, 9, 0))
-	a.emit(eorRegShift(13, 13, 10, arm64ShiftLSL, 0))
+	for off := uint32(0); off < 256; off += 64 {
+		a.emit(ldpx(3, 4, 0, off))
+		a.emit(ldpx(5, 6, 0, off+16))
+		a.emit(ldpx(7, 8, 0, off+32))
+		a.emit(ldpx(9, 10, 0, off+48))
+		emitReadHashChunk(&a)
+	}
+	a.emit(addImm(0, 0, 256))
 	a.emit(subImm(1, 1, 1))
 	a.b("loop")
 	a.label("done")
@@ -232,24 +264,67 @@ func buildReadMemoryHashCode(dataAddr uint64, dataSize int, hashAddr uint64, exi
 	return a.bytes()
 }
 
+func emitReadHashChunk(a *arm64Asm) {
+	a.emit(addRegShift(2, 2, 3, 0))
+	a.emit(eorRegShift(11, 11, 4, arm64ShiftLSL, 0))
+	a.emit(addRegShift(12, 12, 5, 0))
+	a.emit(eorRegShift(13, 13, 6, arm64ShiftLSL, 0))
+	a.emit(addRegShift(2, 2, 7, 0))
+	a.emit(eorRegShift(11, 11, 8, arm64ShiftLSL, 0))
+	a.emit(addRegShift(12, 12, 9, 0))
+	a.emit(eorRegShift(13, 13, 10, arm64ShiftLSL, 0))
+}
+
 func buildWriteMemoryRandomCode(dataAddr uint64, dataSize int, exitAddr uint64) []byte {
 	var a arm64Asm
+	emitEnableBenchmarkMMU(&a)
 	a.mov64(0, dataAddr)
-	a.mov64(1, uint64(dataSize/8))
+	a.mov64(1, uint64(dataSize/64))
 	a.mov64(2, memoryBenchmarkSeed)
 	a.label("loop")
 	a.cbz(1, "done")
-	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSL, 13))
-	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSR, 7))
-	a.emit(eorRegShift(2, 2, 2, arm64ShiftLSL, 17))
-	a.emit(strx(2, 0, 0))
-	a.emit(addImm(0, 0, 8))
+	for off := uint32(0); off < 64; off += 16 {
+		emitXorshift64(&a, 2)
+		a.emit(addRegShift(3, 2, 31, 0))
+		emitXorshift64(&a, 3)
+		a.emit(stpx(2, 3, 0, off))
+		a.emit(addRegShift(2, 3, 31, 0))
+	}
+	a.emit(addImm(0, 0, 64))
 	a.emit(subImm(1, 1, 1))
 	a.b("loop")
 	a.label("done")
 	a.mov64(5, exitAddr)
 	a.emit(strx(2, 5, 0))
 	return a.bytes()
+}
+
+func emitXorshift64(a *arm64Asm, reg uint32) {
+	a.emit(eorRegShift(reg, reg, reg, arm64ShiftLSL, 13))
+	a.emit(eorRegShift(reg, reg, reg, arm64ShiftLSR, 7))
+	a.emit(eorRegShift(reg, reg, reg, arm64ShiftLSL, 17))
+}
+
+func emitEnableBenchmarkMMU(a *arm64Asm) {
+	const (
+		mairEL1 = 0xff
+		// T0SZ=32, IRGN0/ORGN0=WB RA/WA, SH0=inner-shareable.
+		tcrEL1   = 32 | (1 << 8) | (1 << 10) | (3 << 12)
+		sctlrMMU = 1 | (1 << 2) | (1 << 12)
+		ttbr0EL1 = memoryBenchmarkBase + memoryBenchmarkPageTablesOff
+	)
+	a.mov64(14, mairEL1)
+	a.emit(msr(sysRegMAIREL1, 14))
+	a.mov64(14, tcrEL1)
+	a.emit(msr(sysRegTCREL1, 14))
+	a.mov64(14, ttbr0EL1)
+	a.emit(msr(sysRegTTBR0EL1, 14))
+	a.emit(isb())
+	a.emit(mrs(15, sysRegSCTLREL1))
+	a.mov64(14, sctlrMMU)
+	a.emit(orrRegShift(15, 15, 14, 0))
+	a.emit(msr(sysRegSCTLREL1, 15))
+	a.emit(isb())
 }
 
 type arm64Asm struct {
@@ -326,6 +401,15 @@ const (
 	arm64ShiftLSR uint32 = 1
 )
 
+type arm64SysReg uint32
+
+const (
+	sysRegSCTLREL1 arm64SysReg = 0xc080
+	sysRegTCREL1   arm64SysReg = 0xc102
+	sysRegTTBR0EL1 arm64SysReg = 0xc100
+	sysRegMAIREL1  arm64SysReg = 0xc510
+)
+
 func movz(rd uint32, imm uint16, hw uint32) uint32 {
 	return 0xd2800000 | ((hw & 0x3) << 21) | (uint32(imm) << 5) | (rd & 0x1f)
 }
@@ -346,6 +430,10 @@ func addRegShift(rd, rn, rm, shift uint32) uint32 {
 	return 0x8b000000 | ((rm & 0x1f) << 16) | ((shift & 0x3f) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
 }
 
+func orrRegShift(rd, rn, rm, shift uint32) uint32 {
+	return 0xaa000000 | ((rm & 0x1f) << 16) | ((shift & 0x3f) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
+}
+
 func eorRegShift(rd, rn, rm, shiftType, shift uint32) uint32 {
 	return 0xca000000 | ((shiftType & 0x3) << 22) | ((rm & 0x1f) << 16) | ((shift & 0x3f) << 10) | ((rn & 0x1f) << 5) | (rd & 0x1f)
 }
@@ -356,6 +444,26 @@ func ldrx(rt, rn, imm uint32) uint32 {
 
 func strx(rt, rn, imm uint32) uint32 {
 	return 0xf9000000 | (((imm / 8) & 0xfff) << 10) | ((rn & 0x1f) << 5) | (rt & 0x1f)
+}
+
+func ldpx(rt, rt2, rn, imm uint32) uint32 {
+	return 0xa9400000 | (((imm / 8) & 0x7f) << 15) | ((rt2 & 0x1f) << 10) | ((rn & 0x1f) << 5) | (rt & 0x1f)
+}
+
+func stpx(rt, rt2, rn, imm uint32) uint32 {
+	return 0xa9000000 | (((imm / 8) & 0x7f) << 15) | ((rt2 & 0x1f) << 10) | ((rn & 0x1f) << 5) | (rt & 0x1f)
+}
+
+func mrs(rt uint32, reg arm64SysReg) uint32 {
+	return 0xd5300000 | (uint32(reg) << 5) | (rt & 0x1f)
+}
+
+func msr(reg arm64SysReg, rt uint32) uint32 {
+	return 0xd5100000 | (uint32(reg) << 5) | (rt & 0x1f)
+}
+
+func isb() uint32 {
+	return 0xd5033fdf
 }
 
 func branch(insnOffset int) uint32 {

--- a/internal/hv/memory_benchmark_vm_darwin_arm64_test.go
+++ b/internal/hv/memory_benchmark_vm_darwin_arm64_test.go
@@ -1,0 +1,62 @@
+//go:build darwin && arm64
+
+package hv
+
+import (
+	"context"
+	"fmt"
+
+	"j5.nz/cc/internal/hv/hvf"
+)
+
+func newAnonymousMemoryBenchmarkVM(memorySize uint64) (*memoryBenchmarkVM, error) {
+	vm, err := hvf.NewVMWithOptions(context.Background(), hvf.VMOptions{CPUs: 1})
+	if err != nil {
+		return nil, err
+	}
+	mem, err := vm.MapAnonymousMemory(uintptr(memorySize), hvf.IPA(memoryBenchmarkBase), hvf.MemoryFlags(0x7))
+	if err != nil {
+		_ = vm.Close()
+		return nil, err
+	}
+	return newHVFMemoryBenchmarkVM(vm, mem), nil
+}
+
+func newMappedMemoryBenchmarkVM(mem []byte) (*memoryBenchmarkVM, error) {
+	vm, err := hvf.NewVMWithOptions(context.Background(), hvf.VMOptions{CPUs: 1})
+	if err != nil {
+		return nil, err
+	}
+	if err := vm.MapMemory(mem, hvf.IPA(memoryBenchmarkBase), hvf.MemoryFlags(0x7)); err != nil {
+		_ = vm.Close()
+		return nil, err
+	}
+	return newHVFMemoryBenchmarkVM(vm, mem), nil
+}
+
+func newHVFMemoryBenchmarkVM(vm *hvf.VM, mem []byte) *memoryBenchmarkVM {
+	return &memoryBenchmarkVM{
+		memory: mem,
+		close:  vm.Close,
+		setEntry: func(entry, stackTop uint64) error {
+			return vm.ConfigureLinuxBootState(entry, stackTop, 0)
+		},
+		runUntilExit: func() error {
+			exit, err := vm.Run()
+			if err != nil {
+				return err
+			}
+			if hvf.DecodeExceptionClass(exit.Exception.Syndrome) != hvf.ExceptionClassDataAbortLowerEL {
+				return fmt.Errorf("unexpected VM exception syndrome=%#x", exit.Exception.Syndrome)
+			}
+			abort, err := hvf.DecodeDataAbort(exit.Exception.Syndrome)
+			if err != nil {
+				return err
+			}
+			if !abort.Write || uint64(exit.Exception.PhysicalAddress) != memoryBenchmarkExitAddr {
+				return fmt.Errorf("unexpected data abort addr=%#x write=%t", exit.Exception.PhysicalAddress, abort.Write)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/hv/memory_benchmark_vm_linux_arm64_test.go
+++ b/internal/hv/memory_benchmark_vm_linux_arm64_test.go
@@ -1,0 +1,67 @@
+//go:build linux && arm64
+
+package hv
+
+import (
+	"fmt"
+
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/hv/kvm"
+)
+
+func newAnonymousMemoryBenchmarkVM(memorySize uint64) (*memoryBenchmarkVM, error) {
+	vm, err := kvm.NewVM()
+	if err != nil {
+		return nil, err
+	}
+	mem, err := vm.MapAnonymousMemory(memorySize, memoryBenchmarkBase)
+	if err != nil {
+		_ = vm.Close()
+		return nil, err
+	}
+	return newKVMMemoryBenchmarkVM(vm, mem), nil
+}
+
+func newMappedMemoryBenchmarkVM(mem []byte) (*memoryBenchmarkVM, error) {
+	vm, err := kvm.NewVM()
+	if err != nil {
+		return nil, err
+	}
+	if err := vm.MapMemoryAlias(0, memoryBenchmarkBase, mem); err != nil {
+		_ = vm.Close()
+		return nil, err
+	}
+	return newKVMMemoryBenchmarkVM(vm, mem), nil
+}
+
+func newKVMMemoryBenchmarkVM(vm *kvm.VM, mem []byte) *memoryBenchmarkVM {
+	return &memoryBenchmarkVM{
+		memory: mem,
+		close:  vm.Close,
+		setEntry: func(entry, stackTop uint64) error {
+			if err := vm.SetPC(entry); err != nil {
+				return fmt.Errorf("set PC: %w", err)
+			}
+			if err := vm.SetPState(arm64vm.DefaultPStateBits); err != nil {
+				return fmt.Errorf("set PSTATE: %w", err)
+			}
+			if err := vm.SetSpEl1(stackTop); err != nil {
+				return fmt.Errorf("set SP_EL1: %w", err)
+			}
+			return nil
+		},
+		runUntilExit: func() error {
+			var exit kvm.Exit
+			if err := vm.Run(&exit); err != nil {
+				return err
+			}
+			if exit.Reason != kvm.ExitMMIO {
+				return fmt.Errorf("unexpected VM exit reason %d", exit.Reason)
+			}
+			if exit.MMIO.Addr != memoryBenchmarkExitAddr || !exit.MMIO.Write {
+				return fmt.Errorf("unexpected MMIO exit addr=%#x write=%t", exit.MMIO.Addr, exit.MMIO.Write)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/hv/memory_benchmark_vm_test.go
+++ b/internal/hv/memory_benchmark_vm_test.go
@@ -1,0 +1,41 @@
+package hv
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	memoryBenchmarkBase     = 0xa0000000
+	memoryBenchmarkExitAddr = 0xf0000000
+)
+
+var errMemoryBenchmarkUnsupported = errors.New("arm64 memory benchmark is unsupported on this platform")
+
+type memoryBenchmarkVM struct {
+	memory       []byte
+	close        func() error
+	runUntilExit func() error
+	setEntry     func(entry, stackTop uint64) error
+}
+
+func (v *memoryBenchmarkVM) Close() error {
+	if v == nil || v.close == nil {
+		return nil
+	}
+	return v.close()
+}
+
+func (v *memoryBenchmarkVM) RunUntilExit() error {
+	if v == nil || v.runUntilExit == nil {
+		return fmt.Errorf("memory benchmark VM is nil")
+	}
+	return v.runUntilExit()
+}
+
+func (v *memoryBenchmarkVM) SetEntry(entry, stackTop uint64) error {
+	if v == nil || v.setEntry == nil {
+		return fmt.Errorf("memory benchmark VM is nil")
+	}
+	return v.setEntry(entry, stackTop)
+}

--- a/internal/hv/memory_benchmark_vm_unsupported_test.go
+++ b/internal/hv/memory_benchmark_vm_unsupported_test.go
@@ -1,0 +1,11 @@
+//go:build !(arm64 && (linux || darwin || windows))
+
+package hv
+
+func newAnonymousMemoryBenchmarkVM(memorySize uint64) (*memoryBenchmarkVM, error) {
+	return nil, errMemoryBenchmarkUnsupported
+}
+
+func newMappedMemoryBenchmarkVM(mem []byte) (*memoryBenchmarkVM, error) {
+	return nil, errMemoryBenchmarkUnsupported
+}

--- a/internal/hv/memory_benchmark_vm_windows_arm64_test.go
+++ b/internal/hv/memory_benchmark_vm_windows_arm64_test.go
@@ -1,0 +1,55 @@
+//go:build windows && arm64
+
+package hv
+
+import (
+	"fmt"
+
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/hv/whp"
+)
+
+func newAnonymousMemoryBenchmarkVM(memorySize uint64) (*memoryBenchmarkVM, error) {
+	vm, err := whp.NewVM(memorySize, memoryBenchmarkBase)
+	if err != nil {
+		return nil, err
+	}
+	return newWHPMemoryBenchmarkVM(vm), nil
+}
+
+func newMappedMemoryBenchmarkVM(mem []byte) (*memoryBenchmarkVM, error) {
+	vm, err := whp.NewVMWithMemory(mem, memoryBenchmarkBase)
+	if err != nil {
+		return nil, err
+	}
+	return newWHPMemoryBenchmarkVM(vm), nil
+}
+
+func newWHPMemoryBenchmarkVM(vm *whp.VM) *memoryBenchmarkVM {
+	return &memoryBenchmarkVM{
+		memory: vm.Memory(),
+		close:  vm.Close,
+		setEntry: func(entry, stackTop uint64) error {
+			if err := vm.SetPC(entry); err != nil {
+				return fmt.Errorf("set PC: %w", err)
+			}
+			if err := vm.SetPState(arm64vm.DefaultPStateBits); err != nil {
+				return fmt.Errorf("set PSTATE: %w", err)
+			}
+			if err := vm.SetSpEl1(stackTop); err != nil {
+				return fmt.Errorf("set SP_EL1: %w", err)
+			}
+			return nil
+		},
+		runUntilExit: func() error {
+			var exit whp.Exit
+			if err := vm.Run(&exit); err != nil {
+				return err
+			}
+			if exit.MMIO.Addr != memoryBenchmarkExitAddr || !exit.MMIO.Write {
+				return fmt.Errorf("unexpected MMIO exit addr=%#x write=%t", exit.MMIO.Addr, exit.MMIO.Write)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/hv/testmain_darwin_arm64_test.go
+++ b/internal/hv/testmain_darwin_arm64_test.go
@@ -1,0 +1,19 @@
+//go:build darwin && arm64
+
+package hv
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"j5.nz/cc/internal/macos"
+)
+
+func TestMain(m *testing.M) {
+	if err := macos.EnsureExecutableIsSigned(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/hv/whp/vm_windows_arm64.go
+++ b/internal/hv/whp/vm_windows_arm64.go
@@ -15,6 +15,7 @@ import (
 type VM struct {
 	part        partitionHandle
 	mem         *allocation
+	externalMem []byte
 	memGPA      uint64
 	memSize     uint64
 	vcpuCreated bool
@@ -87,6 +88,50 @@ func NewVM(memorySize uint64, memoryBase uint64) (*VM, error) {
 }
 
 func NewVMWithOptions(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM, error) {
+	vm, err := newVMPartition(memorySize, memoryBase, opts)
+	if err != nil {
+		return nil, err
+	}
+	mem, err := virtualAlloc(uintptr(memorySize))
+	if err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("allocate guest memory: %w", err)
+	}
+	vm.mem = mem
+	vm.preTouchGuestMemory()
+	if err := mapGPARange(vm.part, unsafe.Pointer(mem.addr), memoryBase, memorySize, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("map guest memory: %w", err)
+	}
+	vm.populateGuestMemory()
+	if err := vm.finishSetup(); err != nil {
+		_ = vm.Close()
+		return nil, err
+	}
+	return vm, nil
+}
+
+func NewVMWithMemory(mem []byte, memoryBase uint64) (*VM, error) {
+	if len(mem) == 0 {
+		return nil, fmt.Errorf("guest memory must be non-empty")
+	}
+	vm, err := newVMPartition(uint64(len(mem)), memoryBase, VMOptions{})
+	if err != nil {
+		return nil, err
+	}
+	vm.externalMem = mem
+	if err := mapGPARange(vm.part, unsafe.Pointer(&mem[0]), memoryBase, uint64(len(mem)), mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
+		_ = vm.Close()
+		return nil, fmt.Errorf("map guest memory: %w", err)
+	}
+	if err := vm.finishSetup(); err != nil {
+		_ = vm.Close()
+		return nil, err
+	}
+	return vm, nil
+}
+
+func newVMPartition(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM, error) {
 	if memorySize == 0 {
 		return nil, fmt.Errorf("memory size must be non-zero")
 	}
@@ -94,7 +139,7 @@ func NewVMWithOptions(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM
 	if err != nil {
 		return nil, fmt.Errorf("create partition: %w", err)
 	}
-	vm := &VM{part: part, memGPA: memoryBase}
+	vm := &VM{part: part, memGPA: memoryBase, memSize: memorySize}
 	if err := setPartitionProperty(part, partitionPropertyCodeProcessorCount, uint32(1)); err != nil {
 		_ = vm.Close()
 		return nil, fmt.Errorf("set processor count: %w", err)
@@ -122,29 +167,18 @@ func NewVMWithOptions(memorySize uint64, memoryBase uint64, opts VMOptions) (*VM
 		_ = vm.Close()
 		return nil, fmt.Errorf("setup partition: %w", err)
 	}
-	mem, err := virtualAlloc(uintptr(memorySize))
-	if err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("allocate guest memory: %w", err)
-	}
-	vm.mem = mem
-	vm.memSize = memorySize
-	vm.preTouchGuestMemory()
-	if err := mapGPARange(part, unsafe.Pointer(mem.addr), memoryBase, memorySize, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("map guest memory: %w", err)
-	}
-	vm.populateGuestMemory()
-	if err := createVirtualProcessor(part, 0); err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("create virtual processor: %w", err)
-	}
-	vm.vcpuCreated = true
-	if err := vm.setRegister(registerGICR, arm64vm.GICRedistributorMin); err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("set gic redistributor base: %w", err)
-	}
 	return vm, nil
+}
+
+func (v *VM) finishSetup() error {
+	if err := createVirtualProcessor(v.part, 0); err != nil {
+		return fmt.Errorf("create virtual processor: %w", err)
+	}
+	v.vcpuCreated = true
+	if err := v.setRegister(registerGICR, arm64vm.GICRedistributorMin); err != nil {
+		return fmt.Errorf("set gic redistributor base: %w", err)
+	}
+	return nil
 }
 
 func (v *VM) preTouchGuestMemory() {
@@ -196,7 +230,7 @@ func (v *VM) Close() error {
 		}
 		v.vcpuCreated = false
 	}
-	if v.part != 0 && v.mem != nil {
+	if v.part != 0 && (v.mem != nil || v.externalMem != nil) {
 		if err := unmapGPARange(v.part, v.memGPA, v.memSize); err != nil && first == nil {
 			first = err
 		}
@@ -218,8 +252,11 @@ func (v *VM) Close() error {
 }
 
 func (v *VM) Memory() []byte {
-	if v == nil || v.mem == nil {
+	if v == nil {
 		return nil
+	}
+	if v.mem == nil {
+		return v.externalMem
 	}
 	return v.mem.bytes()
 }


### PR DESCRIPTION
## Summary

Adds low-level arm64 VM memory benchmarks for KVM, HVF, and WHP:

- `BenchmarkArm64VMReadMemory` writes a 512 MiB snapshot-like guest memory file once, maps it copy-on-write, starts a fresh VM per iteration, has the guest hash mapped RAM, and validates the digest on the host.
- `BenchmarkArm64VMWriteMemory` starts a fresh anonymous-memory VM per iteration, has the guest generate deterministic bytes, and validates the host-side hash.
- Adds a Darwin/arm64 `TestMain` path that signs the `internal/hv` test binary with the existing hypervisor entitlement helper.
- Adds WHP arm64 support for mapping caller-owned memory so the Windows benchmark can use a file-backed COW view without pre-touching/prefetching it.

## Validation

- `go test ./internal/hv`
- `GOOS=windows GOARCH=arm64 go test -c ./internal/hv`
- `GOOS=linux GOARCH=arm64 go test -c ./internal/hv`
- `go test ./internal/hv -run '^$' -bench 'BenchmarkArm64VM(Read|Write)Memory$' -benchtime=1x -count=1`

Local Darwin/arm64 smoke result:

```text
BenchmarkArm64VMReadMemory-10       550835625 ns/op   974.41 MB/s
BenchmarkArm64VMWriteMemory-10       28484042 ns/op   2356.02 MB/s
```