### PR TITLE
fix KVM startup snapshot restore

### DIFF
--- a/internal/hv/kvm/bindings_linux_amd64.go
+++ b/internal/hv/kvm/bindings_linux_amd64.go
@@ -17,6 +17,7 @@ const kvmCPUIDFlagSignificantIndex = 1
 
 const (
 	kvmCreateVM            = 0xae01
+	kvmCheckExtension      = 0xae03
 	kvmGetVcpuMmapSize     = 0xae04
 	kvmGetSupportedCpuid   = 0xc008ae05
 	kvmSetUserMemoryRegion = 0x4020ae46
@@ -54,7 +55,10 @@ const (
 	kvmGetXCRS             = 0x8188aea6
 	kvmSetXCRS             = 0x4188aea7
 	kvmGetTSCKHz           = 0xaea3
+	kvmGetXSAVE2           = 0x9000aecf
 )
+
+const kvmCapXSAVE2 = 208
 
 const (
 	ia32TSCMSR        = 0x00000010
@@ -81,6 +85,14 @@ func ioctlWithRetry(fd uintptr, request uint64, arg uintptr) (uintptr, error) {
 		}
 		return v1, err
 	}
+}
+
+func checkExtension(fd int, cap int) (uint64, error) {
+	v1, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(kvmCheckExtension), uintptr(cap))
+	if err != 0 {
+		return 0, err
+	}
+	return uint64(v1), nil
 }
 
 func ioctlRunVCPU(fd uintptr) (uintptr, error) {
@@ -322,6 +334,50 @@ func setXSAVE(vcpuFd int, xsave *kvmXSAVE) error {
 	return err
 }
 
+func getXSAVEBytes(vmFd int, vcpuFd int) ([]byte, error) {
+	size := kvmXSAVEBufferSize(vmFd)
+	buf := make([]byte, size)
+	request := uint64(kvmGetXSAVE)
+	if size > int(unsafe.Sizeof(kvmXSAVE{})) {
+		request = uint64(kvmGetXSAVE2)
+	}
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), request, uintptr(unsafe.Pointer(&buf[0]))); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func setXSAVEBytes(vmFd int, vcpuFd int, data []byte) error {
+	size := kvmXSAVEBufferSize(vmFd)
+	if len(data) > size {
+		return unix.EINVAL
+	}
+	buf := make([]byte, size)
+	copy(buf, data)
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmSetXSAVE), uintptr(unsafe.Pointer(&buf[0])))
+	return err
+}
+
+func legacyXSAVEBytes(xsave *kvmXSAVE) []byte {
+	if xsave == nil {
+		return nil
+	}
+	size := int(unsafe.Sizeof(*xsave))
+	out := make([]byte, size)
+	src := unsafe.Slice((*byte)(unsafe.Pointer(xsave)), size)
+	copy(out, src)
+	return out
+}
+
+func kvmXSAVEBufferSize(vmFd int) int {
+	const legacySize = int(unsafe.Sizeof(kvmXSAVE{}))
+	size, err := checkExtension(vmFd, kvmCapXSAVE2)
+	if err != nil || size < uint64(legacySize) {
+		return legacySize
+	}
+	return int(size)
+}
+
 func getXCRS(vcpuFd int) (kvmXCRS, error) {
 	var xcrs kvmXCRS
 	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetXCRS), uintptr(unsafe.Pointer(&xcrs))); err != nil {
@@ -381,7 +437,16 @@ func setCPUIDTopology(cpuid *kvmCPUID2, id, cpus int) {
 					e.Eax = 1
 				}
 				e.Ebx &^= (uint32(1) << 6) | (uint32(1) << 13)
+				e.Ecx &^= uint32(1) << 7
+				e.Edx &^= uint32(1) << 20
 			case 2:
+				e.Eax, e.Ebx, e.Ecx, e.Edx = 0, 0, 0, 0
+			}
+		case 0xd:
+			switch e.Index {
+			case 0:
+				e.Eax &^= (uint32(1) << 11) | (uint32(1) << 12)
+			case 11, 12:
 				e.Eax, e.Ebx, e.Ecx, e.Edx = 0, 0, 0, 0
 			}
 		case 1:

--- a/internal/hv/kvm/snapshot_linux_amd64.go
+++ b/internal/hv/kvm/snapshot_linux_amd64.go
@@ -87,7 +87,8 @@ type kvmSnapshotVCPU struct {
 	MPState   kvmMPState    `json:"mp_state"`
 	Events    kvmVCPUEvents `json:"events"`
 	DebugRegs kvmDebugRegs  `json:"debug_regs"`
-	XSAVE     kvmXSAVE      `json:"xsave"`
+	XSAVE     *kvmXSAVE     `json:"xsave,omitempty"`
+	XSAVEData []byte        `json:"xsave_data,omitempty"`
 	XCRS      kvmXCRS       `json:"xcrs"`
 }
 
@@ -578,7 +579,7 @@ func snapshotKVMVCPU(vm *VM, index int) (kvmSnapshotVCPU, error) {
 	if err != nil {
 		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM debug regs: %w", err)
 	}
-	xsave, err := getXSAVE(vcpu.fd)
+	xsave, err := getXSAVEBytes(vm.vmfd, vcpu.fd)
 	if err != nil {
 		return kvmSnapshotVCPU{}, fmt.Errorf("capture KVM xsave: %w", err)
 	}
@@ -595,7 +596,7 @@ func snapshotKVMVCPU(vm *VM, index int) (kvmSnapshotVCPU, error) {
 		MPState:   mpState,
 		Events:    events,
 		DebugRegs: debugRegs,
-		XSAVE:     xsave,
+		XSAVEData: xsave,
 		XCRS:      xcrs,
 	}, nil
 }
@@ -617,7 +618,11 @@ func restoreKVMVCPU(vm *VM, index int, state kvmSnapshotVCPU) error {
 	if err := setXCRS(vcpu.fd, &state.XCRS); err != nil {
 		return fmt.Errorf("restore KVM xcrs: %w", err)
 	}
-	if err := setXSAVE(vcpu.fd, &state.XSAVE); err != nil {
+	xsave := state.XSAVEData
+	if len(xsave) == 0 {
+		xsave = legacyXSAVEBytes(state.XSAVE)
+	}
+	if err := setXSAVEBytes(vm.vmfd, vcpu.fd, xsave); err != nil {
 		return fmt.Errorf("restore KVM xsave: %w", err)
 	}
 	if err := setLAPIC(vcpu.fd, &state.LAPIC); err != nil {


### PR DESCRIPTION
## Summary
- hide CET xstate from linux/amd64 KVM guests so startup snapshots do not restore unsupported CET state
- store KVM XSAVE state with a `KVM_CAP_XSAVE2`-sized payload and keep legacy manifest fallback

## Root Cause
Alpine enabled CET xstate (`0x18e7`). Startup snapshot restore did not capture and restore the full CET processor/MSR state, so the restored guest faulted in `restore_fpregs_from_fpstate`.

## Impact
Guests no longer see CET support in CPUID on this KVM path. Host CET is unaffected. This avoids advertising processor state that the snapshot path cannot restore reliably.

## Validation
- `go test ./internal/vm -run TestRuntimeRestoresPersistentLinuxFromStartupSnapshot -count=1`
- `go test ./internal/hv/kvm -count=1`