### PR TITLE
Stop exec input senders with their stream

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -478,52 +478,83 @@ func (c *Client) RunInteractiveStreamContext(ctx context.Context, req RunRequest
 		}
 	}()
 	defer close(ctxDone)
-	sendErr := streamExecInputsToWebSocket(ws, inputs)
+	sendCtx, stopSend := context.WithCancel(ctx)
+	sendErr := streamExecInputsToWebSocket(sendCtx, ws, inputs)
 	err = receiveExecEventsFromWebSocket(ws, onEvent)
+	stopSend()
+	_ = ws.Close()
+	sendErrValue := <-sendErr
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if sendErrValue := currentWebSocketSendError(sendErr); sendErrValue != nil {
+	if sendErrValue != nil {
 		return sendErrValue
 	}
 	return err
 }
 
-func streamExecInputsToWebSocket(ws *websocket.Conn, inputs <-chan ExecInput) <-chan error {
+func streamExecInputsToWebSocket(ctx context.Context, ws *websocket.Conn, inputs <-chan ExecInput) <-chan error {
 	done := make(chan error, 1)
-	if inputs == nil {
-		go func() {
-			done <- websocket.JSON.Send(ws, ExecInput{Kind: "stdin_close"})
-		}()
-		return done
-	}
 	go func() {
 		stdinClosed := false
-		for input := range inputs {
+		for {
+			var input ExecInput
+			var ok bool
+			if inputs == nil {
+				input = ExecInput{Kind: "stdin_close"}
+				ok = true
+			} else {
+				select {
+				case <-ctx.Done():
+					done <- nil
+					return
+				case input, ok = <-inputs:
+				}
+			}
+			if !ok {
+				if !stdinClosed {
+					if err := sendExecInputToWebSocket(ctx, ws, ExecInput{Kind: "stdin_close"}); err != nil {
+						done <- err
+						return
+					}
+				}
+				done <- nil
+				return
+			}
 			if input.Kind == "stdin_close" {
 				if stdinClosed {
+					if inputs == nil {
+						done <- nil
+						return
+					}
 					continue
 				}
 				stdinClosed = true
 			} else if input.Kind == "stdin" && stdinClosed {
 				continue
 			}
-			if err := websocket.JSON.Send(ws, input); err != nil {
+			if err := sendExecInputToWebSocket(ctx, ws, input); err != nil {
 				done <- err
-				_ = ws.Close()
+				return
+			}
+			if inputs == nil {
+				done <- nil
 				return
 			}
 		}
-		if !stdinClosed {
-			if err := websocket.JSON.Send(ws, ExecInput{Kind: "stdin_close"}); err != nil {
-				done <- err
-				_ = ws.Close()
-				return
-			}
-		}
-		done <- nil
 	}()
 	return done
+}
+
+func sendExecInputToWebSocket(ctx context.Context, ws *websocket.Conn, input ExecInput) error {
+	if err := websocket.JSON.Send(ws, input); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		_ = ws.Close()
+		return err
+	}
+	return nil
 }
 
 func receiveExecEventsFromWebSocket(ws *websocket.Conn, onEvent func(ExecEvent) error) error {
@@ -545,18 +576,6 @@ func receiveExecEventsFromWebSocket(ws *websocket.Conn, onEvent func(ExecEvent) 
 		}
 	}
 	return nil
-}
-
-func currentWebSocketSendError(sendErr <-chan error) error {
-	if sendErr == nil {
-		return nil
-	}
-	select {
-	case err := <-sendErr:
-		return err
-	default:
-		return nil
-	}
 }
 
 func (c *Client) RunEvents(req RunRequest) ([]ExecEvent, error) {
@@ -632,12 +651,16 @@ func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs 
 		}
 	}()
 	defer close(ctxDone)
-	sendErr := streamExecInputsToWebSocket(ws, inputs)
+	sendCtx, stopSend := context.WithCancel(ctx)
+	sendErr := streamExecInputsToWebSocket(sendCtx, ws, inputs)
 	err = receiveExecEventsFromWebSocket(ws, onEvent)
+	stopSend()
+	_ = ws.Close()
+	sendErrValue := <-sendErr
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if sendErrValue := currentWebSocketSendError(sendErr); sendErrValue != nil {
+	if sendErrValue != nil {
 		return sendErrValue
 	}
 	return err

--- a/client/input_sender_test.go
+++ b/client/input_sender_test.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+func TestWebSocketExecCompletionStopsOpenInputSender(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/vm/run/stream", websocket.Server{
+		Handshake: func(*websocket.Config, *http.Request) error { return nil },
+		Handler: func(ws *websocket.Conn) {
+			var req RunRequest
+			if err := websocket.JSON.Receive(ws, &req); err != nil {
+				t.Errorf("receive request: %v", err)
+				return
+			}
+			if err := websocket.JSON.Send(ws, ExecEvent{Kind: "exit"}); err != nil {
+				t.Errorf("send exit: %v", err)
+			}
+		},
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	client := &Client{url: srv.URL, client: *srv.Client()}
+
+	for i := 0; i < 10; i++ {
+		inputs := make(chan ExecInput)
+		if err := client.RunInteractiveStreamContext(t.Context(), RunRequest{Command: []string{"true"}}, inputs, nil); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		select {
+		case inputs <- ExecInput{Kind: "stdin", Input: "after exit"}:
+			t.Fatalf("run %d input sender still receives after completion", i)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func TestWebSocketExecCancellationStopsInputSender(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/vm/run/stream", websocket.Server{
+		Handshake: func(*websocket.Config, *http.Request) error { return nil },
+		Handler: func(ws *websocket.Conn) {
+			var req RunRequest
+			if err := websocket.JSON.Receive(ws, &req); err != nil {
+				return
+			}
+			var input ExecInput
+			_ = websocket.JSON.Receive(ws, &input)
+		},
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	client := &Client{url: srv.URL, client: *srv.Client()}
+	inputs := make(chan ExecInput)
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := client.RunInteractiveStreamContext(ctx, RunRequest{Command: []string{"sleep"}}, inputs, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cancellation error = %v, want %v", err, context.DeadlineExceeded)
+	}
+	select {
+	case inputs <- ExecInput{Kind: "stdin", Input: "after cancellation"}:
+		t.Fatal("input sender still receives after cancellation")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestWebSocketInputSenderReportsSendFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/ws", websocket.Server{
+		Handshake: func(*websocket.Config, *http.Request) error { return nil },
+		Handler: func(ws *websocket.Conn) {
+			var input ExecInput
+			_ = websocket.JSON.Receive(ws, &input)
+		},
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	wsURL, err := websocketURL(srv.URL, "/ws")
+	if err != nil {
+		t.Fatalf("WebSocket URL: %v", err)
+	}
+	ws, err := websocket.Dial(wsURL, "", srv.URL)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	if err := ws.Close(); err != nil {
+		t.Fatalf("close WebSocket: %v", err)
+	}
+	inputs := make(chan ExecInput, 1)
+	inputs <- ExecInput{Kind: "stdin", Input: "cannot send"}
+
+	select {
+	case err := <-streamExecInputsToWebSocket(t.Context(), ws, inputs):
+		if err == nil {
+			t.Fatal("send failure was not returned")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("input sender did not return")
+	}
+}


### PR DESCRIPTION
Closes #80.

## Summary

- bind each WebSocket input sender to the exec stream lifecycle
- cancel the sender and close the socket after receive completion to unblock reads and in-flight sends
- wait for sender termination before returning, preserving real send failures and caller cancellation
- verify repeated early exits do not leave readers on open input channels

## Validation

- `go vet ./client`
- `go test -race ./client`
- `go test -race ./client -run '^(TestWebSocketExecCompletionStopsOpenInputSender|TestWebSocketExecCancellationStopsInputSender|TestWebSocketInputSenderReportsSendFailure)$' -count=10`
- `go test ./...`
