### PR TITLE
Surface daemon shutdown failures

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -416,13 +416,13 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 
 	var httpServer http.Server
 	shutdown := newServerShutdown(srvState, &httpServer)
-	watchdog := newWatchdogController(shutdown)
+	watchdog := newWatchdogController(shutdown.Shutdown)
 	if opts.Persistent {
-		watchdog = newPersistentWatchdogController(shutdown)
+		watchdog = newPersistentWatchdogController(shutdown.Shutdown)
 	}
 	defer watchdog.Stop()
 	srvState.images.CVMFSActivity = watchdog.RecordCVMFSActivity
-	mux := newMux(srvState, watchdog, shutdown, opts)
+	mux := newMux(srvState, watchdog, shutdown.Shutdown, opts)
 	if opts.RegisterHandlers != nil {
 		opts.RegisterHandlers(mux, srvState)
 	}
@@ -432,10 +432,9 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 		handler = opts.WrapHandler(handler)
 	}
 	httpServer = http.Server{Handler: handler}
-	if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return true, fmt.Errorf("serve daemon API: %w", err)
-	}
-	return true, nil
+	serveErr := daemonServeError(httpServer.Serve(l))
+	shutdownErr := shutdown.Err()
+	return true, errors.Join(serveErr, shutdownErr)
 }
 
 func writeStartupError(w interface{ Write([]byte) (int, error) }, err error) error {
@@ -773,20 +772,63 @@ func sendWorkerError(codec *vm.WorkerCodec, id uint64, err error) error {
 	return sendWorkerPayload(codec, id, vm.WorkerFrameError, vm.WorkerError{Error: err.Error()})
 }
 
-func newServerShutdown(srvState *server, httpServer *http.Server) func() {
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if srvState != nil && srvState.vms != nil {
-				_ = srvState.vms.ShutdownAll(ctx)
-			}
-			if httpServer != nil {
-				_ = httpServer.Shutdown(ctx)
-			}
-		})
+type serverShutdown struct {
+	once         sync.Once
+	shutdownVMs  func(context.Context) error
+	shutdownHTTP func(context.Context) error
+	err          error
+}
+
+func newServerShutdown(srvState *server, httpServer *http.Server) *serverShutdown {
+	shutdown := &serverShutdown{}
+	if srvState != nil && srvState.vms != nil {
+		shutdown.shutdownVMs = srvState.vms.ShutdownAll
 	}
+	if httpServer != nil {
+		shutdown.shutdownHTTP = httpServer.Shutdown
+	}
+	return shutdown
+}
+
+func (s *serverShutdown) Shutdown() {
+	if s == nil {
+		return
+	}
+	s.once.Do(func() {
+		var errs []error
+		if s.shutdownVMs != nil {
+			if err := runShutdownStep(s.shutdownVMs); err != nil {
+				errs = append(errs, fmt.Errorf("shutdown VMs: %w", err))
+			}
+		}
+		if s.shutdownHTTP != nil {
+			if err := runShutdownStep(s.shutdownHTTP); err != nil {
+				errs = append(errs, fmt.Errorf("shutdown HTTP server: %w", err))
+			}
+		}
+		s.err = errors.Join(errs...)
+	})
+}
+
+func (s *serverShutdown) Err() error {
+	if s == nil {
+		return nil
+	}
+	s.Shutdown()
+	return s.err
+}
+
+func runShutdownStep(step func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return step(ctx)
+}
+
+func daemonServeError(err error) error {
+	if err == nil || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return fmt.Errorf("serve daemon API: %w", err)
 }
 
 func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opts ServerOptions) *http.ServeMux {

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -2,7 +2,9 @@ package ccvmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -197,6 +199,44 @@ func TestSanitizeExecEventForJSONUsesTextOrBinary(t *testing.T) {
 	}
 	if !bytes.Equal(decoded.Data, []byte{0xff, 0x00}) {
 		t.Fatalf("decoded data = %v", decoded.Data)
+	}
+}
+
+func TestServerShutdownReportsErrorsAndAttemptsEveryResource(t *testing.T) {
+	vmErr := errors.New("vm shutdown failed")
+	httpErr := errors.New("http shutdown failed")
+	var calls []string
+	shutdown := &serverShutdown{
+		shutdownVMs: func(context.Context) error {
+			calls = append(calls, "vm")
+			return vmErr
+		},
+		shutdownHTTP: func(context.Context) error {
+			calls = append(calls, "http")
+			return httpErr
+		},
+	}
+
+	err := shutdown.Err()
+	if !errors.Is(err, vmErr) || !errors.Is(err, httpErr) {
+		t.Fatalf("shutdown error = %v", err)
+	}
+	if len(calls) != 2 || calls[0] != "vm" || calls[1] != "http" {
+		t.Fatalf("shutdown calls = %v", calls)
+	}
+	shutdown.Shutdown()
+	if len(calls) != 2 {
+		t.Fatalf("repeated shutdown calls = %v", calls)
+	}
+}
+
+func TestDaemonServeErrorDistinguishesNormalShutdown(t *testing.T) {
+	if err := daemonServeError(http.ErrServerClosed); err != nil {
+		t.Fatalf("normal shutdown error = %v", err)
+	}
+	serveErr := errors.New("listener failed")
+	if err := daemonServeError(serveErr); !errors.Is(err, serveErr) {
+		t.Fatalf("serve error = %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #64

Daemon shutdown is now coordinated by an idempotent result-bearing object. VM and HTTP cleanup each receive an independent five-second context, both are attempted even when one fails, and their errors are joined into the `RunServer` result. Real serve failures are joined as well, while `http.ErrServerClosed` remains the expected successful shutdown signal.

Tests use structured `errors.Is` assertions to verify both cleanup failures survive, all resources are attempted exactly once, and normal versus real serve termination is distinguished.

Validation:
- `go test -race ./internal/ccvmd -run 'TestServerShutdown|TestDaemonServeError' -count=100`\n- `go vet ./internal/ccvmd`\n- `go test ./...`