### PR TITLE
Reject malformed worker control payloads

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -591,8 +591,10 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 		switch frame.Type {
 		case vm.WorkerFrameStart:
 			var req client.CreateInstanceRequest
-			if err := frame.DecodePayload(&req); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
+			if !decodeWorkerRequest(codec, frame, &req) {
+				continue
+			}
+			if !validateWorkerInstanceID(codec, frame, req.ID) {
 				continue
 			}
 			if opts.NormalizeCreateRequest != nil {
@@ -611,8 +613,10 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStartResponse{State: state})
 		case vm.WorkerFrameStartBlank:
 			var req client.StartInstanceRequest
-			if err := frame.DecodePayload(&req); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
+			if !decodeWorkerRequest(codec, frame, &req) {
+				continue
+			}
+			if !validateWorkerInstanceID(codec, frame, req.ID) {
 				continue
 			}
 			if opts.NormalizeStartRequest != nil {
@@ -631,11 +635,15 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStartResponse{State: state})
 		case vm.WorkerFrameStatus:
 			var req vm.WorkerStatusRequest
-			_ = frame.DecodePayload(&req)
+			if !decodeWorkerRequest(codec, frame, &req) || !validateWorkerInstanceID(codec, frame, req.ID) {
+				continue
+			}
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: srvState.vms.StatusOf(req.ID)})
 		case vm.WorkerFrameStop:
 			var req vm.WorkerStopRequest
-			_ = frame.DecodePayload(&req)
+			if !decodeWorkerRequest(codec, frame, &req) || !validateWorkerInstanceID(codec, frame, req.ID) {
+				continue
+			}
 			if err := srvState.vms.ShutdownInstance(context.Background(), req.ID); err != nil {
 				_ = sendWorkerError(codec, frame.ID, err)
 				continue
@@ -643,11 +651,15 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: srvState.vms.StatusOf(req.ID)})
 		case vm.WorkerFrameWait:
 			var req vm.WorkerWaitRequest
-			_ = frame.DecodePayload(&req)
+			if !decodeWorkerRequest(codec, frame, &req) || !validateWorkerInstanceID(codec, frame, req.ID) {
+				continue
+			}
 			go serveWorkerWait(codec, srvState, frame.ID, req.ID)
 		case vm.WorkerFrameFlush:
 			var req vm.WorkerFlushRequest
-			_ = frame.DecodePayload(&req)
+			if !decodeWorkerRequest(codec, frame, &req) || !validateWorkerInstanceID(codec, frame, req.ID) {
+				continue
+			}
 			if err := srvState.vms.FlushInstance(context.Background(), req.ID); err != nil {
 				_ = sendWorkerError(codec, frame.ID, err)
 				continue
@@ -655,8 +667,7 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "flushed"})
 		case vm.WorkerFrameAddShare:
 			var req vm.WorkerAddShareRequest
-			if err := frame.DecodePayload(&req); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
+			if !decodeWorkerRequest(codec, frame, &req) || !validateWorkerInstanceID(codec, frame, req.ID) {
 				continue
 			}
 			if err := srvState.vms.AddShareTo(context.Background(), req.ID, req.Share); err != nil {
@@ -666,7 +677,9 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "mounted"})
 		case vm.WorkerFrameConsole:
 			var req vm.WorkerConsoleRequest
-			_ = frame.DecodePayload(&req)
+			if !decodeWorkerRequest(codec, frame, &req) || !validateWorkerInstanceID(codec, frame, req.ID) {
+				continue
+			}
 			history, err := srvState.vms.ConsoleHistory(context.Background(), req.ID)
 			if err != nil {
 				_ = sendWorkerError(codec, frame.ID, err)
@@ -675,12 +688,11 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerConsoleResponse{History: history})
 		case vm.WorkerFrameExec:
 			if err := serveWorkerExec(codec, srvState, frame, &activeMu, activeExecs); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
+				_ = sendWorkerRequestError(codec, frame, err)
 			}
 		case vm.WorkerFrameExecInput:
 			var req vm.WorkerExecInput
-			if err := frame.DecodePayload(&req); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
+			if !decodeWorkerRequest(codec, frame, &req) {
 				continue
 			}
 			activeMu.Lock()
@@ -697,6 +709,10 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 				_ = sendWorkerError(codec, frame.ID, fmt.Errorf("worker exec input queue is full"))
 			}
 		case vm.WorkerFrameCancel:
+			var req vm.WorkerCancelRequest
+			if !decodeWorkerRequest(codec, frame, &req) {
+				continue
+			}
 			activeMu.Lock()
 			exec := activeExecs[frame.ID]
 			activeMu.Unlock()
@@ -727,6 +743,9 @@ func serveWorkerExec(codec *vm.WorkerCodec, srvState *server, frame vm.WorkerFra
 	var req vm.WorkerExecRequest
 	if err := frame.DecodePayload(&req); err != nil {
 		return err
+	}
+	if strings.TrimSpace(req.ID) == "" {
+		return fmt.Errorf("worker instance id is required")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	exec := &workerActiveExec{cancel: cancel}
@@ -771,6 +790,30 @@ func sendWorkerPayload(codec *vm.WorkerCodec, id uint64, frameType string, paylo
 
 func sendWorkerError(codec *vm.WorkerCodec, id uint64, err error) error {
 	return sendWorkerPayload(codec, id, vm.WorkerFrameError, vm.WorkerError{Error: err.Error()})
+}
+
+func decodeWorkerRequest(codec *vm.WorkerCodec, frame vm.WorkerFrame, dst any) bool {
+	if err := frame.DecodePayload(dst); err != nil {
+		_ = sendWorkerRequestError(codec, frame, fmt.Errorf("decode payload: %w", err))
+		return false
+	}
+	return true
+}
+
+func validateWorkerInstanceID(codec *vm.WorkerCodec, frame vm.WorkerFrame, id string) bool {
+	if strings.TrimSpace(id) != "" {
+		return true
+	}
+	_ = sendWorkerRequestError(codec, frame, fmt.Errorf("worker instance id is required"))
+	return false
+}
+
+func sendWorkerRequestError(codec *vm.WorkerCodec, frame vm.WorkerFrame, err error) error {
+	return sendWorkerPayload(codec, frame.ID, vm.WorkerFrameError, vm.WorkerError{
+		Error:       err.Error(),
+		RequestID:   frame.ID,
+		RequestType: frame.Type,
+	})
 }
 
 func newServerShutdown(srvState *server, httpServer *http.Server) func() {

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,6 +75,118 @@ func TestMuxHealthStatusWatchdogAndShutdown(t *testing.T) {
 	case <-shutdownCalled:
 	case <-time.After(time.Second):
 		t.Fatalf("shutdown callback was not called")
+	}
+}
+
+func TestWorkerControlRejectsMalformedPayloadsAndRemainsUsable(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	clientCodec := vm.NewWorkerCodec(clientConn)
+	serverCodec := vm.NewWorkerCodec(serverConn)
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- serveWorkerControl(serverCodec, &server{vms: vm.NewManagerWithHost(nil)}, ServerOptions{})
+	}()
+	defer serverConn.Close()
+
+	frameTypes := []string{
+		vm.WorkerFrameStart,
+		vm.WorkerFrameStartBlank,
+		vm.WorkerFrameStatus,
+		vm.WorkerFrameStop,
+		vm.WorkerFrameWait,
+		vm.WorkerFrameFlush,
+		vm.WorkerFrameAddShare,
+		vm.WorkerFrameConsole,
+		vm.WorkerFrameExec,
+		vm.WorkerFrameExecInput,
+		vm.WorkerFrameCancel,
+	}
+	for i, frameType := range frameTypes {
+		id := uint64(i + 1)
+		if err := clientCodec.Send(vm.WorkerFrame{
+			ID:      id,
+			Service: vm.WorkerServiceControl,
+			Type:    frameType,
+			Payload: json.RawMessage(`"invalid"`),
+		}); err != nil {
+			t.Fatalf("send malformed %s frame: %v", frameType, err)
+		}
+		assertWorkerRequestError(t, clientCodec, id, frameType)
+	}
+
+	emptyIDTypes := []string{
+		vm.WorkerFrameStart,
+		vm.WorkerFrameStartBlank,
+		vm.WorkerFrameStatus,
+		vm.WorkerFrameStop,
+		vm.WorkerFrameWait,
+		vm.WorkerFrameFlush,
+		vm.WorkerFrameAddShare,
+		vm.WorkerFrameConsole,
+		vm.WorkerFrameExec,
+	}
+	for i, frameType := range emptyIDTypes {
+		id := uint64(100 + i)
+		frame, err := vm.NewWorkerFrame(id, vm.WorkerServiceControl, frameType, map[string]any{})
+		if err != nil {
+			t.Fatalf("create empty-id %s frame: %v", frameType, err)
+		}
+		if err := clientCodec.Send(frame); err != nil {
+			t.Fatalf("send empty-id %s frame: %v", frameType, err)
+		}
+		assertWorkerRequestError(t, clientCodec, id, frameType)
+	}
+
+	valid, err := vm.NewWorkerFrame(999, vm.WorkerServiceControl, vm.WorkerFrameStatus, vm.WorkerStatusRequest{ID: "named"})
+	if err != nil {
+		t.Fatalf("create valid status frame: %v", err)
+	}
+	if err := clientCodec.Send(valid); err != nil {
+		t.Fatalf("send valid status frame: %v", err)
+	}
+	response, err := clientCodec.Receive()
+	if err != nil {
+		t.Fatalf("receive valid status response: %v", err)
+	}
+	if response.ID != 999 || response.Type != vm.WorkerFrameDone {
+		t.Fatalf("valid response = %+v", response)
+	}
+	var status vm.WorkerStatusResponse
+	if err := response.DecodePayload(&status); err != nil {
+		t.Fatalf("decode valid status response: %v", err)
+	}
+	if status.State.ID != "named" {
+		t.Fatalf("valid status targeted %q, want named", status.State.ID)
+	}
+
+	if err := clientConn.Close(); err != nil {
+		t.Fatalf("close worker client: %v", err)
+	}
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("worker server after client close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker server did not stop after client close")
+	}
+}
+
+func assertWorkerRequestError(t *testing.T, codec *vm.WorkerCodec, id uint64, requestType string) {
+	t.Helper()
+	response, err := codec.Receive()
+	if err != nil {
+		t.Fatalf("receive %s error: %v", requestType, err)
+	}
+	if response.ID != id || response.Type != vm.WorkerFrameError {
+		t.Fatalf("%s error envelope = %+v", requestType, response)
+	}
+	var workerErr vm.WorkerError
+	if err := response.DecodePayload(&workerErr); err != nil {
+		t.Fatalf("decode %s error: %v", requestType, err)
+	}
+	if workerErr.Error == "" || workerErr.RequestID != id || workerErr.RequestType != requestType {
+		t.Fatalf("%s structured error = %+v", requestType, workerErr)
 	}
 }
 

--- a/internal/vm/sidecar/protocol.go
+++ b/internal/vm/sidecar/protocol.go
@@ -118,7 +118,9 @@ type WorkerCancelRequest struct {
 }
 
 type WorkerError struct {
-	Error string `json:"error"`
+	Error       string `json:"error"`
+	RequestID   uint64 `json:"request_id,omitempty"`
+	RequestType string `json:"request_type,omitempty"`
 }
 
 func (r WorkerStartRequest) Validate() error {


### PR DESCRIPTION
## What changed

- reject decode failures for every payload-bearing worker control frame
- reject empty instance IDs before any VM manager operation
- include original request ID and request type in structured worker errors
- decode cancel frames as part of the same protocol policy
- preserve the connection after request-scoped protocol errors

## Why

Status, stop, wait, flush, and console handlers ignored payload decode failures. Their zero-value IDs flowed into manager helpers that normalize an empty ID to the default VM, allowing malformed frames to inspect or operate on the wrong instance.

## Impact

Malformed or semantically incomplete frames cannot reach VM operations. Clients receive request-scoped error frames and can continue using the connection.

## Validation

- all malformed payload shapes and empty-ID VM requests return structured errors
- a valid named-VM status request succeeds on the same connection afterward
- `go test -race ./internal/ccvmd -run 'TestWorkerControlRejectsMalformedPayloadsAndRemainsUsable' -count=10`
- `go test ./...`

Closes #68
