### PR TITLE
Require terminal exec stream events

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -527,12 +528,16 @@ func streamExecInputsToWebSocket(ws *websocket.Conn, inputs <-chan ExecInput) <-
 }
 
 func receiveExecEventsFromWebSocket(ws *websocket.Conn, onEvent func(ExecEvent) error) error {
+	var state execStreamState
 	for {
 		var event ExecEvent
 		if err := websocket.JSON.Receive(ws, &event); err != nil {
 			if err == io.EOF {
-				break
+				return state.finish()
 			}
+			return err
+		}
+		if err := state.accept(event); err != nil {
 			return err
 		}
 		if onEvent != nil {
@@ -540,11 +545,47 @@ func receiveExecEventsFromWebSocket(ws *websocket.Conn, onEvent func(ExecEvent) 
 				return err
 			}
 		}
-		if event.Kind == "exit" || event.Kind == "error" {
-			break
+	}
+}
+
+var (
+	// ErrExecStreamEndedBeforeTerminal reports a clean transport end without an
+	// exit or error event.
+	ErrExecStreamEndedBeforeTerminal = errors.New("exec stream ended before terminal event")
+	// ErrExecStreamDuplicateTerminal reports more than one exit/error event.
+	ErrExecStreamDuplicateTerminal = errors.New("exec stream sent duplicate terminal event")
+)
+
+type execStreamState struct {
+	lastKind     string
+	terminalKind string
+	terminalErr  error
+}
+
+func (s *execStreamState) accept(event ExecEvent) error {
+	s.lastKind = event.Kind
+	if event.Kind != "exit" && event.Kind != "error" {
+		return nil
+	}
+	if s.terminalKind != "" {
+		return fmt.Errorf("%w: received %q after %q", ErrExecStreamDuplicateTerminal, event.Kind, s.terminalKind)
+	}
+	s.terminalKind = event.Kind
+	if event.Kind == "error" {
+		if event.Error != "" {
+			s.terminalErr = errors.New(event.Error)
+		} else {
+			s.terminalErr = errors.New("streamed exec failed")
 		}
 	}
 	return nil
+}
+
+func (s *execStreamState) finish() error {
+	if s.terminalKind == "" {
+		return fmt.Errorf("%w after event kind %q", ErrExecStreamEndedBeforeTerminal, s.lastKind)
+	}
+	return s.terminalErr
 }
 
 func currentWebSocketSendError(sendErr <-chan error) error {
@@ -825,27 +866,22 @@ func (c *Client) postJSONExecStream(ctx context.Context, path string, reqBody an
 	defer resp.Body.Close()
 
 	dec := json.NewDecoder(resp.Body)
+	var state execStreamState
 	for {
 		var event ExecEvent
 		if err := dec.Decode(&event); err != nil {
 			if err == io.EOF {
-				return nil
+				return state.finish()
 			}
+			return err
+		}
+		if err := state.accept(event); err != nil {
 			return err
 		}
 		if onEvent != nil {
 			if err := onEvent(event); err != nil {
 				return err
 			}
-		}
-		if event.Kind == "error" {
-			if event.Error != "" {
-				return fmt.Errorf("%s", event.Error)
-			}
-			return fmt.Errorf("streamed exec failed")
-		}
-		if event.Kind == "exit" {
-			return nil
 		}
 	}
 }

--- a/client/exec_stream_test.go
+++ b/client/exec_stream_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/websocket"
+)
+
+func TestNDJSONExecStreamTerminalProtocol(t *testing.T) {
+	testExecStreamTerminalProtocol(t, func(t *testing.T, events []ExecEvent, onEvent func(ExecEvent) error) error {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			enc := json.NewEncoder(w)
+			for _, event := range events {
+				if err := enc.Encode(event); err != nil {
+					t.Errorf("write event: %v", err)
+					return
+				}
+			}
+		}))
+		defer srv.Close()
+		client := &Client{url: srv.URL, client: *srv.Client()}
+		return client.postJSONExecStream(t.Context(), "/exec", struct{}{}, onEvent)
+	})
+}
+
+func TestWebSocketExecStreamTerminalProtocol(t *testing.T) {
+	testExecStreamTerminalProtocol(t, func(t *testing.T, events []ExecEvent, onEvent func(ExecEvent) error) error {
+		t.Helper()
+		mux := http.NewServeMux()
+		mux.Handle("/vm/run/stream", websocket.Server{
+			Handshake: func(*websocket.Config, *http.Request) error { return nil },
+			Handler: func(ws *websocket.Conn) {
+				var req RunRequest
+				if err := websocket.JSON.Receive(ws, &req); err != nil {
+					t.Errorf("receive request: %v", err)
+					return
+				}
+				var input ExecInput
+				if err := websocket.JSON.Receive(ws, &input); err != nil {
+					t.Errorf("receive stdin close: %v", err)
+					return
+				}
+				for _, event := range events {
+					if err := websocket.JSON.Send(ws, event); err != nil {
+						t.Errorf("send event: %v", err)
+						return
+					}
+				}
+			},
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		client := &Client{url: srv.URL, client: *srv.Client()}
+		return client.RunInteractiveStreamContext(t.Context(), RunRequest{Command: []string{"true"}}, nil, onEvent)
+	})
+}
+
+func testExecStreamTerminalProtocol(t *testing.T, run func(*testing.T, []ExecEvent, func(ExecEvent) error) error) {
+	t.Helper()
+	for _, test := range []struct {
+		name          string
+		events        []ExecEvent
+		wantKinds     []string
+		wantPremature bool
+		wantDuplicate bool
+		wantError     bool
+	}{
+		{
+			name:          "premature EOF",
+			events:        []ExecEvent{{Kind: "stdout", Output: "partial"}},
+			wantKinds:     []string{"stdout"},
+			wantPremature: true,
+		},
+		{
+			name:      "nonzero exit is terminal",
+			events:    []ExecEvent{{Kind: "stdout", Output: "done"}, {Kind: "exit", ExitCode: 7}},
+			wantKinds: []string{"stdout", "exit"},
+		},
+		{
+			name:          "duplicate exit",
+			events:        []ExecEvent{{Kind: "exit"}, {Kind: "exit"}},
+			wantKinds:     []string{"exit"},
+			wantDuplicate: true,
+		},
+		{
+			name:          "error then exit",
+			events:        []ExecEvent{{Kind: "error", Error: "failed"}, {Kind: "exit"}},
+			wantKinds:     []string{"error"},
+			wantDuplicate: true,
+		},
+		{
+			name:      "terminal error",
+			events:    []ExecEvent{{Kind: "error", Error: "failed"}},
+			wantKinds: []string{"error"},
+			wantError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var kinds []string
+			err := run(t, test.events, func(event ExecEvent) error {
+				kinds = append(kinds, event.Kind)
+				return nil
+			})
+			if got := errors.Is(err, ErrExecStreamEndedBeforeTerminal); got != test.wantPremature {
+				t.Fatalf("premature error = %t, want %t (error: %v)", got, test.wantPremature, err)
+			}
+			if got := errors.Is(err, ErrExecStreamDuplicateTerminal); got != test.wantDuplicate {
+				t.Fatalf("duplicate error = %t, want %t (error: %v)", got, test.wantDuplicate, err)
+			}
+			if (err != nil) != (test.wantPremature || test.wantDuplicate || test.wantError) {
+				t.Fatalf("error = %v", err)
+			}
+			if !reflect.DeepEqual(kinds, test.wantKinds) {
+				t.Fatalf("callback kinds = %v, want %v", kinds, test.wantKinds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #81.

## Summary

- share terminal-event state between NDJSON and WebSocket exec streams
- return `ErrExecStreamEndedBeforeTerminal` when a clean EOF arrives before `exit` or `error`
- reject a second terminal event with `ErrExecStreamDuplicateTerminal`
- preserve nonzero exit events for callers and return terminal error events as failures

## Validation

- `go vet ./client`
- `go test -race ./client`
- `go test -race ./client -run '^(TestNDJSONExecStreamTerminalProtocol|TestWebSocketExecStreamTerminalProtocol)$' -count=20`
- `go test ./...`
