### PR TITLE
[codex] support persistent vmshd protocol clients

### DIFF
--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -11,6 +11,8 @@ import (
 type ServerOptions struct {
 	Kind                   string
 	TokenPath              string
+	Persistent             bool
+	OnStartup              func(client.ServerHello) error
 	RegisterHandlers       func(*http.ServeMux, RuntimeView)
 	WrapHandler            func(http.Handler) http.Handler
 	NormalizeCreateRequest func(*client.CreateInstanceRequest, RuntimeView) error
@@ -30,8 +32,10 @@ func Main(args []string) {
 
 func RunServer(args []string, opts ServerOptions) (bool, error) {
 	return internal.RunServer(args, internal.ServerOptions{
-		Kind:      opts.Kind,
-		TokenPath: opts.TokenPath,
+		Kind:       opts.Kind,
+		TokenPath:  opts.TokenPath,
+		Persistent: opts.Persistent,
+		OnStartup:  opts.OnStartup,
 		NormalizeCreateRequest: func(req *client.CreateInstanceRequest, runtime internal.RuntimeView) error {
 			if opts.NormalizeCreateRequest == nil {
 				return nil

--- a/client/client.go
+++ b/client/client.go
@@ -15,10 +15,10 @@ import (
 )
 
 type Client struct {
-	url       string
-	dialer    func() (net.Conn, error)
-	authToken string
-	client    http.Client
+	url     string
+	dialer  func() (net.Conn, error)
+	headers http.Header
+	client  http.Client
 }
 
 func NewClient(url string, dialer func() (net.Conn, error)) *Client {
@@ -34,7 +34,10 @@ func NewClient(url string, dialer func() (net.Conn, error)) *Client {
 				},
 			},
 			token: func() string {
-				return c.authToken
+				return c.headers.Get("Authorization")
+			},
+			headers: func() http.Header {
+				return c.headers.Clone()
 			},
 		},
 	}
@@ -42,22 +45,51 @@ func NewClient(url string, dialer func() (net.Conn, error)) *Client {
 }
 
 type authTransport struct {
-	base  http.RoundTripper
-	token func() string
+	base    http.RoundTripper
+	token   func() string
+	headers func() http.Header
 }
 
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	if t.headers != nil {
+		for key, values := range t.headers() {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	}
 	if t.token != nil {
 		if token := strings.TrimSpace(t.token()); token != "" {
-			req = req.Clone(req.Context())
-			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Authorization", token)
 		}
 	}
 	return t.base.RoundTrip(req)
 }
 
 func (c *Client) SetBearerToken(token string) {
-	c.authToken = strings.TrimSpace(token)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		c.SetHeader("Authorization", "")
+		return
+	}
+	c.SetHeader("Authorization", "Bearer "+token)
+}
+
+func (c *Client) SetHeader(key, value string) {
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" {
+		return
+	}
+	if c.headers == nil {
+		c.headers = http.Header{}
+	}
+	if value == "" {
+		c.headers.Del(key)
+		return
+	}
+	c.headers.Set(key, value)
 }
 
 func (c *Client) HealthCheck() error {
@@ -615,11 +647,15 @@ func (c *Client) applyWebSocketAuth(cfg *websocket.Config) {
 	if cfg == nil {
 		return
 	}
-	if token := strings.TrimSpace(c.authToken); token != "" {
+	if c.headers != nil {
 		if cfg.Header == nil {
 			cfg.Header = http.Header{}
 		}
-		cfg.Header.Set("Authorization", "Bearer "+token)
+		for key, values := range c.headers {
+			for _, value := range values {
+				cfg.Header.Add(key, value)
+			}
+		}
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,18 +79,23 @@ func TestClientBearerTokenIsSent(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
 			t.Fatalf("Authorization = %q", got)
 		}
+		if got := r.Header.Get("X-Test-Protocol"); got != "1" {
+			t.Fatalf("X-Test-Protocol = %q", got)
+		}
 		writeTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	}))
 	defer srv.Close()
 
 	c := &Client{
-		url:       srv.URL,
-		authToken: "secret",
+		url: srv.URL,
 		client: http.Client{
 			Transport: &authTransport{
 				base: srv.Client().Transport,
 				token: func() string {
-					return "secret"
+					return "Bearer secret"
+				},
+				headers: func() http.Header {
+					return http.Header{"X-Test-Protocol": []string{"1"}}
 				},
 			},
 		},

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -80,6 +80,8 @@ type server struct {
 type ServerOptions struct {
 	Kind                   string
 	TokenPath              string
+	Persistent             bool
+	OnStartup              func(client.ServerHello) error
 	RegisterHandlers       func(*http.ServeMux, RuntimeView)
 	WrapHandler            func(http.Handler) http.Handler
 	NormalizeCreateRequest func(*client.CreateInstanceRequest, RuntimeView) error
@@ -124,6 +126,7 @@ type watchdogController struct {
 	active      bool
 	leases      map[string]time.Time
 	onExpired   func()
+	persistent  bool
 	cvmfsEvents uint64
 	cvmfsBytes  int64
 	cvmfsLast   time.Time
@@ -135,6 +138,12 @@ type watchdogRequest struct {
 
 func newWatchdogController(onExpired func()) *watchdogController {
 	return &watchdogController{onExpired: onExpired}
+}
+
+func newPersistentWatchdogController(onExpired func()) *watchdogController {
+	w := newWatchdogController(onExpired)
+	w.persistent = true
+	return w
 }
 
 func (w *watchdogController) Create(timeout time.Duration) {
@@ -231,7 +240,9 @@ func (w *watchdogController) ReleaseLease(id string) bool {
 		if w.timer != nil {
 			w.timer.Stop()
 		}
-		onExpired = w.onExpired
+		if !w.persistent {
+			onExpired = w.onExpired
+		}
 	} else {
 		w.resetTimerLocked(time.Now())
 	}
@@ -281,7 +292,9 @@ func (w *watchdogController) expire() {
 	}
 	if w.active || w.leases != nil {
 		w.active = false
-		onExpired = w.onExpired
+		if !w.persistent {
+			onExpired = w.onExpired
+		}
 	}
 	w.mu.Unlock()
 
@@ -394,10 +407,19 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 		_ = l.Close()
 		return false, fmt.Errorf("write startup banner: %w", err)
 	}
+	if opts.OnStartup != nil {
+		if err := opts.OnStartup(hello); err != nil {
+			_ = l.Close()
+			return false, fmt.Errorf("startup callback: %w", err)
+		}
+	}
 
 	var httpServer http.Server
 	shutdown := newServerShutdown(srvState, &httpServer)
 	watchdog := newWatchdogController(shutdown)
+	if opts.Persistent {
+		watchdog = newPersistentWatchdogController(shutdown)
+	}
 	defer watchdog.Stop()
 	srvState.images.CVMFSActivity = watchdog.RecordCVMFSActivity
 	mux := newMux(srvState, watchdog, shutdown, opts)

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -77,6 +77,38 @@ func TestMuxHealthStatusWatchdogAndShutdown(t *testing.T) {
 	}
 }
 
+func TestPersistentWatchdogDoesNotShutdownWhenLeasesEnd(t *testing.T) {
+	shutdownCalled := make(chan struct{}, 1)
+	watchdog := newPersistentWatchdogController(func() {
+		shutdownCalled <- struct{}{}
+	})
+	defer watchdog.Stop()
+
+	leaseID, err := watchdog.CreateLease(10 * time.Millisecond)
+	if err != nil {
+		t.Fatalf("create lease: %v", err)
+	}
+	if !watchdog.ReleaseLease(leaseID) {
+		t.Fatalf("release lease failed")
+	}
+	assertNoShutdown(t, shutdownCalled)
+
+	if _, err := watchdog.CreateLease(10 * time.Millisecond); err != nil {
+		t.Fatalf("create expiring lease: %v", err)
+	}
+	time.Sleep(30 * time.Millisecond)
+	assertNoShutdown(t, shutdownCalled)
+}
+
+func assertNoShutdown(t *testing.T, shutdownCalled <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-shutdownCalled:
+		t.Fatalf("persistent watchdog called shutdown")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestMuxBadRequests(t *testing.T) {
 	watchdog := newWatchdogController(func() {})
 	defer watchdog.Stop()


### PR DESCRIPTION
## Summary

Adds the small cc daemon/client support needed by vmshd's user-wide daemon work:

- allows clients to send vmsh frontend protocol headers on every request
- exposes a startup callback so vmshd can publish daemon state after the listener is ready
- adds persistent watchdog mode for systemd-managed daemons so lease release/expiry does not stop the service

## Validation

- `go test ./ccvmd ./internal/ccvmd ./client`
