### PR TITLE
Cancel abandoned sidecar waits

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -577,8 +577,11 @@ func (e *workerActiveExec) forwardInputs() {
 }
 
 func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOptions) error {
+	connectionCtx, cancelConnection := context.WithCancel(context.Background())
+	defer cancelConnection()
 	var activeMu sync.Mutex
 	activeExecs := make(map[uint64]*workerActiveExec)
+	activeWaits := make(map[uint64]*workerActiveWait)
 
 	for {
 		frame, err := codec.Receive()
@@ -644,7 +647,7 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 		case vm.WorkerFrameWait:
 			var req vm.WorkerWaitRequest
 			_ = frame.DecodePayload(&req)
-			go serveWorkerWait(codec, srvState, frame.ID, req.ID)
+			serveWorkerWait(connectionCtx, codec, srvState, frame.ID, req.ID, &activeMu, activeWaits)
 		case vm.WorkerFrameFlush:
 			var req vm.WorkerFlushRequest
 			_ = frame.DecodePayload(&req)
@@ -674,7 +677,7 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 			}
 			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerConsoleResponse{History: history})
 		case vm.WorkerFrameExec:
-			if err := serveWorkerExec(codec, srvState, frame, &activeMu, activeExecs); err != nil {
+			if err := serveWorkerExec(connectionCtx, codec, srvState, frame, &activeMu, activeExecs); err != nil {
 				_ = sendWorkerError(codec, frame.ID, err)
 			}
 		case vm.WorkerFrameExecInput:
@@ -699,10 +702,14 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 		case vm.WorkerFrameCancel:
 			activeMu.Lock()
 			exec := activeExecs[frame.ID]
+			wait := activeWaits[frame.ID]
 			activeMu.Unlock()
 			if exec != nil {
 				exec.cancel()
 				exec.closeInputs()
+			}
+			if wait != nil {
+				wait.cancel()
 			}
 		default:
 			_ = sendWorkerError(codec, frame.ID, fmt.Errorf("unsupported worker frame %q", frame.Type))
@@ -710,25 +717,60 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 	}
 }
 
-func serveWorkerWait(codec *vm.WorkerCodec, srvState *server, frameID uint64, id string) {
+type workerActiveWait struct {
+	cancel context.CancelFunc
+}
+
+func serveWorkerWait(parent context.Context, codec *vm.WorkerCodec, srvState *server, frameID uint64, id string, activeMu *sync.Mutex, activeWaits map[uint64]*workerActiveWait) {
+	ctx, cancel := context.WithCancel(parent)
+	wait := &workerActiveWait{cancel: cancel}
+	activeMu.Lock()
+	if previous := activeWaits[frameID]; previous != nil {
+		previous.cancel()
+	}
+	activeWaits[frameID] = wait
+	activeMu.Unlock()
+
+	go func() {
+		defer cancel()
+		defer func() {
+			activeMu.Lock()
+			if activeWaits[frameID] == wait {
+				delete(activeWaits, frameID)
+			}
+			activeMu.Unlock()
+		}()
+		state, completed := waitForWorkerState(ctx, func() client.InstanceState {
+			return srvState.vms.StatusOf(id)
+		})
+		if completed {
+			_ = sendWorkerPayload(codec, frameID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: state})
+		}
+	}()
+}
+
+func waitForWorkerState(ctx context.Context, status func() client.InstanceState) (client.InstanceState, bool) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		state := srvState.vms.StatusOf(id)
+		state := status()
 		if state.Status != "running" && state.Status != "starting" {
-			_ = sendWorkerPayload(codec, frameID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: state})
-			return
+			return state, true
 		}
-		<-ticker.C
+		select {
+		case <-ctx.Done():
+			return client.InstanceState{}, false
+		case <-ticker.C:
+		}
 	}
 }
 
-func serveWorkerExec(codec *vm.WorkerCodec, srvState *server, frame vm.WorkerFrame, activeMu *sync.Mutex, activeExecs map[uint64]*workerActiveExec) error {
+func serveWorkerExec(parent context.Context, codec *vm.WorkerCodec, srvState *server, frame vm.WorkerFrame, activeMu *sync.Mutex, activeExecs map[uint64]*workerActiveExec) error {
 	var req vm.WorkerExecRequest
 	if err := frame.DecodePayload(&req); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(parent)
 	exec := &workerActiveExec{cancel: cancel}
 	if req.InputStream {
 		exec.inputs = make(chan client.ExecInput, 16)

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -2,10 +2,12 @@ package ccvmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -197,6 +199,49 @@ func TestSanitizeExecEventForJSONUsesTextOrBinary(t *testing.T) {
 	}
 	if !bytes.Equal(decoded.Data, []byte{0xff, 0x00}) {
 		t.Fatalf("decoded data = %v", decoded.Data)
+	}
+}
+
+func TestWaitForWorkerStateReturnsTerminalState(t *testing.T) {
+	want := client.InstanceState{ID: "vm", Status: "stopped"}
+	got, completed := waitForWorkerState(t.Context(), func() client.InstanceState { return want })
+	if !completed || got != want {
+		t.Fatalf("wait result = %+v, %t", got, completed)
+	}
+}
+
+func TestWaitForWorkerStateCancellationReleasesAllWaiters(t *testing.T) {
+	const waiterCount = 100
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{}, waiterCount)
+	done := make(chan struct{}, waiterCount)
+	for range waiterCount {
+		go func() {
+			var once sync.Once
+			_, completed := waitForWorkerState(ctx, func() client.InstanceState {
+				once.Do(func() { started <- struct{}{} })
+				return client.InstanceState{Status: "running"}
+			})
+			if completed {
+				t.Errorf("canceled wait reported completion")
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range waiterCount {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not start")
+		}
+	}
+	cancel()
+	for range waiterCount {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not stop after cancellation")
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #72

The worker control connection now owns a cancellation context shared by its asynchronous waits and execs. Wait requests are registered by frame ID, cancel frames cancel both waits and execs idempotently, duplicate wait IDs replace and cancel the prior operation, and connection teardown releases every outstanding operation. Canceled waits exit without attempting a terminal write on the abandoned connection.

Tests verify terminal wait results and release 100 simultaneously abandoned waits after cancellation without goroutine-count heuristics.

Validation:
- `go test -race ./internal/ccvmd -run 'TestWaitForWorkerState' -count=50`\n- `go vet ./internal/ccvmd`\n- `go test ./...`