### PR TITLE
Honor context during WebSocket handshakes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -445,6 +445,9 @@ func (c *Client) RunInteractiveStream(req RunRequest, inputs <-chan ExecInput, o
 }
 
 func (c *Client) RunInteractiveStreamContext(ctx context.Context, req RunRequest, inputs <-chan ExecInput, onEvent func(ExecEvent) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	wsURL, err := websocketURL(c.url, "/vm/run/stream")
 	if err != nil {
 		return err
@@ -457,7 +460,7 @@ func (c *Client) RunInteractiveStreamContext(ctx context.Context, req RunRequest
 	if c.dialer != nil {
 		cfg.Dialer = &net.Dialer{}
 	}
-	ws, err := websocket.DialConfig(cfg)
+	ws, err := dialWebSocketContext(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -465,9 +468,6 @@ func (c *Client) RunInteractiveStreamContext(ctx context.Context, req RunRequest
 
 	if err := websocket.JSON.Send(ws, req); err != nil {
 		return err
-	}
-	if ctx == nil {
-		ctx = context.Background()
 	}
 	ctxDone := make(chan struct{})
 	go func() {
@@ -599,6 +599,9 @@ func (c *Client) ExecStream(req ExecRequest, inputs <-chan ExecInput, onEvent fu
 }
 
 func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs <-chan ExecInput, onEvent func(ExecEvent) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	wsURL, err := websocketURL(c.url, "/vm/run")
 	if err != nil {
 		return err
@@ -611,7 +614,7 @@ func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs 
 	if c.dialer != nil {
 		cfg.Dialer = &net.Dialer{}
 	}
-	ws, err := websocket.DialConfig(cfg)
+	ws, err := dialWebSocketContext(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -619,9 +622,6 @@ func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs 
 
 	if err := websocket.JSON.Send(ws, req); err != nil {
 		return err
-	}
-	if ctx == nil {
-		ctx = context.Background()
 	}
 	ctxDone := make(chan struct{})
 	go func() {
@@ -641,6 +641,36 @@ func (c *Client) ExecStreamContext(ctx context.Context, req ExecRequest, inputs 
 		return sendErrValue
 	}
 	return err
+}
+
+// WebSocketDialError identifies the endpoint whose connection or handshake
+// failed. Err retains cancellation and transport errors for errors.Is/As.
+type WebSocketDialError struct {
+	Endpoint string
+	Err      error
+}
+
+func (e *WebSocketDialError) Error() string {
+	return fmt.Sprintf("dial WebSocket %s: %v", e.Endpoint, e.Err)
+}
+
+func (e *WebSocketDialError) Unwrap() error {
+	return e.Err
+}
+
+func dialWebSocketContext(ctx context.Context, cfg *websocket.Config) (*websocket.Conn, error) {
+	ws, err := cfg.DialContext(ctx)
+	if err == nil {
+		return ws, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		err = ctxErr
+	}
+	endpoint := ""
+	if cfg != nil && cfg.Location != nil {
+		endpoint = cfg.Location.String()
+	}
+	return nil, &WebSocketDialError{Endpoint: endpoint, Err: err}
 }
 
 func (c *Client) applyWebSocketAuth(cfg *websocket.Config) {

--- a/client/websocket_dial_test.go
+++ b/client/websocket_dial_test.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWebSocketHandshakeHonorsContextCancellation(t *testing.T) {
+	started := make(chan string, 2)
+	finished := make(chan string, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		started <- r.URL.Path
+		<-r.Context().Done()
+		finished <- r.URL.Path
+	}))
+	defer srv.Close()
+	client := &Client{url: srv.URL, client: *srv.Client()}
+
+	for _, test := range []struct {
+		name string
+		path string
+		run  func(context.Context) error
+	}{
+		{
+			name: "interactive run",
+			path: "/vm/run/stream",
+			run: func(ctx context.Context) error {
+				return client.RunInteractiveStreamContext(ctx, RunRequest{Command: []string{"true"}}, nil, nil)
+			},
+		},
+		{
+			name: "exec",
+			path: "/vm/run",
+			run: func(ctx context.Context) error {
+				return client.ExecStreamContext(ctx, ExecRequest{Command: []string{"true"}}, nil, nil)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			result := make(chan error, 1)
+			go func() {
+				result <- test.run(ctx)
+			}()
+			select {
+			case path := <-started:
+				if path != test.path {
+					t.Fatalf("handshake path = %q, want %q", path, test.path)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handshake did not start")
+			}
+			cancel()
+			var err error
+			select {
+			case err = <-result:
+			case <-time.After(2 * time.Second):
+				t.Fatal("canceled handshake did not return")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("handshake error = %v, want %v", err, context.Canceled)
+			}
+			var dialErr *WebSocketDialError
+			if !errors.As(err, &dialErr) {
+				t.Fatalf("handshake error type = %T, want *WebSocketDialError", err)
+			}
+			wantEndpoint, err := websocketURL(srv.URL, test.path)
+			if err != nil {
+				t.Fatalf("WebSocket URL: %v", err)
+			}
+			if dialErr.Endpoint != wantEndpoint {
+				t.Fatalf("dial endpoint = %q, want %q", dialErr.Endpoint, wantEndpoint)
+			}
+			select {
+			case path := <-finished:
+				if path != test.path {
+					t.Fatalf("finished handshake path = %q, want %q", path, test.path)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("partial handshake connection was not closed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #79.

## Summary

- normalize caller context before either WebSocket connection attempt
- use `websocket.Config.DialContext` for context-aware DNS, TCP, TLS, and upgrade handshake work
- return a structured `WebSocketDialError` carrying the endpoint and an unwrap-compatible cause
- verify cancellation closes stalled partial handshakes for both interactive-run and exec endpoints

## Validation

- `go vet ./client`
- `go test -race ./client`
- `go test -race ./client -run '^TestWebSocketHandshakeHonorsContextCancellation$' -count=20`
- `go test ./...`
