### PR TITLE
Complete fragmented region replacement

### DIFF
--- a/internal/ext4image/vmregion/fragmented.go
+++ b/internal/ext4image/vmregion/fragmented.go
@@ -3,7 +3,7 @@ package vmregion
 import (
 	"fmt"
 	"io"
-	"log/slog"
+	"sort"
 )
 
 // regionFragment is effectively an extent.
@@ -23,8 +23,8 @@ func (f regionFragment) end() int64   { return f.offset + f.size }
 
 // Return a new region starting at off.
 func (f regionFragment) offsetAt(off int64) *regionFragment {
-	if off > f.size {
-		panic("offsetAt: off > f.size")
+	if off < 0 || off > f.size {
+		return nil
 	}
 
 	return &regionFragment{
@@ -36,8 +36,8 @@ func (f regionFragment) offsetAt(off int64) *regionFragment {
 
 // Return a new region ending at off.
 func (f regionFragment) cutAt(off int64) *regionFragment {
-	if off > f.size {
-		panic("cutAt: off > f.size")
+	if off < 0 || off > f.size {
+		return nil
 	}
 
 	return &regionFragment{
@@ -45,76 +45,6 @@ func (f regionFragment) cutAt(off int64) *regionFragment {
 		offset: f.offset,
 		size:   off,
 	}
-}
-
-func remapRegion(old *regionFragment, new *regionFragment) []*regionFragment {
-	// This function assumes that old and new can't overlap at the start.
-	// That would have been picked up and resolved by mapFragment.
-	oldStart := old.start()
-	oldEnd := old.end()
-
-	newStart := new.start()
-	newEnd := new.end()
-
-	// If old and end don't overlap at all then just return old.
-	if oldEnd <= newStart || newEnd <= oldStart {
-		// log.Info("case 1", "old", old, "new", new)
-		return []*regionFragment{old}
-	}
-
-	// If old and new completely overlap or new overwrites old then just return new.
-	if newStart == oldStart && newEnd >= oldEnd {
-		// log.Info("case 2", "old", old, "new", new)
-		return []*regionFragment{new}
-	}
-
-	// If the start of old and new perfectly overlap but the end doesn't overlap
-	// then return new, old[offset]
-	if newStart == oldStart && newEnd < oldEnd {
-		// Find the overlap at the end.
-		endOverlap := new.size
-
-		// log.Info("case 3", "old", old, "new", new, "endOverlap", endOverlap)
-
-		return []*regionFragment{
-			new,
-			old.offsetAt(endOverlap),
-		}
-	}
-
-	// If new is entirely contained in old then return old[cut], new. old[offset]
-	if newStart > oldStart && newEnd < oldEnd {
-		// Find the overlap at the start
-		startOverlap := newStart - oldStart
-
-		// Find the overlap at the end.
-		endOverlap := old.size - (oldEnd - newEnd)
-
-		// log.Info("case 4", "old", old, "new", new, "startOverlap", startOverlap, "endOverlap", endOverlap)
-
-		return []*regionFragment{
-			old.cutAt(startOverlap),
-			new,
-			old.offsetAt(endOverlap),
-		}
-	}
-
-	// If old and new overlap on the end only then return [old, new].
-	// This also handles the case that new ends at old's end.
-	if newStart > oldStart && newEnd >= oldEnd {
-		overlap := newStart - oldStart
-
-		// log.Info("case 5", "old", old, "new", new, "overlap", overlap)
-
-		return []*regionFragment{
-			old.cutAt(overlap),
-			new,
-		}
-	}
-
-	slog.Debug("unimplemented", "oldStart", oldStart, "oldEnd", oldEnd, "newStart", newStart, "newEnd", newEnd)
-
-	panic("unimplemented")
 }
 
 // This is a implementation detail so the struct is private.
@@ -136,44 +66,57 @@ func (f *fragmentedRegion) String() string {
 	return s
 }
 
+func (f *fragmentedRegion) findFragmentsForRange(off, length int64) (startIdx, count int) {
+	if len(f.fragments) == 0 || length <= 0 {
+		return 0, 0
+	}
+	rangeEnd := off + length
+	startIdx = sort.Search(len(f.fragments), func(i int) bool {
+		return f.fragments[i].end() > off
+	})
+	if startIdx >= len(f.fragments) {
+		return startIdx, 0
+	}
+	for i := startIdx; i < len(f.fragments) && f.fragments[i].start() < rangeEnd; i++ {
+		count++
+	}
+	return startIdx, count
+}
+
 // ReadAt implements MemoryRegion.
 func (f *fragmentedRegion) ReadAt(p []byte, off int64) (n int, err error) {
 	if err := boundsCheck(f, off); err != nil {
 		return 0, err
 	}
-
-	for _, frag := range f.fragments {
-		// If the fragment doesn't overlap with the read area then skip it.
-		if (frag.offset + int64(frag.size)) <= off {
+	if int64(len(p)) > f.Size()-off {
+		p = p[:int(f.Size()-off)]
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	clear(p)
+	startIdx, count := f.findFragmentsForRange(off, int64(len(p)))
+	requestStart := off
+	for i := 0; i < count; i++ {
+		frag := f.fragments[startIdx+i]
+		readStart := max(frag.start(), requestStart)
+		readEnd := min(frag.end(), requestStart+int64(len(p)))
+		if readStart >= readEnd {
 			continue
 		}
-
-		fragOffset := int64(off) - frag.offset
-
-		var childN int
-
-		readFragment := len(p)
-
-		// If the read fragment is bigger than the remaining fragment size then decrease it to that.
-		if readFragment > int(frag.size-fragOffset) {
-			readFragment = int(frag.size - fragOffset)
+		dstStart := readStart - requestStart
+		fragOffset := readStart - frag.start()
+		readSize := readEnd - readStart
+		childN, childErr := frag.region.ReadAt(p[dstStart:dstStart+readSize], fragOffset)
+		if childErr != nil && childErr != io.EOF {
+			return n, childErr
 		}
-
-		childN, err = frag.region.ReadAt(p[:readFragment], int64(fragOffset))
 		n += childN
-		if err != nil {
-			return
-		}
-
-		p = p[childN:]
-		off = int64(frag.offset) + int64(frag.size)
-
-		if len(p) == 0 {
-			break
+		if int64(childN) < readSize && childErr == io.EOF {
+			continue
 		}
 	}
-
-	return
+	return len(p), nil
 }
 
 // Size implements MemoryRegion.
@@ -187,7 +130,9 @@ func (f *fragmentedRegion) WriteAt(p []byte, off int64) (n int, err error) {
 		return 0, err
 	}
 
-	for _, frag := range f.fragments {
+	startIdx, count := f.findFragmentsForRange(off, int64(len(p)))
+	for i := 0; i < count; i++ {
+		frag := f.fragments[startIdx+i]
 		// If the fragment doesn't overlap with the read area then skip it.
 		if (frag.offset + int64(frag.size)) <= off {
 			continue
@@ -220,43 +165,61 @@ func (f *fragmentedRegion) WriteAt(p []byte, off int64) (n int, err error) {
 }
 
 func (f *fragmentedRegion) mapFragment(frag MemoryRegion, off int64) error {
-	// Check that the offset is not more than the maximum size.
-	if off > int64(f.totalSize) {
-		return fmt.Errorf("off > int64(f.totalSize)")
+	if frag == nil {
+		return fmt.Errorf("fragment is nil")
 	}
-
-	// create the new fragmentRegion that needs to be inserted.
+	limit := int64(f.totalSize)
+	if off < 0 || off > limit {
+		return fmt.Errorf("fragment offset %d is outside [0,%d]", off, limit)
+	}
+	size := frag.Size()
+	if size < 0 || size > limit-off {
+		return fmt.Errorf("fragment size %d at offset %d exceeds region size %d", size, off, limit)
+	}
+	if size == 0 {
+		return nil
+	}
 	newFragment := &regionFragment{
 		region: frag,
 		offset: off,
-		size:   frag.Size(),
+		size:   size,
 	}
 
-	var newFrags []*regionFragment
-
-	for _, frag := range f.fragments {
-		// If there's already a fragment then check if we can skip it.
-		if len(newFrags) > 0 {
-			last := newFrags[len(newFrags)-1]
-
-			if last.end() > frag.start() {
-				if frag.end() > last.end() {
-					overlap := frag.size - (frag.end() - last.end())
-
-					// log.Info("case 6", "last", last, "frag", frag, "overlap", overlap, "overlap_part", (frag.end() - last.end()))
-
-					newFrags = append(newFrags, frag.offsetAt(overlap))
-				}
-
-				continue
+	newFrags := make([]*regionFragment, 0, len(f.fragments)+1)
+	inserted := false
+	for _, old := range f.fragments {
+		if old.end() <= newFragment.start() || old.start() >= newFragment.end() {
+			if !inserted && newFragment.end() <= old.start() {
+				newFrags = append(newFrags, newFragment)
+				inserted = true
 			}
+			newFrags = append(newFrags, old)
+			continue
 		}
 
-		newFrags = append(newFrags, remapRegion(frag, newFragment)...)
+		if old.start() < newFragment.start() {
+			left := old.cutAt(newFragment.start() - old.start())
+			if left == nil {
+				return fmt.Errorf("invalid left fragment split")
+			}
+			newFrags = append(newFrags, left)
+		}
+		if !inserted {
+			newFrags = append(newFrags, newFragment)
+			inserted = true
+		}
+		if old.end() > newFragment.end() {
+			right := old.offsetAt(newFragment.end() - old.start())
+			if right == nil {
+				return fmt.Errorf("invalid right fragment split")
+			}
+			newFrags = append(newFrags, right)
+		}
 	}
-
+	if !inserted {
+		newFrags = append(newFrags, newFragment)
+	}
 	f.fragments = newFrags
-
 	return nil
 }
 

--- a/internal/ext4image/vmregion/vm.go
+++ b/internal/ext4image/vmregion/vm.go
@@ -51,8 +51,8 @@ func (vm *VirtualMemory) mapFragment(region MemoryRegion, offset int64) error {
 			newFrag := newFragmentRegion(vm.pageSize)
 
 			// Add the existing region.
-			if err := newFrag.mapFragment(existingRegion, 0); err != nil {
-				return nil
+			if err := newFrag.mapFragment(NewTruncatedRegion(existingRegion, int64(vm.pageSize)), 0); err != nil {
+				return errors.Join(fmt.Errorf("failed to preserve existing page fragment"), err)
 			}
 
 			// Add the new fragment last so it can overwrite the old region.
@@ -110,20 +110,25 @@ func (vm *VirtualMemory) Map(region MemoryRegion, offset int64) error {
 
 	// log.Info("map", "region", region, "offset", offset)
 
-	// Get the size of the region.
+	if region == nil {
+		return fmt.Errorf("cannot map a nil region")
+	}
 	regionSize := region.Size()
+	if offset < 0 || regionSize < 0 || offset > vm.totalSize || regionSize > vm.totalSize-offset {
+		return fmt.Errorf("mapping offset %d size %d exceeds virtual memory size %d", offset, regionSize, vm.totalSize)
+	}
 
 	var regionOffset int64 = 0
 
 	// Check if the offset is aligned.
 	if offset%int64(vm.pageSize) != 0 {
-		// The offset is unaligned so we need to use a subdivided region.
-		if err := vm.mapFragment(region, offset); err != nil {
-			return nil
-		}
-
-		// Calculate the size of the fragment.
 		fragmentSize := int64(vm.pageSize) - (offset % int64(vm.pageSize))
+		if fragmentSize > regionSize {
+			fragmentSize = regionSize
+		}
+		if err := vm.mapFragment(NewTruncatedRegion(region, fragmentSize), offset); err != nil {
+			return errors.Join(fmt.Errorf("failed to map leading fragment"), err)
+		}
 
 		// Update the offsets.
 		regionOffset += fragmentSize

--- a/internal/fsimage/vm/fragmented.go
+++ b/internal/fsimage/vm/fragmented.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 	"io"
-	"log/slog"
 	"sort"
 )
 
@@ -24,8 +23,8 @@ func (f regionFragment) end() int64   { return f.offset + f.size }
 
 // Return a new region starting at off.
 func (f regionFragment) offsetAt(off int64) *regionFragment {
-	if off > f.size {
-		panic("offsetAt: off > f.size")
+	if off < 0 || off > f.size {
+		return nil
 	}
 
 	return &regionFragment{
@@ -37,8 +36,8 @@ func (f regionFragment) offsetAt(off int64) *regionFragment {
 
 // Return a new region ending at off.
 func (f regionFragment) cutAt(off int64) *regionFragment {
-	if off > f.size {
-		panic("cutAt: off > f.size")
+	if off < 0 || off > f.size {
+		return nil
 	}
 
 	return &regionFragment{
@@ -46,76 +45,6 @@ func (f regionFragment) cutAt(off int64) *regionFragment {
 		offset: f.offset,
 		size:   off,
 	}
-}
-
-func remapRegion(old *regionFragment, new *regionFragment) []*regionFragment {
-	// This function assumes that old and new can't overlap at the start.
-	// That would have been picked up and resolved by mapFragment.
-	oldStart := old.start()
-	oldEnd := old.end()
-
-	newStart := new.start()
-	newEnd := new.end()
-
-	// If old and end don't overlap at all then just return old.
-	if oldEnd <= newStart || newEnd <= oldStart {
-		// slog.Info("case 1", "old", old, "new", new)
-		return []*regionFragment{old}
-	}
-
-	// If old and new completely overlap or new overwrites old then just return new.
-	if newStart == oldStart && newEnd >= oldEnd {
-		// slog.Info("case 2", "old", old, "new", new)
-		return []*regionFragment{new}
-	}
-
-	// If the start of old and new perfectly overlap but the end doesn't overlap
-	// then return new, old[offset]
-	if newStart == oldStart && newEnd < oldEnd {
-		// Find the overlap at the end.
-		endOverlap := new.size
-
-		// slog.Info("case 3", "old", old, "new", new, "endOverlap", endOverlap)
-
-		return []*regionFragment{
-			new,
-			old.offsetAt(endOverlap),
-		}
-	}
-
-	// If new is entirely contained in old then return old[cut], new. old[offset]
-	if newStart > oldStart && newEnd < oldEnd {
-		// Find the overlap at the start
-		startOverlap := newStart - oldStart
-
-		// Find the overlap at the end.
-		endOverlap := old.size - (oldEnd - newEnd)
-
-		// slog.Info("case 4", "old", old, "new", new, "startOverlap", startOverlap, "endOverlap", endOverlap)
-
-		return []*regionFragment{
-			old.cutAt(startOverlap),
-			new,
-			old.offsetAt(endOverlap),
-		}
-	}
-
-	// If old and new overlap on the end only then return [old, new].
-	// This also handles the case that new ends at old's end.
-	if newStart > oldStart && newEnd >= oldEnd {
-		overlap := newStart - oldStart
-
-		// slog.Info("case 5", "old", old, "new", new, "overlap", overlap)
-
-		return []*regionFragment{
-			old.cutAt(overlap),
-			new,
-		}
-	}
-
-	slog.Error("unimplemented", "oldStart", oldStart, "oldEnd", oldEnd, "newStart", newStart, "newEnd", newEnd)
-
-	panic("unimplemented")
 }
 
 // This is a implementation detail so the struct is private.
@@ -266,16 +195,24 @@ func (f *fragmentedRegion) WriteAt(p []byte, off int64) (n int, err error) {
 }
 
 func (f *fragmentedRegion) mapFragment(frag MemoryRegion, off int64) error {
-	// Check that the offset is not more than the maximum size.
-	if off > int64(f.totalSize) {
-		return fmt.Errorf("off > int64(f.totalSize)")
+	if frag == nil {
+		return fmt.Errorf("fragment is nil")
 	}
-
-	// create the new fragmentRegion that needs to be inserted.
+	limit := int64(f.totalSize)
+	if off < 0 || off > limit {
+		return fmt.Errorf("fragment offset %d is outside [0,%d]", off, limit)
+	}
+	size := frag.Size()
+	if size < 0 || size > limit-off {
+		return fmt.Errorf("fragment size %d at offset %d exceeds region size %d", size, off, limit)
+	}
+	if size == 0 {
+		return nil
+	}
 	newFragment := &regionFragment{
 		region: frag,
 		offset: off,
-		size:   frag.Size(),
+		size:   size,
 	}
 
 	newFrags := make([]*regionFragment, 0, len(f.fragments)+1)
@@ -291,14 +228,22 @@ func (f *fragmentedRegion) mapFragment(frag MemoryRegion, off int64) error {
 		}
 
 		if old.start() < newFragment.start() {
-			newFrags = append(newFrags, old.cutAt(newFragment.start()-old.start()))
+			left := old.cutAt(newFragment.start() - old.start())
+			if left == nil {
+				return fmt.Errorf("invalid left fragment split")
+			}
+			newFrags = append(newFrags, left)
 		}
 		if !inserted {
 			newFrags = append(newFrags, newFragment)
 			inserted = true
 		}
 		if old.end() > newFragment.end() {
-			newFrags = append(newFrags, old.offsetAt(newFragment.end()-old.start()))
+			right := old.offsetAt(newFragment.end() - old.start())
+			if right == nil {
+				return fmt.Errorf("invalid right fragment split")
+			}
+			newFrags = append(newFrags, right)
 		}
 	}
 	if !inserted {

--- a/internal/fsimage/vm/fragmented_test.go
+++ b/internal/fsimage/vm/fragmented_test.go
@@ -1,82 +1,9 @@
-package vmregion
+package vm
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
 )
-
-// TestFragmentedRegionReadAt tests the ReadAt method of fragmentedRegion.
-func TestFragmentedRegionReadAt(t *testing.T) {
-	fragRegion := newFragmentRegion(16)
-	region := RawRegion(make([]byte, 16))
-	copy(region, []byte("Hello, World!"))
-	_ = fragRegion.mapFragment(&region, 0)
-
-	buff := make([]byte, 5)
-	n, err := fragRegion.ReadAt(buff, 0)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if n != 5 {
-		t.Errorf("ReadAt = %d, want 5", n)
-	}
-	expected := []byte("Hello")
-	if !reflect.DeepEqual(buff, expected) {
-		t.Errorf("ReadAt buffer = %v, want %v", buff, expected)
-	}
-}
-
-// TestFragmentedRegionWriteAt tests the WriteAt method of fragmentedRegion.
-func TestFragmentedRegionWriteAt(t *testing.T) {
-	fragRegion := newFragmentRegion(16)
-	data := []byte("Goodbye!")
-	n, err := fragRegion.WriteAt(data, 0)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if n != len(data) {
-		t.Errorf("WriteAt = %d, want %d", n, len(data))
-	}
-
-	buff := make([]byte, 8)
-	n, err = fragRegion.ReadAt(buff, 0)
-	if err != nil {
-		t.Errorf("unexpected error during read: %v", err)
-	}
-	if n != 8 {
-		t.Errorf("ReadAt after WriteAt = %d, want 8", n)
-	}
-	if !bytes.Equal(buff, data) {
-		t.Errorf("ReadAt buffer after WriteAt = %v, want %v", buff, data)
-	}
-}
-
-// TestFragmentedRegionMapFragment tests the mapFragment method of fragmentedRegion.
-func TestFragmentedRegionMapFragment(t *testing.T) {
-	fragRegion := newFragmentRegion(32)
-	addRegion := RawRegion([]byte("Gophers!"))
-	err := fragRegion.mapFragment(&addRegion, 8)
-	if err != nil {
-		t.Errorf("mapFragment error: %v", err)
-	}
-
-	buff := make([]byte, 8)
-	n, err := fragRegion.ReadAt(buff, 8)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if n != len(buff) {
-		t.Errorf("ReadAt = %d, want %d", n, len(buff))
-	}
-
-	t.Logf("buff %+v", buff)
-
-	expected := []byte("Gophers!")
-	if !reflect.DeepEqual(buff, expected) {
-		t.Errorf("ReadAt buffer after mapFragment = %v, want %v", buff, expected)
-	}
-}
 
 func TestFragmentedRegionRejectsInvalidMappingsWithoutMutation(t *testing.T) {
 	region := newFragmentRegion(16)

--- a/internal/fsimage/vm/vm.go
+++ b/internal/fsimage/vm/vm.go
@@ -152,8 +152,8 @@ func (vm *VirtualMemory) mapFragment(region MemoryRegion, offset int64) error {
 			newFrag := newFragmentRegion(vm.pageSize)
 
 			// Add the existing region.
-			if err := newFrag.mapFragment(existingRegion, 0); err != nil {
-				return nil
+			if err := newFrag.mapFragment(NewTruncatedRegion(existingRegion, int64(vm.pageSize)), 0); err != nil {
+				return errors.Join(fmt.Errorf("failed to preserve existing page fragment"), err)
 			}
 
 			// Add the new fragment last so it can overwrite the old region.
@@ -214,20 +214,25 @@ func (vm *VirtualMemory) Map(region MemoryRegion, offset int64) error {
 
 	// slog.Info("map", "region", region, "offset", offset)
 
-	// Get the size of the region.
+	if region == nil {
+		return fmt.Errorf("cannot map a nil region")
+	}
 	regionSize := region.Size()
+	if offset < 0 || regionSize < 0 || offset > vm.totalSize || regionSize > vm.totalSize-offset {
+		return fmt.Errorf("mapping offset %d size %d exceeds virtual memory size %d", offset, regionSize, vm.totalSize)
+	}
 
 	var regionOffset int64 = 0
 
 	// Check if the offset is aligned.
 	if offset%int64(vm.pageSize) != 0 {
-		// The offset is unaligned so we need to use a subdivided region.
-		if err := vm.mapFragment(region, offset); err != nil {
-			return nil
-		}
-
-		// Calculate the size of the fragment.
 		fragmentSize := int64(vm.pageSize) - (offset % int64(vm.pageSize))
+		if fragmentSize > regionSize {
+			fragmentSize = regionSize
+		}
+		if err := vm.mapFragment(NewTruncatedRegion(region, fragmentSize), offset); err != nil {
+			return errors.Join(fmt.Errorf("failed to map leading fragment"), err)
+		}
 
 		// Update the offsets.
 		regionOffset += fragmentSize


### PR DESCRIPTION
Closes #87.

## Summary

- define replacement semantics for every fragmented-region overlap in both VM region implementations
- reject invalid fragment mappings without panicking or mutating the existing region
- correctly split unaligned multi-page mappings and propagate mapping failures
- add fuzz/property coverage for byte contents, ordering, contiguity, and full region coverage

## Validation

- `go test -race ./internal/ext4image/vmregion ./internal/fsimage/vm`
- `go test ./...`
- `go vet ./internal/ext4image/vmregion ./internal/fsimage/vm`
- 3-second fuzz runs for `FuzzFragmentedRegionReplacement` in both changed packages

The first full-suite run timed out once while waiting for a guest shell in `TestRuntimePersistentLinuxExercisesRuntimeFeatures`. The exact test passed immediately on retry, and the subsequent complete suite passed.
