### PR TITLE
Avoid duplicate pprof route registration

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -39,7 +39,6 @@ func isBuiltInBSDImage(name string) bool {
 }
 
 var debugTiming = strings.TrimSpace(os.Getenv("CCX3_DEBUG_TIMING")) != ""
-var debugPprof = strings.TrimSpace(os.Getenv("CCX3_DEBUG_PPROF")) != ""
 var bootEventWriteMu sync.Mutex
 
 const defaultVMBootTimeout = 5 * time.Second
@@ -791,20 +790,10 @@ func newServerShutdown(srvState *server, httpServer *http.Server) func() {
 
 func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opts ServerOptions) *http.ServeMux {
 	mux := http.NewServeMux()
-	if debugPprof {
+	if pprofEnabled() {
 		runtime.SetBlockProfileRate(1)
 		runtime.SetMutexProfileFraction(1)
 		registerPprofHandlers(mux)
-	}
-
-	if strings.TrimSpace(os.Getenv("CCX3_PPROF")) != "" {
-		runtime.SetMutexProfileFraction(1)
-		runtime.SetBlockProfileRate(1)
-		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
-		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 	}
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -1662,6 +1651,11 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		},
 	})
 	return mux
+}
+
+func pprofEnabled() bool {
+	return strings.TrimSpace(os.Getenv("CCX3_DEBUG_PPROF")) != "" ||
+		strings.TrimSpace(os.Getenv("CCX3_PPROF")) != ""
 }
 
 func resolveCacheDir(arg string) (string, error) {

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -77,6 +77,34 @@ func TestMuxHealthStatusWatchdogAndShutdown(t *testing.T) {
 	}
 }
 
+func TestMuxPprofEnvironmentCombinations(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		debug string
+		plain string
+		want  int
+	}{
+		{name: "disabled", want: http.StatusNotFound},
+		{name: "debug", debug: "1", want: http.StatusOK},
+		{name: "plain", plain: "1", want: http.StatusOK},
+		{name: "both", debug: "1", plain: "1", want: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CCX3_DEBUG_PPROF", tc.debug)
+			t.Setenv("CCX3_PPROF", tc.plain)
+			watchdog := newWatchdogController(func() {})
+			defer watchdog.Stop()
+
+			mux := newMux(&server{vms: vm.NewManagerWithHost(nil)}, watchdog, func() {}, ServerOptions{})
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+			if rr.Code != tc.want {
+				t.Fatalf("pprof status = %d, want %d", rr.Code, tc.want)
+			}
+		})
+	}
+}
+
 func TestPersistentWatchdogDoesNotShutdownWhenLeasesEnd(t *testing.T) {
 	shutdownCalled := make(chan struct{}, 1)
 	watchdog := newPersistentWatchdogController(func() {


### PR DESCRIPTION
## What changed

- normalize `CCX3_DEBUG_PPROF` and `CCX3_PPROF` into one enablement decision
- register the complete pprof route set exactly once
- cover all four environment-variable combinations

## Why

Each flag previously registered overlapping patterns on the same `http.ServeMux`. Setting both caused startup to panic on duplicate route registration.

## Impact

Either flag enables the same complete profiling surface. Setting both is deterministic and no longer panics; setting neither leaves pprof unavailable.

## Validation

- `go test ./internal/ccvmd -run 'TestMuxPprofEnvironmentCombinations|TestMuxHealthStatusWatchdogAndShutdown' -count=10`
- `go test ./...`

Closes #59
