### PR TITLE
Use contexts for sidecar dialing

### DIFF
--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -29,24 +29,15 @@ type workerFrameResult struct {
 	err   error
 }
 
+const (
+	workerConnectTimeout = 5 * time.Second
+	workerRetryDelay     = 10 * time.Millisecond
+)
+
 func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
-	var conn net.Conn
-	var err error
-	network, address := workerDialTarget(socketPath)
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		conn, err = net.Dial(network, address)
-		if err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("dial sidecar worker control socket: %w", err)
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(10 * time.Millisecond):
-		}
+	conn, err := dialWorkerConnection(ctx, socketPath, workerConnectTimeout, (&net.Dialer{}).DialContext)
+	if err != nil {
+		return nil, fmt.Errorf("dial sidecar worker control socket: %w", err)
 	}
 	worker := &Client{conn: conn, codec: NewWorkerCodec(conn), pending: map[uint64]chan workerFrameResult{}}
 	frame, err := worker.codec.Receive()
@@ -60,6 +51,37 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 	}
 	go worker.receiveLoop()
 	return worker, nil
+}
+
+type workerDialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+func dialWorkerConnection(ctx context.Context, socketPath string, timeout time.Duration, dial workerDialContextFunc) (net.Conn, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	network, address := workerDialTarget(socketPath)
+	retry := time.NewTimer(workerRetryDelay)
+	if !retry.Stop() {
+		<-retry.C
+	}
+	defer retry.Stop()
+	for {
+		conn, err := dial(connectCtx, network, address)
+		if err == nil {
+			return conn, nil
+		}
+		if connectCtx.Err() != nil {
+			return nil, connectCtx.Err()
+		}
+		retry.Reset(workerRetryDelay)
+		select {
+		case <-connectCtx.Done():
+			return nil, connectCtx.Err()
+		case <-retry.C:
+		}
+	}
 }
 
 func workerDialTarget(address string) (string, string) {

--- a/internal/vm/sidecar/client_test.go
+++ b/internal/vm/sidecar/client_test.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -18,6 +19,80 @@ func TestWorkerDialTarget(t *testing.T) {
 	network, address = workerDialTarget("/tmp/worker.sock")
 	if network != "unix" || address != "/tmp/worker.sock" {
 		t.Fatalf("unix target = %q %q", network, address)
+	}
+}
+
+func TestDialWorkerConnectionUsesContextForUnixAndTCP(t *testing.T) {
+	tests := []struct {
+		target  string
+		network string
+		address string
+	}{
+		{target: "tcp://127.0.0.1:1234", network: "tcp", address: "127.0.0.1:1234"},
+		{target: "/tmp/worker.sock", network: "unix", address: "/tmp/worker.sock"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			peer := make(chan net.Conn, 1)
+			conn, err := dialWorkerConnection(t.Context(), tt.target, time.Second, func(ctx context.Context, network, address string) (net.Conn, error) {
+				if network != tt.network || address != tt.address {
+					t.Fatalf("dial target = %q %q", network, address)
+				}
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("dial context has no connection deadline")
+				}
+				clientConn, serverConn := net.Pipe()
+				peer <- serverConn
+				return clientConn, nil
+			})
+			if err != nil {
+				t.Fatalf("dialWorkerConnection: %v", err)
+			}
+			_ = conn.Close()
+			_ = (<-peer).Close()
+		})
+	}
+}
+
+func TestDialWorkerConnectionHonorsCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		_, err := dialWorkerConnection(ctx, "tcp://127.0.0.1:1", time.Second, func(ctx context.Context, _, _ string) (net.Conn, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+		result <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("dial did not start")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("dial error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("dial did not return after cancellation")
+	}
+}
+
+func TestDialWorkerConnectionHasTotalBudget(t *testing.T) {
+	started := time.Now()
+	_, err := dialWorkerConnection(t.Context(), "tcp://127.0.0.1:1", 20*time.Millisecond, func(ctx context.Context, _, _ string) (net.Conn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("dial error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("dial exceeded total budget: %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
Closes #70

Sidecar worker connections now use `net.Dialer.DialContext` under one five-second connection-budget context (or an earlier caller deadline). Retries share that context and reuse one timer, so an individual dial and the retry loop are both interruptible and bounded. Unix and TCP targets follow the same path.

Tests verify deadline-bearing contexts for both target types, in-flight caller cancellation, and structured total-budget expiry.

Validation:
- `go test -race ./internal/vm/sidecar -run 'TestDialWorkerConnection' -count=50`\n- `go vet ./internal/vm/sidecar`\n- `go test ./...`