### PR TITLE
Bound sidecar exec input queues

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -517,6 +517,28 @@ type workerActiveExec struct {
 	closed bool
 }
 
+const (
+	workerExecInputQueueCapacity = 64
+	workerExecStdinQueueLimit    = 56
+	workerExecControlQueueLimit  = workerExecInputQueueCapacity - 1
+)
+
+var (
+	errWorkerExecInputsClosed  = errors.New("worker exec input queue is closed")
+	errWorkerExecInputOverflow = errors.New("worker exec input queue is full")
+)
+
+func newWorkerActiveExec(cancel context.CancelFunc, withInputs bool) *workerActiveExec {
+	exec := &workerActiveExec{cancel: cancel}
+	if withInputs {
+		exec.inputs = make(chan client.ExecInput, 16)
+		exec.done = make(chan struct{})
+		exec.cond = sync.NewCond(&exec.mu)
+		exec.queue = make([]client.ExecInput, 0, workerExecInputQueueCapacity)
+	}
+	return exec
+}
+
 func (e *workerActiveExec) closeInputs() {
 	if e == nil || e.inputs == nil {
 		return
@@ -532,21 +554,42 @@ func (e *workerActiveExec) closeInputs() {
 	})
 }
 
-func (e *workerActiveExec) sendInput(input client.ExecInput) bool {
+func (e *workerActiveExec) sendInput(input client.ExecInput) error {
 	if e == nil || e.inputs == nil {
-		return false
+		return errWorkerExecInputsClosed
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.closed {
-		return false
+		return errWorkerExecInputsClosed
+	}
+	limit := workerExecControlQueueLimit
+	if input.Kind == "stdin" {
+		limit = workerExecStdinQueueLimit
+	} else if input.Kind == "stdin_close" {
+		limit = workerExecInputQueueCapacity
+	}
+	if len(e.queue) >= limit {
+		return errWorkerExecInputOverflow
 	}
 	if input.Kind == "stdin_close" {
 		e.closed = true
 	}
 	e.queue = append(e.queue, input)
 	e.cond.Signal()
-	return true
+	return nil
+}
+
+func enqueueWorkerExecInput(exec *workerActiveExec, input client.ExecInput) error {
+	err := exec.sendInput(input)
+	if !errors.Is(err, errWorkerExecInputOverflow) {
+		return err
+	}
+	if exec.cancel != nil {
+		exec.cancel()
+	}
+	exec.closeInputs()
+	return err
 }
 
 func (e *workerActiveExec) forwardInputs() {
@@ -690,11 +733,11 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 				continue
 			}
 			if req.Closed {
-				_ = exec.sendInput(client.ExecInput{Kind: "stdin_close"})
+				_ = enqueueWorkerExecInput(exec, client.ExecInput{Kind: "stdin_close"})
 				continue
 			}
-			if !exec.sendInput(req.Input) {
-				_ = sendWorkerError(codec, frame.ID, fmt.Errorf("worker exec input queue is full"))
+			if err := enqueueWorkerExecInput(exec, req.Input); errors.Is(err, errWorkerExecInputOverflow) {
+				_ = sendWorkerError(codec, frame.ID, err)
 			}
 		case vm.WorkerFrameCancel:
 			activeMu.Lock()
@@ -729,11 +772,8 @@ func serveWorkerExec(codec *vm.WorkerCodec, srvState *server, frame vm.WorkerFra
 		return err
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	exec := &workerActiveExec{cancel: cancel}
+	exec := newWorkerActiveExec(cancel, req.InputStream)
 	if req.InputStream {
-		exec.inputs = make(chan client.ExecInput, 16)
-		exec.done = make(chan struct{})
-		exec.cond = sync.NewCond(&exec.mu)
 		go exec.forwardInputs()
 	}
 	activeMu.Lock()

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -2,7 +2,9 @@ package ccvmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -197,6 +199,58 @@ func TestSanitizeExecEventForJSONUsesTextOrBinary(t *testing.T) {
 	}
 	if !bytes.Equal(decoded.Data, []byte{0xff, 0x00}) {
 		t.Fatalf("decoded data = %v", decoded.Data)
+	}
+}
+
+func TestWorkerExecInputQueueBoundsAndReservesControlCapacity(t *testing.T) {
+	exec := newWorkerActiveExec(nil, true)
+	for i := 0; i < workerExecStdinQueueLimit; i++ {
+		if err := exec.sendInput(client.ExecInput{Kind: "stdin", Data: []byte{byte(i)}}); err != nil {
+			t.Fatalf("enqueue stdin %d: %v", i, err)
+		}
+	}
+	if err := exec.sendInput(client.ExecInput{Kind: "stdin"}); !errors.Is(err, errWorkerExecInputOverflow) {
+		t.Fatalf("stdin overflow error = %v", err)
+	}
+	for len(exec.queue) < workerExecControlQueueLimit {
+		if err := exec.sendInput(client.ExecInput{Kind: "resize", Cols: len(exec.queue)}); err != nil {
+			t.Fatalf("enqueue reserved control input: %v", err)
+		}
+	}
+	if err := exec.sendInput(client.ExecInput{Kind: "signal", Signal: "TERM"}); !errors.Is(err, errWorkerExecInputOverflow) {
+		t.Fatalf("control overflow error = %v", err)
+	}
+	if err := exec.sendInput(client.ExecInput{Kind: "stdin_close"}); err != nil {
+		t.Fatalf("enqueue reserved stdin close: %v", err)
+	}
+	if len(exec.queue) != workerExecInputQueueCapacity || cap(exec.queue) != workerExecInputQueueCapacity {
+		t.Fatalf("queue length/capacity = %d/%d", len(exec.queue), cap(exec.queue))
+	}
+}
+
+func TestWorkerExecInputOverflowCancelsOnlyExec(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	exec := newWorkerActiveExec(cancel, true)
+	for i := 0; i < workerExecStdinQueueLimit; i++ {
+		if err := exec.sendInput(client.ExecInput{Kind: "stdin"}); err != nil {
+			t.Fatalf("enqueue stdin %d: %v", i, err)
+		}
+	}
+	if err := enqueueWorkerExecInput(exec, client.ExecInput{Kind: "stdin"}); !errors.Is(err, errWorkerExecInputOverflow) {
+		t.Fatalf("overflow error = %v", err)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("overflow did not cancel exec")
+	}
+	select {
+	case <-exec.done:
+	case <-time.After(time.Second):
+		t.Fatal("overflow did not close exec inputs")
+	}
+	if len(exec.queue) != workerExecStdinQueueLimit || cap(exec.queue) != workerExecInputQueueCapacity {
+		t.Fatalf("queue length/capacity = %d/%d", len(exec.queue), cap(exec.queue))
 	}
 }
 


### PR DESCRIPTION
Closes #69

Each sidecar exec now preallocates a fixed 64-entry input queue. Ordinary stdin is capped at 56 entries, general exec controls retain seven additional slots, and `stdin_close` retains the final slot; request cancellation continues to bypass the queue. Overflow returns the per-request worker error path and cancels/closes only the affected exec.

Tests assert the exact bounded queue state and reserved control capacity, then verify overflow is structurally reported and cancels the affected exec.

Validation:
- `go test -race ./internal/ccvmd -run 'TestWorkerExecInput' -count=100`\n- `go vet ./internal/ccvmd`\n- `go test ./...`