### PR TITLE
Validate sidecar worker hello

### DIFF
--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -14,6 +14,7 @@ import (
 type Client struct {
 	conn  net.Conn
 	codec *WorkerCodec
+	hello WorkerHello
 
 	idMu sync.Mutex
 	next uint64
@@ -24,12 +25,38 @@ type Client struct {
 	recvErr   error
 }
 
+type WorkerRequirements struct {
+	SupportsFSRPC bool
+	SupportsL2    bool
+}
+
+type WorkerProtocolVersionError struct {
+	Received  int
+	Supported int
+}
+
+func (e *WorkerProtocolVersionError) Error() string {
+	return fmt.Sprintf("unsupported sidecar worker protocol version %d (supported version: %d)", e.Received, e.Supported)
+}
+
+type MissingWorkerCapabilityError struct {
+	Capability string
+}
+
+func (e *MissingWorkerCapabilityError) Error() string {
+	return fmt.Sprintf("sidecar worker does not support required capability %q", e.Capability)
+}
+
 type workerFrameResult struct {
 	frame WorkerFrame
 	err   error
 }
 
 func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
+	return DialWorkerWithRequirements(ctx, socketPath, WorkerRequirements{})
+}
+
+func DialWorkerWithRequirements(ctx context.Context, socketPath string, requirements WorkerRequirements) (*Client, error) {
 	var conn net.Conn
 	var err error
 	network, address := workerDialTarget(socketPath)
@@ -58,8 +85,31 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("sidecar worker sent %q before hello", frame.Type)
 	}
+	var hello WorkerHello
+	if err := frame.DecodePayload(&hello); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("decode sidecar worker hello: %w", err)
+	}
+	if err := validateWorkerHello(hello, requirements); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	worker.hello = hello
 	go worker.receiveLoop()
 	return worker, nil
+}
+
+func validateWorkerHello(hello WorkerHello, requirements WorkerRequirements) error {
+	if hello.Version != WorkerProtocolVersion {
+		return &WorkerProtocolVersionError{Received: hello.Version, Supported: WorkerProtocolVersion}
+	}
+	if requirements.SupportsFSRPC && !hello.Capabilities.SupportsFSRPC {
+		return &MissingWorkerCapabilityError{Capability: "filesystem-rpc"}
+	}
+	if requirements.SupportsL2 && !hello.Capabilities.SupportsL2 {
+		return &MissingWorkerCapabilityError{Capability: "l2-networking"}
+	}
+	return nil
 }
 
 func workerDialTarget(address string) (string, string) {
@@ -74,6 +124,13 @@ func (c *Client) Close() error {
 		return nil
 	}
 	return c.conn.Close()
+}
+
+func (c *Client) Hello() WorkerHello {
+	if c == nil {
+		return WorkerHello{}
+	}
+	return c.hello
 }
 
 func (c *Client) receiveLoop() {

--- a/internal/vm/sidecar/client_test.go
+++ b/internal/vm/sidecar/client_test.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -22,13 +23,88 @@ func TestWorkerDialTarget(t *testing.T) {
 }
 
 func TestDialWorkerReadsHello(t *testing.T) {
-	addr, done := serveWorkerFrame(t, WorkerFrame{Type: WorkerFrameHello})
+	addr, done := serveWorkerFrame(t, mustWorkerFrame(0, WorkerFrameHello, WorkerHello{
+		Version:  WorkerProtocolVersion,
+		WorkerID: "worker-1",
+		Backend:  "test",
+	}))
 	worker, err := DialWorker(context.Background(), "tcp://"+addr)
 	if err != nil {
 		t.Fatalf("DialWorker: %v", err)
 	}
 	if worker == nil || worker.codec == nil {
 		t.Fatalf("worker client was not initialized")
+	}
+	if hello := worker.Hello(); hello.Version != WorkerProtocolVersion || hello.WorkerID != "worker-1" || hello.Backend != "test" {
+		t.Fatalf("worker hello = %+v", hello)
+	}
+	_ = worker.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestDialWorkerRejectsUnsupportedVersion(t *testing.T) {
+	addr, done := serveWorkerFrame(t, mustWorkerFrame(0, WorkerFrameHello, WorkerHello{Version: WorkerProtocolVersion + 1}))
+	worker, err := DialWorker(context.Background(), "tcp://"+addr)
+	if worker != nil {
+		_ = worker.Close()
+	}
+	var versionErr *WorkerProtocolVersionError
+	if !errors.As(err, &versionErr) {
+		t.Fatalf("DialWorker error = %v, want WorkerProtocolVersionError", err)
+	}
+	if versionErr.Received != WorkerProtocolVersion+1 || versionErr.Supported != WorkerProtocolVersion {
+		t.Fatalf("version error = %+v", versionErr)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestDialWorkerChecksRequiredCapabilities(t *testing.T) {
+	addr, done := serveWorkerFrame(t, mustWorkerFrame(0, WorkerFrameHello, WorkerHello{
+		Version: WorkerProtocolVersion,
+		Capabilities: HostCapabilities{
+			SupportsFSRPC: true,
+		},
+	}))
+	worker, err := DialWorkerWithRequirements(context.Background(), "tcp://"+addr, WorkerRequirements{
+		SupportsFSRPC: true,
+		SupportsL2:    true,
+	})
+	if worker != nil {
+		_ = worker.Close()
+	}
+	var capabilityErr *MissingWorkerCapabilityError
+	if !errors.As(err, &capabilityErr) {
+		t.Fatalf("DialWorkerWithRequirements error = %v, want MissingWorkerCapabilityError", err)
+	}
+	if capabilityErr.Capability != "l2-networking" {
+		t.Fatalf("missing capability = %q", capabilityErr.Capability)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestDialWorkerToleratesOptionalHelloFields(t *testing.T) {
+	frame := mustWorkerFrame(0, WorkerFrameHello, map[string]any{
+		"version":      WorkerProtocolVersion,
+		"worker_id":    "future-worker",
+		"future_field": map[string]any{"enabled": true},
+		"capabilities": map[string]any{"SupportsFSRPC": true, "SupportsL2": true, "FutureCapability": true},
+	})
+	addr, done := serveWorkerFrame(t, frame)
+	worker, err := DialWorkerWithRequirements(context.Background(), "tcp://"+addr, WorkerRequirements{
+		SupportsFSRPC: true,
+		SupportsL2:    true,
+	})
+	if err != nil {
+		t.Fatalf("DialWorkerWithRequirements: %v", err)
+	}
+	if worker.Hello().WorkerID != "future-worker" {
+		t.Fatalf("worker hello = %+v", worker.Hello())
 	}
 	_ = worker.Close()
 	if err := <-done; err != nil {
@@ -68,7 +144,7 @@ func TestWorkerClientMultiplexesControlWhileExecStreams(t *testing.T) {
 		}
 		codec := NewWorkerCodec(conn)
 		defer codec.Close()
-		if err := codec.Send(WorkerFrame{Type: WorkerFrameHello}); err != nil {
+		if err := codec.Send(mustWorkerFrame(0, WorkerFrameHello, WorkerHello{Version: WorkerProtocolVersion})); err != nil {
 			serverErr <- err
 			return
 		}

--- a/internal/vm/sidecar_host.go
+++ b/internal/vm/sidecar_host.go
@@ -395,7 +395,11 @@ func (h *sidecarVMHost) launch(ctx context.Context, env []string) (*sidecarpkg.D
 		started = false
 		return nil, err
 	}
-	worker, err := sidecarpkg.DialWorker(ctx, hello.Addr)
+	features := sidecarHostFeatures()
+	worker, err := sidecarpkg.DialWorkerWithRequirements(ctx, hello.Addr, sidecarpkg.WorkerRequirements{
+		SupportsFSRPC: features.supportsFSRPC,
+		SupportsL2:    features.supportsL2,
+	})
 	if err != nil {
 		started = false
 		return nil, err


### PR DESCRIPTION
Closes #73

Worker dialing now decodes and retains the hello payload before starting the receive loop. It rejects incompatible protocol versions with a structured error containing received and supported versions, and a requirements-aware dial path rejects missing filesystem-RPC or L2 capabilities. The real sidecar launcher passes the capabilities required by its platform (both on Darwin/arm64, neither elsewhere). Unknown optional hello and capability fields remain forward-compatible.

Tests cover retained identity metadata, structured version rejection, required-capability rejection, and unknown future fields.

Validation:
- `go test -race ./internal/vm/sidecar -run 'TestDialWorker(ReadsHello|RejectsUnsupportedVersion|ChecksRequiredCapabilities|ToleratesOptionalHelloFields)$' -count=50`\n- `go vet ./internal/vm/sidecar ./internal/vm`\n- `go test ./...`\n\nA broad `-race -count=20` package repetition also exercised the unrelated pre-existing `WaitCommand` timeout bug fixed separately in #136; the focused negotiation race run above is clean.