### PR TITLE
Snapshot virtio-fs atomic statistics in place

### DIFF
--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -2643,12 +2643,13 @@ func (f *FS) Stats() FSStats {
 	defer f.mu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	ops := make([]FUSEOpStats, 0, len(f.fuseOpStats))
-	for opcode, stat := range f.fuseOpStats {
-		count := stat.timingStat.count.Load()
+	for opcode := range f.fuseOpStats {
+		stat := &f.fuseOpStats[opcode].timingStat
+		count := stat.count.Load()
 		if count == 0 {
 			continue
 		}
-		totalNanos := stat.timingStat.totalNanos.Load()
+		totalNanos := stat.totalNanos.Load()
 		avg := int64(0)
 		if count != 0 {
 			avg = totalNanos / int64(count)
@@ -2659,7 +2660,7 @@ func (f *FS) Stats() FSStats {
 			Name:         fuseOpcodeName(opcodeValue),
 			Count:        count,
 			TotalNanos:   totalNanos,
-			MaxNanos:     stat.timingStat.maxNanos.Load(),
+			MaxNanos:     stat.maxNanos.Load(),
 			AverageNanos: avg,
 		})
 	}
@@ -2670,8 +2671,8 @@ func (f *FS) Stats() FSStats {
 		return ops[i].Count > ops[j].Count
 	})
 	stages := make([]TimingStats, 0, len(f.stageStats))
-	for stage, stat := range f.stageStats {
-		if stats, ok := timingStatsSnapshot(fsStageName(stage), &stat); ok {
+	for stage := range f.stageStats {
+		if stats, ok := timingStatsSnapshot(fsStageName(stage), &f.stageStats[stage]); ok {
 			stages = append(stages, stats)
 		}
 	}

--- a/internal/virtio/fs_stats_test.go
+++ b/internal/virtio/fs_stats_test.go
@@ -1,0 +1,87 @@
+package virtio
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFSStatsConcurrentTimingSnapshots(t *testing.T) {
+	const iterations = 10_000
+	const opcode = fuseLookup
+	const opDuration = 7 * time.Nanosecond
+	const stageDuration = 11 * time.Nanosecond
+
+	fs := &FS{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range iterations {
+			fs.fuseRequests.Add(1)
+			recordTimingStat(&fs.fuseOpStats[opcode].timingStat, opDuration)
+			recordTimingStat(&fs.stageStats[fsStageQueueHarvest], stageDuration)
+		}
+	}()
+
+	var previousOp, previousStage TimingStats
+	for {
+		stats := fs.Stats()
+		if op, ok := findFUSEOpStats(stats.FUSEOps, opcode); ok {
+			assertTimingStatsDoNotRegress(t, previousOp, TimingStats{
+				Count:      op.Count,
+				TotalNanos: op.TotalNanos,
+				MaxNanos:   op.MaxNanos,
+			})
+			previousOp = TimingStats{Count: op.Count, TotalNanos: op.TotalNanos, MaxNanos: op.MaxNanos}
+		}
+		if stage, ok := findTimingStats(stats.Stages, fsStageName(fsStageQueueHarvest)); ok {
+			assertTimingStatsDoNotRegress(t, previousStage, stage)
+			previousStage = stage
+		}
+
+		select {
+		case <-done:
+			final := fs.Stats()
+			op, ok := findFUSEOpStats(final.FUSEOps, opcode)
+			if !ok {
+				t.Fatal("FUSE operation statistics are missing")
+			}
+			if op.Count != iterations || op.TotalNanos != int64(iterations*opDuration) || op.MaxNanos != int64(opDuration) {
+				t.Fatalf("FUSE operation statistics = %+v", op)
+			}
+			stage, ok := findTimingStats(final.Stages, fsStageName(fsStageQueueHarvest))
+			if !ok {
+				t.Fatal("stage statistics are missing")
+			}
+			if stage.Count != iterations || stage.TotalNanos != int64(iterations*stageDuration) || stage.MaxNanos != int64(stageDuration) {
+				t.Fatalf("stage statistics = %+v", stage)
+			}
+			return
+		default:
+		}
+	}
+}
+
+func assertTimingStatsDoNotRegress(t *testing.T, previous, current TimingStats) {
+	t.Helper()
+	if current.Count < previous.Count || current.TotalNanos < previous.TotalNanos || current.MaxNanos < previous.MaxNanos {
+		t.Fatalf("timing statistics regressed from %+v to %+v", previous, current)
+	}
+}
+
+func findFUSEOpStats(stats []FUSEOpStats, opcode uint32) (FUSEOpStats, bool) {
+	for _, stat := range stats {
+		if stat.Opcode == opcode {
+			return stat, true
+		}
+	}
+	return FUSEOpStats{}, false
+}
+
+func findTimingStats(stats []TimingStats, name string) (TimingStats, bool) {
+	for _, stat := range stats {
+		if stat.Name == name {
+			return stat, true
+		}
+	}
+	return TimingStats{}, false
+}


### PR DESCRIPTION
Closes #85.

## Summary

- snapshot virtio-fs timing counters through pointers to their original atomic fields
- avoid copying `atomic.*` no-copy markers in operation and stage loops
- verify concurrent snapshots remain monotonic and reach exact final values

## Validation

- `go vet ./internal/virtio`
- `go test -race ./internal/virtio`
- `go test -race ./internal/virtio -run '^TestFSStatsConcurrentTimingSnapshots$' -count=20`
- `go test ./...`
- `go vet ./...` has no remaining virtio or copied-lock findings; it still reports the separately tracked BSD keyed-literal and HVF defer findings
