### PR TITLE
Enforce private worker control permissions

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -457,6 +457,11 @@ func runWorkerControlSocket(socketPath string, srvState *server, opts ServerOpti
 		return false, fmt.Errorf("listen worker control socket: %w", err)
 	}
 	defer l.Close()
+	if listenNetwork == "unix" {
+		if err := secureWorkerControlSocket(listenAddress); err != nil {
+			return false, fmt.Errorf("secure worker control socket: %w", err)
+		}
+	}
 	if err := json.NewEncoder(os.Stdout).Encode(client.ServerHello{Kind: "worker", Addr: workerControlDialEndpoint(listenNetwork, l.Addr().String())}); err != nil {
 		return false, fmt.Errorf("write worker startup banner: %w", err)
 	}
@@ -494,6 +499,9 @@ func workerControlListenEndpoint(address string) (network string, listenAddress 
 	}
 	if err := os.MkdirAll(filepath.Dir(address), 0o700); err != nil {
 		return "", "", cleanup, fmt.Errorf("prepare worker control socket dir: %w", err)
+	}
+	if err := validateWorkerControlDirectory(filepath.Dir(address)); err != nil {
+		return "", "", cleanup, fmt.Errorf("validate worker control socket dir: %w", err)
 	}
 	_ = os.Remove(address)
 	return "unix", address, func() { _ = os.Remove(address) }, nil

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -75,6 +79,86 @@ func TestMuxHealthStatusWatchdogAndShutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("shutdown callback was not called")
 	}
+}
+
+func TestWorkerControlEndpointPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix ownership and mode semantics are not available on Windows")
+	}
+	t.Run("private parent and socket", func(t *testing.T) {
+		root := shortCCVMDSocketDir(t)
+		path := filepath.Join(root, "private", "control.sock")
+		network, address, cleanup, err := workerControlListenEndpoint(path)
+		if err != nil {
+			t.Fatalf("prepare endpoint: %v", err)
+		}
+		defer cleanup()
+		parentInfo, err := os.Lstat(filepath.Dir(path))
+		if err != nil {
+			t.Fatalf("stat parent: %v", err)
+		}
+		if parentInfo.Mode().Perm() != 0o700 {
+			t.Fatalf("parent permissions = %04o, want 0700", parentInfo.Mode().Perm())
+		}
+
+		listener, err := net.Listen(network, address)
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer listener.Close()
+		if err := secureWorkerControlSocket(path); err != nil {
+			t.Fatalf("secure socket: %v", err)
+		}
+		socketInfo, err := os.Lstat(path)
+		if err != nil {
+			t.Fatalf("stat socket: %v", err)
+		}
+		if socketInfo.Mode().Perm() != 0o600 || socketInfo.Mode()&os.ModeSocket == 0 {
+			t.Fatalf("socket mode = %v, want owner-only socket", socketInfo.Mode())
+		}
+	})
+
+	t.Run("insecure existing parent", func(t *testing.T) {
+		parent := filepath.Join(shortCCVMDSocketDir(t), "open")
+		if err := os.Mkdir(parent, 0o700); err != nil {
+			t.Fatalf("create parent: %v", err)
+		}
+		if err := os.Chmod(parent, 0o755); err != nil {
+			t.Fatalf("make parent insecure: %v", err)
+		}
+		path := filepath.Join(parent, "control.sock")
+		if _, _, _, err := workerControlListenEndpoint(path); err == nil {
+			t.Fatal("insecure worker parent was accepted")
+		}
+		if info, err := os.Stat(parent); err != nil || info.Mode().Perm() != 0o755 {
+			t.Fatalf("insecure parent was modified: info=%v err=%v", info, err)
+		}
+	})
+
+	t.Run("symlink parent", func(t *testing.T) {
+		root := shortCCVMDSocketDir(t)
+		target := filepath.Join(root, "target")
+		if err := os.Mkdir(target, 0o700); err != nil {
+			t.Fatalf("create target: %v", err)
+		}
+		parent := filepath.Join(root, "linked")
+		if err := os.Symlink(target, parent); err != nil {
+			t.Fatalf("create parent symlink: %v", err)
+		}
+		if _, _, _, err := workerControlListenEndpoint(filepath.Join(parent, "control.sock")); err == nil {
+			t.Fatal("symlink worker parent was accepted")
+		}
+	})
+}
+
+func shortCCVMDSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ccvmd-")
+	if err != nil {
+		t.Fatalf("create short socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 func TestPersistentWatchdogDoesNotShutdownWhenLeasesEnd(t *testing.T) {

--- a/internal/ccvmd/worker_permissions_unix.go
+++ b/internal/ccvmd/worker_permissions_unix.go
@@ -1,0 +1,62 @@
+//go:build !windows
+
+package ccvmd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func validateWorkerControlDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("worker control parent is not a real directory")
+	}
+	if info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("worker control parent permissions are %04o, want 0700", info.Mode().Perm())
+	}
+	owned, err := workerControlPathOwnedByCurrentUser(info)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return fmt.Errorf("worker control parent is not owned by the current user")
+	}
+	return nil
+}
+
+func secureWorkerControlSocket(path string) error {
+	if err := os.Chmod(path, 0o600); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("worker control endpoint is not a socket")
+	}
+	if info.Mode().Perm() != 0o600 {
+		return fmt.Errorf("worker control socket permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	owned, err := workerControlPathOwnedByCurrentUser(info)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return fmt.Errorf("worker control socket is not owned by the current user")
+	}
+	return nil
+}
+
+func workerControlPathOwnedByCurrentUser(info os.FileInfo) (bool, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("worker control path has unsupported stat metadata")
+	}
+	return stat.Uid == uint32(os.Geteuid()), nil
+}

--- a/internal/ccvmd/worker_permissions_windows.go
+++ b/internal/ccvmd/worker_permissions_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+
+package ccvmd
+
+func validateWorkerControlDirectory(string) error { return nil }
+func secureWorkerControlSocket(string) error      { return nil }


### PR DESCRIPTION
## What changed

- validate that Unix worker-control parents are real, owner-owned `0700` directories
- fail closed for permissive, foreign-owned, non-directory, or symlink parents
- explicitly chmod bound worker sockets to `0600`
- re-read and verify socket type, mode, and owner before publishing startup discovery
- keep Windows builds supported while Unix ownership rules remain platform-specific

## Why

`MkdirAll(..., 0700)` does not tighten or validate an existing directory, and Unix socket mode otherwise depends on the process umask. A permissive endpoint can expose privileged VM control to another local user.

## Impact

Unix worker control endpoints are owner-only by construction and verification. Insecure existing parents are rejected without modification.

## Validation

- repeated tests for private creation, permissive-parent rejection, and symlink-parent rejection
- `go test -race ./internal/ccvmd -run 'TestWorkerControlEndpointPermissions' -count=10`
- `go test ./...`
- `GOOS=windows GOARCH=arm64 go test -c ./internal/ccvmd`

Closes #66
