### PR TITLE
Preserve watchdog lease timeouts

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -122,14 +123,26 @@ type watchdogController struct {
 	mu          sync.Mutex
 	timeout     time.Duration
 	deadline    time.Time
-	timer       *time.Timer
+	timer       watchdogTimer
 	active      bool
-	leases      map[string]time.Time
+	leases      map[string]watchdogLease
 	onExpired   func()
 	persistent  bool
+	now         func() time.Time
+	afterFunc   func(time.Duration, func()) watchdogTimer
 	cvmfsEvents uint64
 	cvmfsBytes  int64
 	cvmfsLast   time.Time
+}
+
+type watchdogLease struct {
+	timeout  time.Duration
+	deadline time.Time
+}
+
+type watchdogTimer interface {
+	Stop() bool
+	Reset(time.Duration) bool
 }
 
 type watchdogRequest struct {
@@ -137,7 +150,13 @@ type watchdogRequest struct {
 }
 
 func newWatchdogController(onExpired func()) *watchdogController {
-	return &watchdogController{onExpired: onExpired}
+	return &watchdogController{
+		onExpired: onExpired,
+		now:       time.Now,
+		afterFunc: func(delay time.Duration, fn func()) watchdogTimer {
+			return time.AfterFunc(delay, fn)
+		},
+	}
 }
 
 func newPersistentWatchdogController(onExpired func()) *watchdogController {
@@ -150,13 +169,14 @@ func (w *watchdogController) Create(timeout time.Duration) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.timeout = timeout
-	w.deadline = time.Now().Add(timeout)
+	now := w.now()
+	w.deadline = now.Add(timeout)
 	w.active = true
 	if w.timer == nil {
-		w.timer = time.AfterFunc(timeout, w.expire)
+		w.timer = w.afterFunc(timeout, w.expire)
 		return
 	}
-	w.resetTimerLocked(time.Now())
+	w.resetTimerLocked(now)
 }
 
 func (w *watchdogController) Feed() bool {
@@ -173,7 +193,7 @@ func (w *watchdogController) RecordCVMFSActivity(bytes int) {
 	defer w.mu.Unlock()
 	w.cvmfsEvents++
 	w.cvmfsBytes += int64(bytes)
-	w.cvmfsLast = time.Now()
+	w.cvmfsLast = w.now()
 }
 
 func (w *watchdogController) ActivityState() client.WatchdogActivityState {
@@ -185,7 +205,7 @@ func (w *watchdogController) ActivityState() client.WatchdogActivityState {
 	}
 	if !w.cvmfsLast.IsZero() {
 		cvmfs.LastActivityUnix = w.cvmfsLast.Unix()
-		cvmfs.SecondsSinceLast = time.Since(w.cvmfsLast).Seconds()
+		cvmfs.SecondsSinceLast = w.now().Sub(w.cvmfsLast).Seconds()
 	}
 	return client.WatchdogActivityState{CVMFS: cvmfs}
 }
@@ -201,25 +221,27 @@ func (w *watchdogController) CreateLease(timeout time.Duration) (string, error) 
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.leases == nil {
-		w.leases = map[string]time.Time{}
+		w.leases = map[string]watchdogLease{}
 	}
-	now := time.Now()
-	w.leases[id] = now.Add(timeout)
+	now := w.now()
+	w.leases[id] = watchdogLease{timeout: timeout, deadline: now.Add(timeout)}
 	w.resetTimerLocked(now)
 	return id, nil
 }
 
-func (w *watchdogController) FeedLease(id string, timeout time.Duration) bool {
+func (w *watchdogController) FeedLease(id string) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.leases == nil {
 		return false
 	}
-	if _, ok := w.leases[id]; !ok {
+	lease, ok := w.leases[id]
+	if !ok {
 		return false
 	}
-	now := time.Now()
-	w.leases[id] = now.Add(timeout)
+	now := w.now()
+	lease.deadline = now.Add(lease.timeout)
+	w.leases[id] = lease
 	w.resetTimerLocked(now)
 	return true
 }
@@ -244,7 +266,7 @@ func (w *watchdogController) ReleaseLease(id string) bool {
 			onExpired = w.onExpired
 		}
 	} else {
-		w.resetTimerLocked(time.Now())
+		w.resetTimerLocked(w.now())
 	}
 	w.mu.Unlock()
 	if onExpired != nil {
@@ -257,8 +279,9 @@ func (w *watchdogController) feedLocked() bool {
 	if !w.active || w.timer == nil {
 		return false
 	}
-	w.deadline = time.Now().Add(w.timeout)
-	w.resetTimerLocked(time.Now())
+	now := w.now()
+	w.deadline = now.Add(w.timeout)
+	w.resetTimerLocked(now)
 	return true
 }
 
@@ -274,9 +297,9 @@ func (w *watchdogController) Stop() {
 func (w *watchdogController) expire() {
 	var onExpired func()
 	w.mu.Lock()
-	now := time.Now()
-	for id, deadline := range w.leases {
-		if !deadline.After(now) {
+	now := w.now()
+	for id, lease := range w.leases {
+		if !lease.deadline.After(now) {
 			delete(w.leases, id)
 		}
 	}
@@ -308,9 +331,9 @@ func (w *watchdogController) resetTimerLocked(now time.Time) {
 	if w.active && !w.deadline.IsZero() {
 		next = w.deadline
 	}
-	for _, deadline := range w.leases {
-		if next.IsZero() || deadline.Before(next) {
-			next = deadline
+	for _, lease := range w.leases {
+		if next.IsZero() || lease.deadline.Before(next) {
+			next = lease.deadline
 		}
 	}
 	if next.IsZero() {
@@ -324,7 +347,7 @@ func (w *watchdogController) resetTimerLocked(now time.Time) {
 		delay = time.Millisecond
 	}
 	if w.timer == nil {
-		w.timer = time.AfterFunc(delay, w.expire)
+		w.timer = w.afterFunc(delay, w.expire)
 		return
 	}
 	w.timer.Stop()
@@ -882,9 +905,9 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
-		timeout := time.Duration(req.TimeoutSeconds * float64(time.Second))
-		if timeout <= 0 {
-			writeError(w, http.StatusBadRequest, fmt.Errorf("watchdog lease timeout must be positive"))
+		timeout, err := watchdogLeaseDuration(req.TimeoutSeconds)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
 			return
 		}
 		id, err := watchdog.CreateLease(timeout)
@@ -892,7 +915,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			writeError(w, http.StatusInternalServerError, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, client.WatchdogLeaseResponse{LeaseID: id, TimeoutSeconds: req.TimeoutSeconds})
+		writeJSON(w, http.StatusOK, client.WatchdogLeaseResponse{LeaseID: id, TimeoutSeconds: timeout.Seconds()})
 	})
 
 	mux.HandleFunc("POST /watchdog/lease/feed", func(w http.ResponseWriter, r *http.Request) {
@@ -905,11 +928,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
-		timeout := time.Duration(req.TimeoutSeconds * float64(time.Second))
-		if timeout <= 0 {
-			timeout = 10 * time.Second
-		}
-		if !watchdog.FeedLease(req.LeaseID, timeout) {
+		if !watchdog.FeedLease(req.LeaseID) {
 			writeError(w, http.StatusConflict, fmt.Errorf("watchdog lease is not active"))
 			return
 		}
@@ -1688,6 +1707,21 @@ func registerPprofHandlers(mux *http.ServeMux) {
 	mux.Handle("GET /debug/pprof/heap", pprof.Handler("heap"))
 	mux.Handle("GET /debug/pprof/mutex", pprof.Handler("mutex"))
 	mux.Handle("GET /debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+}
+
+func watchdogLeaseDuration(seconds float64) (time.Duration, error) {
+	if seconds <= 0 || math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		return 0, fmt.Errorf("watchdog lease timeout must be a finite positive duration")
+	}
+	nanoseconds := seconds * float64(time.Second)
+	if nanoseconds >= float64(uint64(1)<<63) {
+		return 0, fmt.Errorf("watchdog lease timeout is too large")
+	}
+	timeout := time.Duration(nanoseconds)
+	if timeout <= 0 {
+		return 0, fmt.Errorf("watchdog lease timeout is below timer resolution")
+	}
+	return timeout, nil
 }
 
 func sharedRuntimeRoot() string {

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,6 +101,100 @@ func TestPersistentWatchdogDoesNotShutdownWhenLeasesEnd(t *testing.T) {
 	assertNoShutdown(t, shutdownCalled)
 }
 
+func TestWatchdogLeaseFeedsPreserveCreatedTimeout(t *testing.T) {
+	clock := &fakeWatchdogClock{now: time.Unix(100, 0)}
+	expired := 0
+	watchdog := newWatchdogController(func() { expired++ })
+	watchdog.now = clock.Now
+	watchdog.afterFunc = clock.AfterFunc
+	defer watchdog.Stop()
+
+	id, err := watchdog.CreateLease(5 * time.Second)
+	if err != nil {
+		t.Fatalf("create lease: %v", err)
+	}
+	clock.Advance(4 * time.Second)
+	if !watchdog.FeedLease(id) {
+		t.Fatal("first lease feed failed")
+	}
+	clock.Advance(4 * time.Second)
+	if expired != 0 {
+		t.Fatalf("lease expired before its created timeout after first feed")
+	}
+	if !watchdog.FeedLease(id) {
+		t.Fatal("second lease feed failed")
+	}
+	clock.Advance(4 * time.Second)
+	if expired != 0 {
+		t.Fatalf("lease expired before its created timeout after second feed")
+	}
+	clock.Advance(time.Second)
+	if expired != 1 {
+		t.Fatalf("expiry callbacks = %d, want 1 at the preserved deadline", expired)
+	}
+}
+
+type fakeWatchdogClock struct {
+	now   time.Time
+	timer *fakeWatchdogTimer
+}
+
+func (c *fakeWatchdogClock) Now() time.Time { return c.now }
+
+func (c *fakeWatchdogClock) AfterFunc(delay time.Duration, fn func()) watchdogTimer {
+	timer := &fakeWatchdogTimer{clock: c, deadline: c.now.Add(delay), fn: fn}
+	c.timer = timer
+	return timer
+}
+
+func (c *fakeWatchdogClock) Advance(delay time.Duration) {
+	c.now = c.now.Add(delay)
+	if c.timer == nil || c.timer.stopped || c.timer.deadline.After(c.now) {
+		return
+	}
+	c.timer.stopped = true
+	c.timer.fn()
+}
+
+type fakeWatchdogTimer struct {
+	clock    *fakeWatchdogClock
+	deadline time.Time
+	fn       func()
+	stopped  bool
+}
+
+func (t *fakeWatchdogTimer) Stop() bool {
+	wasActive := !t.stopped
+	t.stopped = true
+	return wasActive
+}
+
+func (t *fakeWatchdogTimer) Reset(delay time.Duration) bool {
+	wasActive := !t.stopped
+	t.deadline = t.clock.now.Add(delay)
+	t.stopped = false
+	return wasActive
+}
+
+func TestWatchdogLeaseDurationRejectsInvalidValues(t *testing.T) {
+	for _, seconds := range []float64{
+		-1,
+		0,
+		math.SmallestNonzeroFloat64,
+		math.Inf(1),
+		math.Inf(-1),
+		math.NaN(),
+		1e100,
+	} {
+		if _, err := watchdogLeaseDuration(seconds); err == nil {
+			t.Fatalf("watchdogLeaseDuration(%v) returned no error", seconds)
+		}
+	}
+	if got, err := watchdogLeaseDuration(0.25); err != nil || got != 250*time.Millisecond {
+		t.Fatalf("watchdogLeaseDuration(0.25) = %s, %v", got, err)
+	}
+}
+
 func assertNoShutdown(t *testing.T, shutdownCalled <-chan struct{}) {
 	t.Helper()
 	select {
@@ -122,6 +217,7 @@ func TestMuxBadRequests(t *testing.T) {
 		status int
 	}{
 		{name: "bad lease json", method: http.MethodPost, target: "/watchdog/lease", body: []byte("{"), status: http.StatusBadRequest},
+		{name: "overflowing lease timeout", method: http.MethodPost, target: "/watchdog/lease", body: []byte(`{"timeout_seconds":1e100}`), status: http.StatusBadRequest},
 		{name: "bad run json", method: http.MethodPost, target: "/vm/run", body: []byte("{"), status: http.StatusBadRequest},
 		{name: "forward stopped vm", method: http.MethodPost, target: "/vm/forward?id=alpha", body: mustJSON(t, client.PortForward{HostPort: 8080, GuestPort: 80}), status: http.StatusBadRequest},
 	} {


### PR DESCRIPTION
## What changed

- store each watchdog lease's negotiated timeout together with its deadline
- make feeds extend a lease by that stored timeout instead of accepting an implicit ten-second default
- validate finite, positive, representable timeout values before `time.Duration` conversion
- inject clock/timer behavior into the controller for deterministic expiry coverage
- report the actual representable timeout negotiated by the server

## Why

The client intentionally feeds with only a lease ID. The server previously converted the omitted timeout to ten seconds, changing every non-default lease after its first feed. Unchecked floating-point conversion also allowed invalid and overflowing durations to reach timer logic.

## Impact

Repeated feeds now preserve short and long lease policies exactly. Invalid, sub-resolution, infinite, and overflowing durations are rejected with a bad request.

## Validation

- fake-clock tests drive real timer reset and expiry callbacks across repeated feeds
- `go test -race ./internal/ccvmd -run 'TestWatchdogLeaseFeedsPreserveCreatedTimeout|TestWatchdogLeaseDurationRejectsInvalidValues|TestMuxBadRequests' -count=10`
- `go test ./internal/ccvmd -count=1`
- `go test ./...`

Closes #62
