### PR TITLE
Synchronize mutable client headers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,15 +10,17 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"golang.org/x/net/websocket"
 )
 
 type Client struct {
-	url     string
-	dialer  func() (net.Conn, error)
-	headers http.Header
-	client  http.Client
+	url       string
+	dialer    func() (net.Conn, error)
+	headersMu sync.RWMutex
+	headers   http.Header
+	client    http.Client
 }
 
 func NewClient(url string, dialer func() (net.Conn, error)) *Client {
@@ -33,12 +35,7 @@ func NewClient(url string, dialer func() (net.Conn, error)) *Client {
 					return c.dialer()
 				},
 			},
-			token: func() string {
-				return c.headers.Get("Authorization")
-			},
-			headers: func() http.Header {
-				return c.headers.Clone()
-			},
+			headers: c.headerSnapshot,
 		},
 	}
 	return c
@@ -46,7 +43,6 @@ func NewClient(url string, dialer func() (net.Conn, error)) *Client {
 
 type authTransport struct {
 	base    http.RoundTripper
-	token   func() string
 	headers func() http.Header
 }
 
@@ -54,14 +50,12 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	if t.headers != nil {
 		for key, values := range t.headers() {
+			if strings.EqualFold(key, "Authorization") {
+				req.Header.Del(key)
+			}
 			for _, value := range values {
 				req.Header.Add(key, value)
 			}
-		}
-	}
-	if t.token != nil {
-		if token := strings.TrimSpace(t.token()); token != "" {
-			req.Header.Set("Authorization", token)
 		}
 	}
 	return t.base.RoundTrip(req)
@@ -82,6 +76,8 @@ func (c *Client) SetHeader(key, value string) {
 	if key == "" {
 		return
 	}
+	c.headersMu.Lock()
+	defer c.headersMu.Unlock()
 	if c.headers == nil {
 		c.headers = http.Header{}
 	}
@@ -90,6 +86,12 @@ func (c *Client) SetHeader(key, value string) {
 		return
 	}
 	c.headers.Set(key, value)
+}
+
+func (c *Client) headerSnapshot() http.Header {
+	c.headersMu.RLock()
+	defer c.headersMu.RUnlock()
+	return c.headers.Clone()
 }
 
 func (c *Client) HealthCheck() error {
@@ -647,11 +649,12 @@ func (c *Client) applyWebSocketAuth(cfg *websocket.Config) {
 	if cfg == nil {
 		return
 	}
-	if c.headers != nil {
+	headers := c.headerSnapshot()
+	if len(headers) != 0 {
 		if cfg.Header == nil {
 			cfg.Header = http.Header{}
 		}
-		for key, values := range c.headers {
+		for key, values := range headers {
 			for _, value := range values {
 				cfg.Header.Add(key, value)
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,9 +2,13 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -91,17 +95,85 @@ func TestClientBearerTokenIsSent(t *testing.T) {
 		client: http.Client{
 			Transport: &authTransport{
 				base: srv.Client().Transport,
-				token: func() string {
-					return "Bearer secret"
-				},
 				headers: func() http.Header {
-					return http.Header{"X-Test-Protocol": []string{"1"}}
+					return http.Header{
+						"Authorization":   []string{"Bearer secret"},
+						"X-Test-Protocol": []string{"1"},
+					}
 				},
 			},
 		},
 	}
 	if err := c.HealthCheck(); err != nil {
 		t.Fatalf("health check: %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestClientConcurrentHeaderUpdatesAndRequests(t *testing.T) {
+	const iterations = 1_000
+	requestErrs := make(chan error, 2*iterations)
+	c := &Client{url: "http://client.test"}
+	c.client.Transport = &authTransport{
+		headers: c.headerSnapshot,
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			values := req.Header.Values("Authorization")
+			if len(values) > 1 {
+				return nil, fmt.Errorf("Authorization values = %q", values)
+			}
+			if len(values) == 1 {
+				generation, err := strconv.Atoi(strings.TrimPrefix(values[0], "Bearer generation-"))
+				if err != nil || generation < 0 || generation >= iterations {
+					return nil, fmt.Errorf("Authorization = %q", values[0])
+				}
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			c.SetBearerToken(fmt.Sprintf("generation-%d", i))
+			if i%7 == 0 {
+				c.SetBearerToken("")
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if err := c.HealthCheck(); err != nil {
+				requestErrs <- err
+			}
+			cfg := &websocket.Config{}
+			c.applyWebSocketAuth(cfg)
+			if values := cfg.Header.Values("Authorization"); len(values) > 1 {
+				requestErrs <- fmt.Errorf("WebSocket Authorization values = %q", values)
+			}
+		}
+	}()
+	wg.Wait()
+	close(requestErrs)
+	for err := range requestErrs {
+		t.Error(err)
+	}
+
+	c.SetBearerToken("")
+	if authorization := c.headerSnapshot().Get("Authorization"); authorization != "" {
+		t.Fatalf("cleared Authorization = %q", authorization)
 	}
 }
 


### PR DESCRIPTION
Closes #83.

## Summary

- protect mutable client headers with a read/write lock
- clone one immutable header snapshot for each HTTP or WebSocket request
- remove the HTTP transport's second authorization read and preserve client authorization precedence
- delete cleared secrets from the only shared header map
- exercise concurrent token rotation, HTTP requests, and WebSocket header snapshots under race detection

## Validation

- `go vet ./client`
- `go test -race ./client`
- `go test -race ./client -run '^TestClientConcurrentHeaderUpdatesAndRequests$' -count=20`
- `go test ./...`
