### PR TITLE
Bound sidecar call frame delivery

### DIFF
--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -19,14 +20,32 @@ type Client struct {
 	next uint64
 
 	pendingMu sync.Mutex
-	pending   map[uint64]chan workerFrameResult
+	pending   map[uint64]*workerCall
 	closed    bool
 	recvErr   error
 }
 
-type workerFrameResult struct {
-	frame WorkerFrame
-	err   error
+// ErrWorkerCallOverflow reports that a caller stopped consuming frames quickly
+// enough for its bounded delivery queue to fill.
+var ErrWorkerCallOverflow = errors.New("sidecar worker call frame buffer overflow")
+
+type workerCall struct {
+	frames chan WorkerFrame
+	done   chan error
+}
+
+func newWorkerCall() *workerCall {
+	return &workerCall{
+		frames: make(chan WorkerFrame, 256),
+		done:   make(chan error, 1),
+	}
+}
+
+func (c *workerCall) finish(err error) {
+	select {
+	case c.done <- err:
+	default:
+	}
 }
 
 func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
@@ -48,7 +67,7 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	worker := &Client{conn: conn, codec: NewWorkerCodec(conn), pending: map[uint64]chan workerFrameResult{}}
+	worker := &Client{conn: conn, codec: NewWorkerCodec(conn), pending: map[uint64]*workerCall{}}
 	frame, err := worker.codec.Receive()
 	if err != nil {
 		_ = conn.Close()
@@ -84,16 +103,24 @@ func (c *Client) receiveLoop() {
 			return
 		}
 		c.pendingMu.Lock()
-		ch := c.pending[frame.ID]
+		call := c.pending[frame.ID]
 		c.pendingMu.Unlock()
-		if ch == nil {
+		if call == nil {
 			continue
 		}
-		ch <- workerFrameResult{frame: frame}
+		select {
+		case call.frames <- frame:
+		default:
+			err := fmt.Errorf("%w for request %d", ErrWorkerCallOverflow, frame.ID)
+			if c.failCall(frame.ID, call, err) {
+				id := frame.ID
+				go func() { _ = c.sendCancel(id) }()
+			}
+		}
 	}
 }
 
-func (c *Client) registerCall(id uint64) (chan workerFrameResult, error) {
+func (c *Client) registerCall(id uint64) (*workerCall, error) {
 	c.pendingMu.Lock()
 	defer c.pendingMu.Unlock()
 	if c.closed {
@@ -102,15 +129,27 @@ func (c *Client) registerCall(id uint64) (chan workerFrameResult, error) {
 		}
 		return nil, fmt.Errorf("sidecar worker is closed")
 	}
-	ch := make(chan workerFrameResult, 256)
-	c.pending[id] = ch
-	return ch, nil
+	call := newWorkerCall()
+	c.pending[id] = call
+	return call, nil
 }
 
 func (c *Client) unregisterCall(id uint64) {
 	c.pendingMu.Lock()
 	delete(c.pending, id)
 	c.pendingMu.Unlock()
+}
+
+func (c *Client) failCall(id uint64, call *workerCall, err error) bool {
+	c.pendingMu.Lock()
+	if c.pending[id] != call {
+		c.pendingMu.Unlock()
+		return false
+	}
+	delete(c.pending, id)
+	c.pendingMu.Unlock()
+	call.finish(err)
+	return true
 }
 
 func (c *Client) closePending(err error) {
@@ -125,11 +164,10 @@ func (c *Client) closePending(err error) {
 	c.closed = true
 	c.recvErr = err
 	pending := c.pending
-	c.pending = map[uint64]chan workerFrameResult{}
+	c.pending = map[uint64]*workerCall{}
 	c.pendingMu.Unlock()
-	for _, ch := range pending {
-		ch <- workerFrameResult{err: err}
-		close(ch)
+	for _, call := range pending {
+		call.finish(err)
 	}
 }
 
@@ -223,7 +261,7 @@ func (c *Client) ExecStream(ctx context.Context, id string, req client.ExecReque
 		return fmt.Errorf("sidecar worker is not connected")
 	}
 	requestID := c.nextID()
-	frames, err := c.registerCall(requestID)
+	call, err := c.registerCall(requestID)
 	if err != nil {
 		return err
 	}
@@ -263,11 +301,10 @@ func (c *Client) ExecStream(ctx context.Context, id string, req client.ExecReque
 	}()
 
 	for {
-		result, err := c.nextFrame(ctx, frames)
+		got, err := c.nextFrame(ctx, call)
 		if err != nil {
 			return err
 		}
-		got := result.frame
 		switch got.Type {
 		case WorkerFrameError:
 			var workerErr WorkerError
@@ -301,8 +338,11 @@ func (c *Client) call(ctx context.Context, frameType string, payload any, onFram
 	if c == nil || c.codec == nil {
 		return fmt.Errorf("sidecar worker is not connected")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	id := c.nextID()
-	frames, err := c.registerCall(id)
+	call, err := c.registerCall(id)
 	if err != nil {
 		return err
 	}
@@ -327,11 +367,10 @@ func (c *Client) call(ctx context.Context, frameType string, payload any, onFram
 		return err
 	}
 	for {
-		result, err := c.nextFrame(ctx, frames)
+		got, err := c.nextFrame(ctx, call)
 		if err != nil {
 			return err
 		}
-		got := result.frame
 		switch got.Type {
 		case WorkerFrameError:
 			var workerErr WorkerError
@@ -354,24 +393,25 @@ func (c *Client) call(ctx context.Context, frameType string, payload any, onFram
 	}
 }
 
-func (c *Client) nextFrame(ctx context.Context, frames <-chan workerFrameResult) (workerFrameResult, error) {
+func (c *Client) nextFrame(ctx context.Context, call *workerCall) (WorkerFrame, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	select {
+	case err := <-call.done:
+		return WorkerFrame{}, err
+	default:
+	}
+	select {
 	case <-ctx.Done():
-		return workerFrameResult{}, ctx.Err()
-	case result, ok := <-frames:
-		if !ok {
-			return workerFrameResult{}, fmt.Errorf("sidecar worker is closed")
+		return WorkerFrame{}, ctx.Err()
+	case err := <-call.done:
+		if ctx.Err() != nil {
+			return WorkerFrame{}, ctx.Err()
 		}
-		if result.err != nil {
-			if ctx.Err() != nil {
-				return workerFrameResult{}, ctx.Err()
-			}
-			return workerFrameResult{}, result.err
-		}
-		return result, nil
+		return WorkerFrame{}, err
+	case frame := <-call.frames:
+		return frame, nil
 	}
 }
 

--- a/internal/vm/sidecar/client_test.go
+++ b/internal/vm/sidecar/client_test.go
@@ -2,7 +2,9 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -147,6 +149,150 @@ func TestWorkerClientMultiplexesControlWhileExecStreams(t *testing.T) {
 	}
 	if err := <-serverErr; err != nil {
 		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestWorkerCallOverflowDoesNotBlockUnrelatedCall(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	eventsSent := make(chan struct{})
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		codec := NewWorkerCodec(conn)
+		defer codec.Close()
+		if err := codec.Send(WorkerFrame{Type: WorkerFrameHello}); err != nil {
+			serverErr <- err
+			return
+		}
+		execFrame, err := codec.Receive()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if execFrame.Type != WorkerFrameExec {
+			serverErr <- fmt.Errorf("first frame type = %q", execFrame.Type)
+			return
+		}
+		event := mustWorkerFrame(execFrame.ID, WorkerFrameEvent, client.ExecEvent{Kind: "stdout", Output: "x"})
+		if err := codec.Send(event); err != nil {
+			serverErr <- err
+			return
+		}
+		<-callbackStarted
+		for range 257 {
+			if err := codec.Send(event); err != nil {
+				serverErr <- err
+				return
+			}
+		}
+		close(eventsSent)
+
+		gotCancel := false
+		gotControl := false
+		for !gotCancel || !gotControl {
+			frame, err := codec.Receive()
+			if err != nil {
+				serverErr <- err
+				return
+			}
+			switch frame.Type {
+			case WorkerFrameCancel:
+				if frame.ID != execFrame.ID {
+					serverErr <- fmt.Errorf("cancel request id = %d, want %d", frame.ID, execFrame.ID)
+					return
+				}
+				gotCancel = true
+			case WorkerFrameAddShare:
+				gotControl = true
+				if err := codec.Send(mustWorkerFrame(frame.ID, WorkerFrameDone, map[string]string{"status": "mounted"})); err != nil {
+					serverErr <- err
+					return
+				}
+			default:
+				serverErr <- fmt.Errorf("unexpected frame type = %q", frame.Type)
+				return
+			}
+		}
+		serverErr <- nil
+	}()
+
+	worker, err := DialWorker(context.Background(), "tcp://"+ln.Addr().String())
+	if err != nil {
+		t.Fatalf("DialWorker: %v", err)
+	}
+	defer worker.Close()
+
+	execDone := make(chan error, 1)
+	go func() {
+		execDone <- worker.ExecStream(t.Context(), "vm", client.ExecRequest{Command: []string{"yes"}}, nil, func(client.ExecEvent) error {
+			close(callbackStarted)
+			<-releaseCallback
+			return nil
+		})
+	}()
+	select {
+	case <-eventsSent:
+	case err := <-serverErr:
+		t.Fatalf("server: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("worker did not receive overflowing event stream")
+	}
+
+	controlDone := make(chan error, 1)
+	go func() {
+		controlDone <- worker.AddShare(t.Context(), "vm", client.ShareMount{Source: "/host", Mount: "/host"})
+	}()
+	select {
+	case err := <-controlDone:
+		if err != nil {
+			t.Fatalf("unrelated AddShare: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("unrelated AddShare blocked behind overflowing call")
+	}
+	close(releaseCallback)
+	select {
+	case err := <-execDone:
+		if !errors.Is(err, ErrWorkerCallOverflow) {
+			t.Fatalf("ExecStream error = %v, want call overflow", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overflowing ExecStream did not return")
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestClosePendingDoesNotBlockFullCall(t *testing.T) {
+	call := newWorkerCall()
+	for i := 0; i < cap(call.frames); i++ {
+		call.frames <- WorkerFrame{ID: 1, Type: WorkerFrameEvent}
+	}
+	c := &Client{pending: map[uint64]*workerCall{1: call}}
+	closed := make(chan struct{})
+	go func() {
+		c.closePending(io.EOF)
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("connection close blocked on a full call buffer")
+	}
+	if _, err := c.nextFrame(t.Context(), call); !errors.Is(err, io.EOF) {
+		t.Fatalf("call error = %v, want connection EOF", err)
 	}
 }
 


### PR DESCRIPTION
Closes #74

Sidecar calls now keep bounded frame delivery separate from a non-blocking terminal error signal. If one call fills its 256-frame queue, only that call is removed and failed with `ErrWorkerCallOverflow`, and its protocol cancellation is sent asynchronously. The global receive loop remains available to unrelated calls. Connection shutdown also signals pending calls without writing into their potentially full frame queues.

Tests block an exec event consumer through overflow while proving a concurrent control call completes, verify the affected request receives the structured overflow error, and verify connection-close notification cannot block on a full call queue.

Validation:
- `go test -race ./internal/vm/sidecar -run 'TestWorkerCallOverflowDoesNotBlockUnrelatedCall|TestClosePendingDoesNotBlockFullCall' -count=20`\n- `go vet ./internal/vm/sidecar`\n- `go test ./...`