### PR TITLE
Safely prepare worker control sockets

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -447,16 +447,23 @@ func writeStartupError(w interface{ Write([]byte) (int, error) }, err error) err
 }
 
 func runWorkerControlSocket(socketPath string, srvState *server, opts ServerOptions) (bool, error) {
-	listenNetwork, listenAddress, cleanup, err := workerControlListenEndpoint(socketPath)
+	listenNetwork, listenAddress, err := workerControlListenEndpoint(socketPath)
 	if err != nil {
 		return false, err
 	}
-	defer cleanup()
 	l, err := net.Listen(listenNetwork, listenAddress)
 	if err != nil {
 		return false, fmt.Errorf("listen worker control socket: %w", err)
 	}
+	if unixListener, ok := l.(*net.UnixListener); ok {
+		unixListener.SetUnlinkOnClose(false)
+	}
 	defer l.Close()
+	cleanup, err := workerControlSocketCleanup(listenNetwork, listenAddress)
+	if err != nil {
+		return false, fmt.Errorf("capture worker control socket ownership: %w", err)
+	}
+	defer cleanup()
 	if err := json.NewEncoder(os.Stdout).Encode(client.ServerHello{Kind: "worker", Addr: workerControlDialEndpoint(listenNetwork, l.Addr().String())}); err != nil {
 		return false, fmt.Errorf("write worker startup banner: %w", err)
 	}
@@ -487,16 +494,24 @@ func runWorkerControlSocket(socketPath string, srvState *server, opts ServerOpti
 	return true, serveWorkerControl(codec, srvState, opts)
 }
 
-func workerControlListenEndpoint(address string) (network string, listenAddress string, cleanup func(), err error) {
-	cleanup = func() {}
+func workerControlListenEndpoint(address string) (network string, listenAddress string, err error) {
 	if strings.HasPrefix(address, "tcp://") {
-		return "tcp", strings.TrimPrefix(address, "tcp://"), cleanup, nil
+		return "tcp", strings.TrimPrefix(address, "tcp://"), nil
 	}
 	if err := os.MkdirAll(filepath.Dir(address), 0o700); err != nil {
-		return "", "", cleanup, fmt.Errorf("prepare worker control socket dir: %w", err)
+		return "", "", fmt.Errorf("prepare worker control socket dir: %w", err)
 	}
-	_ = os.Remove(address)
-	return "unix", address, func() { _ = os.Remove(address) }, nil
+	if err := prepareWorkerUnixSocket(address); err != nil {
+		return "", "", err
+	}
+	return "unix", address, nil
+}
+
+func workerControlSocketCleanup(network, address string) (func(), error) {
+	if network != "unix" {
+		return func() {}, nil
+	}
+	return ownedWorkerUnixSocketCleanup(address)
 }
 
 func workerControlDialEndpoint(network string, address string) string {

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -75,6 +79,141 @@ func TestMuxHealthStatusWatchdogAndShutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("shutdown callback was not called")
 	}
+}
+
+func TestWorkerControlSocketPreparationProtectsExistingPaths(t *testing.T) {
+	t.Run("regular file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "control.sock")
+		if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+			t.Fatalf("write regular file: %v", err)
+		}
+		if _, _, err := workerControlListenEndpoint(path); err == nil {
+			t.Fatal("regular worker path was accepted")
+		}
+		if data, err := os.ReadFile(path); err != nil || string(data) != "keep" {
+			t.Fatalf("regular worker path changed: data=%q err=%v", data, err)
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "control.sock")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatalf("create directory: %v", err)
+		}
+		if _, _, err := workerControlListenEndpoint(path); err == nil {
+			t.Fatal("directory worker path was accepted")
+		}
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Fatalf("worker directory changed: info=%v err=%v", info, err)
+		}
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires additional Windows privileges")
+		}
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		if err := os.WriteFile(target, []byte("keep"), 0o600); err != nil {
+			t.Fatalf("write symlink target: %v", err)
+		}
+		path := filepath.Join(dir, "control.sock")
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatalf("create symlink: %v", err)
+		}
+		if _, _, err := workerControlListenEndpoint(path); err == nil {
+			t.Fatal("symlink worker path was accepted")
+		}
+		if data, err := os.ReadFile(target); err != nil || string(data) != "keep" {
+			t.Fatalf("symlink target changed: data=%q err=%v", data, err)
+		}
+		if info, err := os.Lstat(path); err != nil || info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("worker symlink changed: info=%v err=%v", info, err)
+		}
+	})
+}
+
+func TestWorkerControlSocketDetectsLiveAndRecoversStaleEndpoint(t *testing.T) {
+	dir := shortWorkerSocketTempDir(t)
+	livePath := filepath.Join(dir, "live.sock")
+	live := listenUnixWithoutAutomaticUnlink(t, livePath)
+	defer func() {
+		_ = live.Close()
+		_ = os.Remove(livePath)
+	}()
+	if _, _, err := workerControlListenEndpoint(livePath); err == nil {
+		t.Fatal("live worker socket was treated as stale")
+	}
+	if info, err := os.Lstat(livePath); err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("live worker socket changed: info=%v err=%v", info, err)
+	}
+
+	stalePath := filepath.Join(dir, "stale.sock")
+	stale := listenUnixWithoutAutomaticUnlink(t, stalePath)
+	if err := stale.Close(); err != nil {
+		t.Fatalf("close stale listener: %v", err)
+	}
+	network, address, err := workerControlListenEndpoint(stalePath)
+	if err != nil {
+		t.Fatalf("recover stale worker socket: %v", err)
+	}
+	if network != "unix" || address != stalePath {
+		t.Fatalf("recovered endpoint = %q %q", network, address)
+	}
+	if _, err := os.Lstat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale socket still exists: %v", err)
+	}
+	recovered := listenUnixWithoutAutomaticUnlink(t, stalePath)
+	_ = recovered.Close()
+	_ = os.Remove(stalePath)
+}
+
+func TestWorkerControlSocketCleanupDoesNotRemoveReplacement(t *testing.T) {
+	path := filepath.Join(shortWorkerSocketTempDir(t), "control.sock")
+	listener := listenUnixWithoutAutomaticUnlink(t, path)
+	cleanup, err := workerControlSocketCleanup("unix", path)
+	if err != nil {
+		t.Fatalf("capture socket cleanup: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove owned socket path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	cleanup()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "replacement" {
+		t.Fatalf("replacement changed by cleanup: data=%q err=%v", data, err)
+	}
+}
+
+func listenUnixWithoutAutomaticUnlink(t *testing.T, path string) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen on Unix socket: %v", err)
+	}
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		unixListener.SetUnlinkOnClose(false)
+	}
+	return listener
+}
+
+func shortWorkerSocketTempDir(t *testing.T) string {
+	t.Helper()
+	base := os.TempDir()
+	if runtime.GOOS != "windows" {
+		base = "/tmp"
+	}
+	dir, err := os.MkdirTemp(base, "ccvmd-")
+	if err != nil {
+		t.Fatalf("create short socket temp directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 func TestPersistentWatchdogDoesNotShutdownWhenLeasesEnd(t *testing.T) {

--- a/internal/ccvmd/worker_socket.go
+++ b/internal/ccvmd/worker_socket.go
@@ -1,0 +1,87 @@
+package ccvmd
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+const workerSocketProbeTimeout = 250 * time.Millisecond
+
+func prepareWorkerUnixSocket(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect worker control socket: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("worker control path already exists and is not a socket")
+	}
+	owned, err := workerSocketOwnedByCurrentUser(info)
+	if err != nil {
+		return fmt.Errorf("inspect worker control socket owner: %w", err)
+	}
+	if !owned {
+		return fmt.Errorf("worker control socket is not owned by the current user")
+	}
+
+	conn, dialErr := net.DialTimeout("unix", path, workerSocketProbeTimeout)
+	if dialErr == nil {
+		_ = conn.Close()
+		return fmt.Errorf("worker control socket is already active")
+	}
+	if errors.Is(dialErr, os.ErrNotExist) || errors.Is(dialErr, syscall.ENOENT) {
+		return nil
+	}
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return fmt.Errorf("worker control socket could not be proven stale: %w", dialErr)
+	}
+	if err := removeWorkerSocketIfSame(path, info); err != nil {
+		return fmt.Errorf("remove stale worker control socket: %w", err)
+	}
+	return nil
+}
+
+func ownedWorkerUnixSocketCleanup(path string) (func(), error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return nil, fmt.Errorf("worker control listener path is not a socket")
+	}
+	owned, err := workerSocketOwnedByCurrentUser(info)
+	if err != nil {
+		return nil, err
+	}
+	if !owned {
+		return nil, fmt.Errorf("worker control listener is not owned by the current user")
+	}
+	return func() { _ = removeWorkerSocketIfSame(path, info) }, nil
+}
+
+func removeWorkerSocketIfSame(path string, expected os.FileInfo) error {
+	current, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if current.Mode()&os.ModeSocket == 0 || !os.SameFile(expected, current) {
+		return fmt.Errorf("worker control socket path changed ownership")
+	}
+	owned, err := workerSocketOwnedByCurrentUser(current)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return fmt.Errorf("worker control socket is not owned by the current user")
+	}
+	return os.Remove(path)
+}

--- a/internal/ccvmd/worker_socket.go
+++ b/internal/ccvmd/worker_socket.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -35,10 +34,10 @@ func prepareWorkerUnixSocket(path string) error {
 		_ = conn.Close()
 		return fmt.Errorf("worker control socket is already active")
 	}
-	if errors.Is(dialErr, os.ErrNotExist) || errors.Is(dialErr, syscall.ENOENT) {
+	if errors.Is(dialErr, os.ErrNotExist) {
 		return nil
 	}
-	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+	if !workerSocketConnectionRefused(dialErr) {
 		return fmt.Errorf("worker control socket could not be proven stale: %w", dialErr)
 	}
 	if err := removeWorkerSocketIfSame(path, info); err != nil {

--- a/internal/ccvmd/worker_socket_unix.go
+++ b/internal/ccvmd/worker_socket_unix.go
@@ -3,10 +3,15 @@
 package ccvmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
 )
+
+func workerSocketConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}
 
 func workerSocketOwnedByCurrentUser(info os.FileInfo) (bool, error) {
 	stat, ok := info.Sys().(*syscall.Stat_t)

--- a/internal/ccvmd/worker_socket_unix.go
+++ b/internal/ccvmd/worker_socket_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package ccvmd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func workerSocketOwnedByCurrentUser(info os.FileInfo) (bool, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("worker socket has unsupported stat metadata")
+	}
+	return stat.Uid == uint32(os.Geteuid()), nil
+}

--- a/internal/ccvmd/worker_socket_windows.go
+++ b/internal/ccvmd/worker_socket_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package ccvmd
+
+import "os"
+
+func workerSocketOwnedByCurrentUser(os.FileInfo) (bool, error) {
+	// Access to the path is governed by the worker directory ACL on Windows.
+	return true, nil
+}

--- a/internal/ccvmd/worker_socket_windows.go
+++ b/internal/ccvmd/worker_socket_windows.go
@@ -2,7 +2,17 @@
 
 package ccvmd
 
-import "os"
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+const wsaeconnrefused syscall.Errno = 10061
+
+func workerSocketConnectionRefused(err error) bool {
+	return errors.Is(err, wsaeconnrefused)
+}
 
 func workerSocketOwnedByCurrentUser(os.FileInfo) (bool, error) {
 	// Access to the path is governed by the worker directory ACL on Windows.


### PR DESCRIPTION
## What changed

- inspect configured Unix worker paths with `Lstat` before binding
- reject regular files, directories, symlinks, and sockets not owned by the current Unix user
- probe owned sockets and only remove endpoints that fail with connection refused
- capture the newly bound socket's identity for generation-safe cleanup
- disable the Unix listener's automatic pathname unlink so cleanup cannot delete a replacement path
- keep TCP worker endpoints unchanged

## Why

Worker startup previously called `os.Remove` on the configured path unconditionally. A typo or malicious path could delete unrelated data, and shutdown could also unlink a replacement endpoint.

## Impact

Live workers are detected, unrelated filesystem objects are preserved, and demonstrably stale owned sockets remain recoverable. Cleanup only removes the socket inode created by the current worker.

## Validation

- repeated behavior tests for files, directories, symlinks, live sockets, stale sockets, and cleanup replacement
- `go test -race ./internal/ccvmd -run 'TestWorkerControlSocket' -count=10`
- `go test ./...`
- `GOOS=windows GOARCH=arm64 go test -c ./internal/ccvmd`

Closes #65
