### PR TITLE
Bound sidecar worker hello

### DIFF
--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -29,6 +29,8 @@ type workerFrameResult struct {
 	err   error
 }
 
+const workerHelloTimeout = 5 * time.Second
+
 func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 	var conn net.Conn
 	var err error
@@ -49,7 +51,7 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 		}
 	}
 	worker := &Client{conn: conn, codec: NewWorkerCodec(conn), pending: map[uint64]chan workerFrameResult{}}
-	frame, err := worker.codec.Receive()
+	frame, err := receiveWorkerHello(ctx, conn, worker.codec, workerHelloTimeout)
 	if err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("read sidecar worker hello: %w", err)
@@ -60,6 +62,37 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 	}
 	go worker.receiveLoop()
 	return worker, nil
+}
+
+func receiveWorkerHello(ctx context.Context, conn net.Conn, codec *WorkerCodec, timeout time.Duration) (WorkerFrame, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	deadline := time.Now().Add(timeout)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
+	}
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		return WorkerFrame{}, err
+	}
+
+	cancelWatchDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-cancelWatchDone:
+		}
+	}()
+	frame, err := codec.Receive()
+	close(cancelWatchDone)
+	if clearErr := conn.SetReadDeadline(time.Time{}); err == nil && clearErr != nil {
+		err = clearErr
+	}
+	if ctx.Err() != nil {
+		return WorkerFrame{}, ctx.Err()
+	}
+	return frame, err
 }
 
 func workerDialTarget(address string) (string, string) {

--- a/internal/vm/sidecar/client_test.go
+++ b/internal/vm/sidecar/client_test.go
@@ -2,7 +2,9 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -46,6 +48,92 @@ func TestDialWorkerRejectsNonHello(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 	if err := <-done; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestWorkerHelloTimesOutForSilentPeer(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	started := time.Now()
+	_, err := receiveWorkerHello(t.Context(), clientConn, NewWorkerCodec(clientConn), 20*time.Millisecond)
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("hello error = %v, want network timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("silent hello took %s", elapsed)
+	}
+}
+
+func TestWorkerHelloCancellationClosesConnection(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		_, err := receiveWorkerHello(ctx, clientConn, NewWorkerCodec(clientConn), time.Second)
+		result <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("hello error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("hello did not return after cancellation")
+	}
+	readDone := make(chan error, 1)
+	go func() {
+		var buf [1]byte
+		_, err := serverConn.Read(buf[:])
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("peer read error = %v, want closed connection EOF", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("peer connection remained open after cancellation")
+	}
+}
+
+func TestWorkerHelloDeadlineIsClearedAfterSuccess(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+	clientCodec := NewWorkerCodec(clientConn)
+	serverCodec := NewWorkerCodec(serverConn)
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := serverCodec.Send(WorkerFrame{Type: WorkerFrameHello}); err != nil {
+			serverErr <- err
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+		serverErr <- serverCodec.Send(WorkerFrame{Type: WorkerFrameDone})
+	}()
+
+	frame, err := receiveWorkerHello(t.Context(), clientConn, clientCodec, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("receive hello: %v", err)
+	}
+	if frame.Type != WorkerFrameHello {
+		t.Fatalf("hello frame type = %q", frame.Type)
+	}
+	frame, err = clientCodec.Receive()
+	if err != nil {
+		t.Fatalf("receive after handshake timeout elapsed: %v", err)
+	}
+	if frame.Type != WorkerFrameDone {
+		t.Fatalf("post-handshake frame type = %q", frame.Type)
+	}
+	if err := <-serverErr; err != nil {
 		t.Fatalf("server: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #71

The sidecar worker hello now has a five-second read deadline, shortened when the caller already has an earlier deadline. Caller cancellation closes the connection to interrupt a blocked decode. After a successful hello, the read deadline is explicitly cleared before normal framed operation begins.

Tests verify timeout against a silent peer, bounded cancellation with peer-observable connection close, and successful receipt of a later frame after the handshake timeout has elapsed.

Validation:
- `go test -race ./internal/vm/sidecar -run 'TestWorkerHello' -count=20`\n- `go vet ./internal/vm/sidecar`\n- `go test ./...`