### PR TITLE
Return ext4 layout limit errors

### DIFF
--- a/internal/ext4image/build.go
+++ b/internal/ext4image/build.go
@@ -21,7 +21,6 @@ import (
 const (
 	defaultImageSize = 64 << 20
 	defaultPageSize  = 16 << 10
-	maxInlineExtents = 4
 )
 
 type Options struct {
@@ -136,7 +135,12 @@ func scan(ctx context.Context, dir imagefs.Directory, guestPath string) (treeSta
 			size, mode := entry.File.Stat()
 			if mode.Type() == 0 {
 				if size > maxSupportedFileSize() {
-					return treeStats{}, fmt.Errorf("%s is too large for the current ext4 writer: %d bytes", childPath, size)
+					extentBytes := uint64(32768 * 4096)
+					requiredExtents := int64((size-1)/extentBytes + 1)
+					return treeStats{}, fmt.Errorf("%s: %w", childPath, &ext4.ExtentLimitError{
+						RequiredExtents:  requiredExtents,
+						SupportedExtents: ext4.MaxInlineExtents,
+					})
 				}
 				stats.files++
 				stats.bytes += size
@@ -298,7 +302,7 @@ func roundUp(v, align int64) int64 {
 }
 
 func maxSupportedFileSize() uint64 {
-	return uint64(maxInlineExtents * 32768 * 4096)
+	return uint64(ext4.MaxInlineExtents * 32768 * 4096)
 }
 
 func sortedDirEnts(entries []imagefs.DirEnt) []imagefs.DirEnt {

--- a/internal/ext4image/build_test.go
+++ b/internal/ext4image/build_test.go
@@ -3,8 +3,12 @@ package ext4image
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io/fs"
 	"testing"
+	"time"
 
+	"j5.nz/cc/internal/ext4image/ext4"
 	"j5.nz/cc/internal/imagefs"
 )
 
@@ -27,4 +31,58 @@ func TestWriteBuildsExt4Image(t *testing.T) {
 	if got := buf.Bytes()[1024+56 : 1024+58]; got[0] != 0x53 || got[1] != 0xef {
 		t.Fatalf("ext4 magic = % x, want 53 ef", got)
 	}
+}
+
+func TestBuildRejectsFilesBeyondInlineExtentLimit(t *testing.T) {
+	file := ext4LimitTestFile{size: maxSupportedFileSize() + 1}
+	root := ext4LimitTestDir{file: file}
+	image, err := Build(context.Background(), root, Options{})
+	if image != nil {
+		t.Fatal("unsupported ext4 layout published an image")
+	}
+	var limitErr *ext4.ExtentLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("oversized build error = %v, want ExtentLimitError", err)
+	}
+	if limitErr.RequiredExtents != ext4.MaxInlineExtents+1 || limitErr.SupportedExtents != ext4.MaxInlineExtents {
+		t.Fatalf("extent limit error = %#v", limitErr)
+	}
+
+	overlay := imagefs.NewOverlay(nil)
+	if err := overlay.AddFile("/ok", 0o644, []byte("ok")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Build(context.Background(), overlay.Root(), Options{}); err != nil {
+		t.Fatalf("build after layout rejection: %v", err)
+	}
+}
+
+type ext4LimitTestDir struct {
+	file ext4LimitTestFile
+}
+
+func (d ext4LimitTestDir) Stat() fs.FileMode       { return fs.ModeDir | 0o755 }
+func (d ext4LimitTestDir) ModTime() time.Time      { return time.Unix(0, 0) }
+func (d ext4LimitTestDir) Owner() (uint32, uint32) { return 0, 0 }
+func (d ext4LimitTestDir) RDev() uint32            { return 0 }
+func (d ext4LimitTestDir) ReadDir() ([]imagefs.DirEnt, error) {
+	return []imagefs.DirEnt{{Name: "large", Mode: 0o644}}, nil
+}
+func (d ext4LimitTestDir) Lookup(name string) (imagefs.Entry, error) {
+	if name != "large" {
+		return imagefs.Entry{}, fs.ErrNotExist
+	}
+	return imagefs.Entry{File: d.file}, nil
+}
+
+type ext4LimitTestFile struct {
+	size uint64
+}
+
+func (f ext4LimitTestFile) Stat() (uint64, fs.FileMode) { return f.size, 0o644 }
+func (f ext4LimitTestFile) ModTime() time.Time          { return time.Unix(0, 0) }
+func (f ext4LimitTestFile) Owner() (uint32, uint32)     { return 0, 0 }
+func (f ext4LimitTestFile) RDev() uint32                { return 0 }
+func (f ext4LimitTestFile) ReadAt(uint64, uint32) ([]byte, error) {
+	return nil, errors.New("oversized test file should not be read")
 }

--- a/internal/ext4image/ext4/ext4.go
+++ b/internal/ext4image/ext4/ext4.go
@@ -535,6 +535,21 @@ type ExtentTree1 struct {
 	arr    *vm.RegionArray[vm.MemoryRegion]
 }
 
+const MaxInlineExtents int64 = 4
+
+type ExtentLimitError struct {
+	RequiredExtents  int64
+	SupportedExtents int64
+}
+
+func (e *ExtentLimitError) Error() string {
+	return fmt.Sprintf("ext4 layout requires %d extents; writer supports at most %d inline extents", e.RequiredExtents, e.SupportedExtents)
+}
+
+func newExtentLimitError(required int64) error {
+	return &ExtentLimitError{RequiredExtents: required, SupportedExtents: MaxInlineExtents}
+}
+
 // AllocateBlocks implements ExtentTree.
 func (e *ExtentTree1) AllocateBlocks(blocks int64) error {
 	return fmt.Errorf("not implemented")
@@ -624,7 +639,7 @@ func newExtentTree1(fs *Ext4Filesystem, base uint64, blocks int64) (*ExtentTree1
 		return nil, err
 	}
 
-	if len(extents) <= 4 {
+	if len(extents) <= int(MaxInlineExtents) {
 		// Set the fields on the header.
 		tree.header.SetMagic(0xF30A)
 		tree.header.SetEntries(uint16(len(extents)))
@@ -655,7 +670,7 @@ func newExtentTree1(fs *Ext4Filesystem, base uint64, blocks int64) (*ExtentTree1
 			return nil, err
 		}
 	} else {
-		panic("unimplemented")
+		return nil, newExtentLimitError(int64(len(extents)))
 	}
 
 	return tree, nil
@@ -669,8 +684,12 @@ type ExtentTree2 struct {
 // AllocateBlocks implements ExtentTree.
 func (t *ExtentTree2) AllocateBlocks(blocks int64) error {
 	// Check that we have enough space in the extentTree to allocate blocks.
-	if t.count > 3 {
-		return fmt.Errorf("no remaining space in extent tree to allocate blocks")
+	if t.count >= int(MaxInlineExtents) {
+		return newExtentLimitError(int64(t.count + 1))
+	}
+	requiredExtents := roundUpDiv(blocks, int64(t.i.fs.sb.BlocksPerGroup()))
+	if int64(t.count)+requiredExtents > MaxInlineExtents {
+		return newExtentLimitError(int64(t.count) + requiredExtents)
 	}
 
 	// Allocate more extents.
@@ -679,8 +698,8 @@ func (t *ExtentTree2) AllocateBlocks(blocks int64) error {
 		return err
 	}
 
-	if len(extents)+t.count > 4 {
-		return fmt.Errorf("allocation would exceed the size constraint of a ExtentTree2")
+	if len(extents)+t.count > int(MaxInlineExtents) {
+		return newExtentLimitError(int64(len(extents) + t.count))
 	}
 
 	i := 0
@@ -793,8 +812,8 @@ func newExtentTree2(fs *Ext4Filesystem, i *InodeWrapper, blocks int64) (*ExtentT
 		return nil, err
 	}
 
-	if len(extents) > 4 {
-		panic("newExtentTree2 called with more than 4 extents.")
+	if len(extents) > int(MaxInlineExtents) {
+		return nil, newExtentLimitError(int64(len(extents)))
 	}
 
 	// Set the fields on the header.
@@ -856,10 +875,10 @@ func newExtentTree(fs *Ext4Filesystem, i *InodeWrapper, blocks int64) (ExtentTre
 
 	// slog.Debug("", "requiredBlockGroups", requiredBlockGroups)
 
-	if requiredBlockGroups <= 4 {
+	if requiredBlockGroups <= MaxInlineExtents {
 		return newExtentTree2(fs, i, blocks)
 	} else {
-		return nil, fmt.Errorf("extent tree is over 4 extents in length")
+		return nil, newExtentLimitError(requiredBlockGroups)
 	}
 }
 

--- a/internal/ext4image/ext4/extent_limit_test.go
+++ b/internal/ext4image/ext4/extent_limit_test.go
@@ -1,0 +1,22 @@
+package ext4
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewExtentTreeRejectsUnsupportedDepthBeforeAllocation(t *testing.T) {
+	var sb Superblock
+	if !sb.SetBlocksPerGroup(8) {
+		t.Fatal("set blocks per group")
+	}
+	filesystem := &Ext4Filesystem{sb: &sb}
+	_, err := newExtentTree(filesystem, &InodeWrapper{fs: filesystem}, 33)
+	var limitErr *ExtentLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("newExtentTree error = %v, want ExtentLimitError", err)
+	}
+	if limitErr.RequiredExtents != 5 || limitErr.SupportedExtents != MaxInlineExtents {
+		t.Fatalf("extent limit error = %#v", limitErr)
+	}
+}


### PR DESCRIPTION
## What changed

- replace ext4 extent-limit panics with a typed `ExtentLimitError`
- expose the writer's four-inline-extent capability and required extent count
- reject predictable unsupported depth before allocating blocks
- make defensive post-allocation and extent-growth checks return the same error
- verify an unsupported build publishes no image and does not poison later builds

## Why

Large or fragmented user filesystems could reach panic paths in ext4 extent construction and crash ccvmd. Unsupported layouts now fail with actionable structured limits.

The separate fragmented-memory-region limitation remains scoped to #87.

## Validation

- `go test ./...`
- `go test -race ./internal/ext4image/...`
- `go vet ./internal/ext4image/...`

Closes #88
