### PR TITLE
Require terminal progress stream success

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -150,7 +151,7 @@ func (c *Client) DownloadKernel(req DownloadRequest) error {
 }
 
 func (c *Client) DownloadKernelStream(req DownloadRequest, onEvent func(ProgressEvent) error) error {
-	return c.postJSONProgressStream("/kernel/download", req, onEvent)
+	return c.postJSONProgressStream("/kernel/download", req, onEvent, progressStatusDownloaded)
 }
 
 func (c *Client) PrepareImageMetadata(name string) (ImageMetadataState, error) {
@@ -204,7 +205,7 @@ func (c *Client) PullImageStream(name string, req PullImageRequest, onEvent func
 }
 
 func (c *Client) PullImageStreamContext(ctx context.Context, name string, req PullImageRequest, onEvent func(ProgressEvent) error) error {
-	return c.postJSONProgressStreamContext(ctx, "/image/"+imagePathName(name), req, onEvent)
+	return c.postJSONProgressStreamContext(ctx, "/image/"+imagePathName(name), req, onEvent, progressStatusDownloaded)
 }
 
 func (c *Client) DeleteImage(name string) error {
@@ -742,11 +743,17 @@ func (c *Client) postJSONExpectOK(path string, reqBody any, respBody any) error 
 	return json.NewDecoder(resp.Body).Decode(respBody)
 }
 
-func (c *Client) postJSONProgressStream(path string, reqBody any, onEvent func(ProgressEvent) error) error {
-	return c.postJSONProgressStreamContext(context.Background(), path, reqBody, onEvent)
+const progressStatusDownloaded = "downloaded"
+
+// ErrProgressStreamEndedBeforeTerminal reports a stream that ended before its
+// operation-level success event.
+var ErrProgressStreamEndedBeforeTerminal = errors.New("progress stream ended before terminal event")
+
+func (c *Client) postJSONProgressStream(path string, reqBody any, onEvent func(ProgressEvent) error, terminalStatus string) error {
+	return c.postJSONProgressStreamContext(context.Background(), path, reqBody, onEvent, terminalStatus)
 }
 
-func (c *Client) postJSONProgressStreamContext(ctx context.Context, path string, reqBody any, onEvent func(ProgressEvent) error) error {
+func (c *Client) postJSONProgressStreamContext(ctx context.Context, path string, reqBody any, onEvent func(ProgressEvent) error, terminalStatus string) error {
 	resp, err := c.postJSONStreamContext(ctx, path, reqBody)
 	if err != nil {
 		return err
@@ -754,14 +761,16 @@ func (c *Client) postJSONProgressStreamContext(ctx context.Context, path string,
 	defer resp.Body.Close()
 
 	dec := json.NewDecoder(resp.Body)
+	lastStatus := ""
 	for {
 		var event ProgressEvent
 		if err := dec.Decode(&event); err != nil {
 			if err == io.EOF {
-				return nil
+				return fmt.Errorf("%w: expected status %q after %q", ErrProgressStreamEndedBeforeTerminal, terminalStatus, lastStatus)
 			}
 			return err
 		}
+		lastStatus = event.Status
 		if onEvent != nil {
 			if err := onEvent(event); err != nil {
 				return err
@@ -772,6 +781,9 @@ func (c *Client) postJSONProgressStreamContext(ctx context.Context, path string,
 				return fmt.Errorf("%s", event.Error)
 			}
 			return fmt.Errorf("streamed operation failed")
+		}
+		if event.Status == terminalStatus && event.Blob == "" {
+			return nil
 		}
 	}
 }

--- a/client/progress_stream_test.go
+++ b/client/progress_stream_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestProgressStreamRequiresTerminalSuccess(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		events        []ProgressEvent
+		wantStatuses  []string
+		wantPremature bool
+		wantError     bool
+	}{
+		{
+			name:          "truncated after progress",
+			events:        []ProgressEvent{{Status: "downloading", Artifact: "kernel"}},
+			wantStatuses:  []string{"downloading"},
+			wantPremature: true,
+		},
+		{
+			name:          "sub-artifact completion is not terminal",
+			events:        []ProgressEvent{{Status: "downloaded", Artifact: "image", Blob: "cvmfs cache"}},
+			wantStatuses:  []string{"downloaded"},
+			wantPremature: true,
+		},
+		{
+			name: "terminal success",
+			events: []ProgressEvent{
+				{Status: "downloading", Artifact: "image"},
+				{Status: "downloaded", Artifact: "image"},
+			},
+			wantStatuses: []string{"downloading", "downloaded"},
+		},
+		{
+			name:         "terminal error",
+			events:       []ProgressEvent{{Status: "error", Error: "pull failed"}},
+			wantStatuses: []string{"error"},
+			wantError:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				enc := json.NewEncoder(w)
+				for _, event := range test.events {
+					if err := enc.Encode(event); err != nil {
+						t.Errorf("write event: %v", err)
+						return
+					}
+				}
+			}))
+			defer srv.Close()
+
+			client := &Client{url: srv.URL, client: *srv.Client()}
+			var statuses []string
+			err := client.postJSONProgressStreamContext(t.Context(), "/progress", struct{}{}, func(event ProgressEvent) error {
+				statuses = append(statuses, event.Status)
+				return nil
+			}, progressStatusDownloaded)
+			if got := errors.Is(err, ErrProgressStreamEndedBeforeTerminal); got != test.wantPremature {
+				t.Fatalf("premature error = %t, want %t (error: %v)", got, test.wantPremature, err)
+			}
+			if (err != nil) != (test.wantPremature || test.wantError) {
+				t.Fatalf("error = %v", err)
+			}
+			if !reflect.DeepEqual(statuses, test.wantStatuses) {
+				t.Fatalf("callback statuses = %v, want %v", statuses, test.wantStatuses)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #82.

## Summary

- require kernel-download and image-pull streams to emit an operation-level `downloaded` event
- distinguish sub-artifact `downloaded` events carrying a `blob` from terminal success
- return `ErrProgressStreamEndedBeforeTerminal` when EOF arrives first
- preserve callbacks for every intermediate, terminal, and error event

## Validation

- `go vet ./client`
- `go test -race ./client`
- `go test ./...`
