### PR TITLE
Bound command reap waits after timeout

### DIFF
--- a/internal/vm/sidecar/daemon.go
+++ b/internal/vm/sidecar/daemon.go
@@ -1,11 +1,38 @@
 package sidecar
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"sync"
 	"time"
 )
+
+const CommandReapTimeout = 100 * time.Millisecond
+
+var ErrCommandTimeout = errors.New("command did not exit before timeout")
+
+type CommandTimeoutError struct {
+	Timeout      time.Duration
+	KillErr      error
+	WaitErr      error
+	ReapTimedOut bool
+}
+
+func (e *CommandTimeoutError) Error() string {
+	if e.ReapTimedOut {
+		return fmt.Sprintf("command timed out after %s and did not exit within %s after kill", e.Timeout, CommandReapTimeout)
+	}
+	if e.KillErr != nil {
+		return fmt.Sprintf("command timed out after %s; kill failed: %v", e.Timeout, e.KillErr)
+	}
+	return fmt.Sprintf("command timed out after %s; wait after kill: %v", e.Timeout, e.WaitErr)
+}
+
+func (e *CommandTimeoutError) Unwrap() error {
+	return errors.Join(ErrCommandTimeout, e.KillErr, e.WaitErr)
+}
 
 type Daemon struct {
 	cmd      *exec.Cmd
@@ -56,18 +83,34 @@ func WaitCommand(cmd *exec.Cmd, timeout time.Duration) error {
 	if cmd == nil {
 		return nil
 	}
+	return waitCommand(timeout, cmd.Wait, func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Kill()
+	})
+}
+
+func waitCommand(timeout time.Duration, wait func() error, kill func() error) error {
 	done := make(chan error, 1)
 	go func() {
-		done <- cmd.Wait()
+		done <- wait()
 	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case err := <-done:
 		return err
-	case <-time.After(timeout):
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-		}
-		return <-done
+	case <-timer.C:
+	}
+	killErr := kill()
+	reapTimer := time.NewTimer(CommandReapTimeout)
+	defer reapTimer.Stop()
+	select {
+	case waitErr := <-done:
+		return &CommandTimeoutError{Timeout: timeout, KillErr: killErr, WaitErr: waitErr}
+	case <-reapTimer.C:
+		return &CommandTimeoutError{Timeout: timeout, KillErr: killErr, ReapTimedOut: true}
 	}
 }
 

--- a/internal/vm/sidecar/daemon_test.go
+++ b/internal/vm/sidecar/daemon_test.go
@@ -1,6 +1,7 @@
 package sidecar
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -31,7 +32,7 @@ func TestWaitCommand(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start exit helper: %v", err)
 	}
-	if err := WaitCommand(cmd, time.Second); err != nil {
+	if err := WaitCommand(cmd, 5*time.Second); err != nil {
 		t.Fatalf("wait exit helper: %v", err)
 	}
 
@@ -46,6 +47,33 @@ func TestWaitCommand(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("wait sleep took %s, want timeout kill", elapsed)
+	}
+}
+
+func TestWaitCommandBoundsKillResistantReap(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	killErr := errors.New("kill refused")
+	start := time.Now()
+	err := waitCommand(10*time.Millisecond, func() error {
+		<-release
+		return nil
+	}, func() error {
+		return killErr
+	})
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("waitCommand took %s", elapsed)
+	}
+	if !errors.Is(err, ErrCommandTimeout) || !errors.Is(err, killErr) {
+		t.Fatalf("waitCommand error = %v", err)
+	}
+	var timeoutErr *CommandTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("waitCommand error type = %T", err)
+	}
+	if timeoutErr.Timeout != 10*time.Millisecond || !timeoutErr.ReapTimedOut {
+		t.Fatalf("timeout state = %+v", timeoutErr)
 	}
 }
 


### PR DESCRIPTION
Closes #76.

## Summary

- bound the post-kill reap wait to 100 ms after the caller's timeout expires
- return structured `CommandTimeoutError` state distinguishing kill failure, eventual wait result, and reap timeout
- retain `errors.Is` support for the timeout and underlying kill/wait failures
- keep normal child reaping unchanged

## Validation

- `go vet ./internal/vm/sidecar`
- `go test -race ./internal/vm/sidecar`
- `go test -race ./internal/vm/sidecar -run '^TestWaitCommandBoundsKillResistantReap$' -count=20`
- `go test ./...` passed every package before the VM integration package stalled in an unrelated virtio-balloon guest boot
- `go test ./internal/vm -run '^TestRuntimeBootsLinuxWithVirtioBalloon$' -count=1 -v` passed on immediate retry
