### PR TITLE
Isolate boot event writers

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -40,7 +40,6 @@ func isBuiltInBSDImage(name string) bool {
 
 var debugTiming = strings.TrimSpace(os.Getenv("CCX3_DEBUG_TIMING")) != ""
 var debugPprof = strings.TrimSpace(os.Getenv("CCX3_DEBUG_PPROF")) != ""
-var bootEventWriteMu sync.Mutex
 
 const defaultVMBootTimeout = 5 * time.Second
 
@@ -1287,18 +1286,20 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		bootTimeout := bootTimeoutFromRequest(req.TimeoutSeconds)
 		bootCtx, cancel := context.WithTimeout(r.Context(), bootTimeout)
 		defer cancel()
+		bootEvents := newBootEventWriter(w)
+		defer bootEvents.Close()
 		timingLog("POST /vm/start decode took=%s", time.Since(start))
 		var startImage *oci.Image
 		builtInBSDImage := isBuiltInBSDImage(req.Image)
 		if imageName := strings.TrimSpace(req.Image); imageName != "" {
 			if builtInBSDImage {
 				if wantsBootEventStream(r) {
-					writeBootEvent(w, client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", imageName)})
+					bootEvents.Write(client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", imageName)})
 				}
 			} else if _, err := srvState.images.Get(imageName); err != nil {
 				msg := fmt.Sprintf("image %q is not available", imageName)
 				if wantsBootEventStream(r) {
-					writeBootEvent(w, client.BootEvent{Kind: "error", Error: msg})
+					bootEvents.Write(client.BootEvent{Kind: "error", Error: msg})
 					return
 				}
 				writeError(w, http.StatusBadRequest, fmt.Errorf("%s", msg))
@@ -1308,7 +1309,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 				if err != nil {
 					msg := fmt.Sprintf("image %q is not available: %s", imageName, err)
 					if wantsBootEventStream(r) {
-						writeBootEvent(w, client.BootEvent{Kind: "error", Error: msg})
+						bootEvents.Write(client.BootEvent{Kind: "error", Error: msg})
 						return
 					}
 					writeError(w, http.StatusBadRequest, fmt.Errorf("%s", msg))
@@ -1316,13 +1317,13 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 				}
 				startImage = image
 				if wantsBootEventStream(r) {
-					writeBootEvent(w, client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", imageName)})
+					bootEvents.Write(client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", imageName)})
 				}
 			}
 		}
 		if err := vm.Supports(); err != nil {
 			if wantsBootEventStream(r) {
-				writeBootEvent(w, client.BootEvent{Kind: "error", Error: err.Error()})
+				bootEvents.Write(client.BootEvent{Kind: "error", Error: err.Error()})
 				return
 			}
 			writeError(w, http.StatusServiceUnavailable, err)
@@ -1330,15 +1331,15 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		}
 		if !builtInBSDImage && srvState.kernel.Status().Status != "downloaded" {
 			if wantsBootEventStream(r) {
-				writeBootEvent(w, client.BootEvent{Kind: "status", Message: "ensuring kernel is available"})
+				bootEvents.Write(client.BootEvent{Kind: "status", Message: "ensuring kernel is available"})
 			}
 			if err := srvState.kernel.Ensure(bootCtx); err != nil {
 				if wantsBootEventStream(r) {
 					if errors.Is(err, context.DeadlineExceeded) || errors.Is(bootCtx.Err(), context.DeadlineExceeded) {
-						writeBootEvent(w, client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
+						bootEvents.Write(client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
 						return
 					}
-					writeBootEvent(w, client.BootEvent{Kind: "error", Error: err.Error()})
+					bootEvents.Write(client.BootEvent{Kind: "error", Error: err.Error()})
 					return
 				}
 				if errors.Is(err, context.DeadlineExceeded) || errors.Is(bootCtx.Err(), context.DeadlineExceeded) {
@@ -1352,22 +1353,22 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		timingLog("POST /vm/start kernel ensure/status took=%s", time.Since(start))
 		if vm.NeedsAMD64Emulation(startImage) {
 			if wantsBootEventStream(r) {
-				writeBootEvent(w, client.BootEvent{Kind: "status", Message: "preparing amd64 emulator"})
+				bootEvents.Write(client.BootEvent{Kind: "status", Message: "preparing amd64 emulator"})
 				_, err := srvState.kernel.ExtractPackageFileWithProgress(
 					bootCtx,
 					"community",
 					"qemu-x86_64",
 					"usr/bin/qemu-x86_64",
 					func(event client.ProgressEvent) {
-						_ = writeBootEvent(w, client.BootEvent{Kind: "status", Message: bootProgressMessage("preparing amd64 emulator", event)})
+						_ = bootEvents.Write(client.BootEvent{Kind: "status", Message: bootProgressMessage("preparing amd64 emulator", event)})
 					},
 				)
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) || errors.Is(bootCtx.Err(), context.DeadlineExceeded) {
-						writeBootEvent(w, client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
+						bootEvents.Write(client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
 						return
 					}
-					writeBootEvent(w, client.BootEvent{Kind: "error", Error: err.Error()})
+					bootEvents.Write(client.BootEvent{Kind: "error", Error: err.Error()})
 					return
 				}
 			} else if _, err := vm.PrepareAMD64Emulator(bootCtx, startImage, srvState.kernel.ExtractPackageFile); err != nil {
@@ -1380,22 +1381,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			}
 		}
 		if wantsBootEventStream(r) {
-			var streamMu sync.Mutex
-			streamOpen := true
-			writeStreamEvent := func(event client.BootEvent) error {
-				streamMu.Lock()
-				defer streamMu.Unlock()
-				if !streamOpen {
-					return nil
-				}
-				return writeBootEvent(w, event)
-			}
-			closeStream := func() {
-				streamMu.Lock()
-				streamOpen = false
-				streamMu.Unlock()
-			}
-			defer closeStream()
+			writeStreamEvent := bootEvents.Write
 
 			writeStreamEvent(client.BootEvent{Kind: "status", Message: "starting VM"})
 			state, err := srvState.vms.StartBlankStream(bootCtx, req, func(event client.BootEvent) error {
@@ -1447,12 +1433,14 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		bootTimeout := bootTimeoutFromRequest(req.TimeoutSeconds)
 		bootCtx, cancel := context.WithTimeout(r.Context(), bootTimeout)
 		defer cancel()
+		bootEvents := newBootEventWriter(w)
+		defer bootEvents.Close()
 		timingLog("POST /vm decode took=%s image=%q", time.Since(start), req.Image)
 		builtInBSDImage := isBuiltInBSDImage(req.Image)
 		if !builtInBSDImage {
 			if _, err := srvState.images.Get(req.Image); err != nil {
 				if wantsBootEventStream(r) {
-					writeBootEvent(w, client.BootEvent{Kind: "error", Error: fmt.Sprintf("image %q is not available", req.Image)})
+					bootEvents.Write(client.BootEvent{Kind: "error", Error: fmt.Sprintf("image %q is not available", req.Image)})
 					return
 				}
 				writeError(w, http.StatusBadRequest, fmt.Errorf("image %q is not available", req.Image))
@@ -1463,11 +1451,11 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			timingLog("POST /vm builtin image lookup took=%s", time.Since(start))
 		}
 		if wantsBootEventStream(r) {
-			writeBootEvent(w, client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", req.Image)})
+			bootEvents.Write(client.BootEvent{Kind: "status", Message: fmt.Sprintf("validated image %s", req.Image)})
 		}
 		if err := vm.Supports(); err != nil {
 			if wantsBootEventStream(r) {
-				writeBootEvent(w, client.BootEvent{Kind: "error", Error: err.Error()})
+				bootEvents.Write(client.BootEvent{Kind: "error", Error: err.Error()})
 				return
 			}
 			writeError(w, http.StatusServiceUnavailable, err)
@@ -1475,15 +1463,15 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		}
 		if !builtInBSDImage && srvState.kernel.Status().Status != "downloaded" {
 			if wantsBootEventStream(r) {
-				writeBootEvent(w, client.BootEvent{Kind: "status", Message: "ensuring kernel is available"})
+				bootEvents.Write(client.BootEvent{Kind: "status", Message: "ensuring kernel is available"})
 			}
 			if err := srvState.kernel.Ensure(bootCtx); err != nil {
 				if wantsBootEventStream(r) {
 					if errors.Is(err, context.DeadlineExceeded) || errors.Is(bootCtx.Err(), context.DeadlineExceeded) {
-						writeBootEvent(w, client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
+						bootEvents.Write(client.BootEvent{Kind: "error", Error: fmt.Sprintf("vm boot timed out after %s", bootTimeout)})
 						return
 					}
-					writeBootEvent(w, client.BootEvent{Kind: "error", Error: err.Error()})
+					bootEvents.Write(client.BootEvent{Kind: "error", Error: err.Error()})
 					return
 				}
 				if errors.Is(err, context.DeadlineExceeded) || errors.Is(bootCtx.Err(), context.DeadlineExceeded) {
@@ -1496,22 +1484,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		}
 		timingLog("POST /vm kernel ensure/status took=%s", time.Since(start))
 		if wantsBootEventStream(r) {
-			var streamMu sync.Mutex
-			streamOpen := true
-			writeStreamEvent := func(event client.BootEvent) error {
-				streamMu.Lock()
-				defer streamMu.Unlock()
-				if !streamOpen {
-					return nil
-				}
-				return writeBootEvent(w, event)
-			}
-			closeStream := func() {
-				streamMu.Lock()
-				streamOpen = false
-				streamMu.Unlock()
-			}
-			defer closeStream()
+			writeStreamEvent := bootEvents.Write
 
 			writeStreamEvent(client.BootEvent{Kind: "status", Message: fmt.Sprintf("starting VM for %s", req.Image)})
 			state, err := srvState.vms.StartStream(bootCtx, req, func(event client.BootEvent) error {
@@ -1903,22 +1876,47 @@ func sanitizeExecEventForJSON(event client.ExecEvent) client.ExecEvent {
 	return event
 }
 
-func writeBootEvent(w http.ResponseWriter, event client.BootEvent) (err error) {
-	bootEventWriteMu.Lock()
-	defer bootEventWriteMu.Unlock()
+type bootEventWriter struct {
+	mu   sync.Mutex
+	w    http.ResponseWriter
+	open bool
+}
+
+func newBootEventWriter(w http.ResponseWriter) *bootEventWriter {
+	return &bootEventWriter{w: w, open: true}
+}
+
+func (w *bootEventWriter) Close() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	w.open = false
+	w.mu.Unlock()
+}
+
+func (w *bootEventWriter) Write(event client.BootEvent) (err error) {
+	if w == nil {
+		return fmt.Errorf("boot event writer is unavailable")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.open {
+		return nil
+	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("write boot event: %v", recovered)
 		}
 	}()
-	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.w.Header().Set("Content-Type", "application/x-ndjson")
 	if event.Kind == "" {
 		event.Kind = "status"
 	}
-	if err := json.NewEncoder(w).Encode(event); err != nil {
+	if err := json.NewEncoder(w.w).Encode(event); err != nil {
 		return err
 	}
-	if flusher, ok := w.(http.Flusher); ok {
+	if flusher, ok := w.w.(http.Flusher); ok {
 		flusher.Flush()
 	}
 	return nil

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -2,10 +2,14 @@ package ccvmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -198,6 +202,131 @@ func TestSanitizeExecEventForJSONUsesTextOrBinary(t *testing.T) {
 	if !bytes.Equal(decoded.Data, []byte{0xff, 0x00}) {
 		t.Fatalf("decoded data = %v", decoded.Data)
 	}
+}
+
+func TestBootEventWritersDoNotBlockOtherStreams(t *testing.T) {
+	blockedResponse := &blockingResponseWriter{
+		header:  http.Header{},
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	blocked := newBootEventWriter(blockedResponse)
+	blockedDone := make(chan error, 1)
+	go func() {
+		blockedDone <- blocked.Write(client.BootEvent{Kind: "status", Message: "blocked"})
+	}()
+	select {
+	case <-blockedResponse.started:
+	case <-time.After(time.Second):
+		t.Fatal("first stream did not begin writing")
+	}
+
+	fast := newBootEventWriter(httptest.NewRecorder())
+	fastDone := make(chan error, 1)
+	go func() {
+		fastDone <- fast.Write(client.BootEvent{Kind: "status", Message: "independent"})
+	}()
+	select {
+	case err := <-fastDone:
+		if err != nil {
+			t.Fatalf("independent stream write: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("independent stream blocked behind another response")
+	}
+	close(blockedResponse.release)
+	if err := <-blockedDone; err != nil {
+		t.Fatalf("blocked stream write: %v", err)
+	}
+}
+
+func TestBootEventWriterSerializesValidNDJSON(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writer := newBootEventWriter(recorder)
+	const eventCount = 100
+	var wg sync.WaitGroup
+	errs := make(chan error, eventCount)
+	for i := 0; i < eventCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- writer.Write(client.BootEvent{Kind: "status", Data: fmt.Sprintf("%d", i)})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("write event: %v", err)
+		}
+	}
+	seen := make(map[string]bool, eventCount)
+	decoder := json.NewDecoder(recorder.Body)
+	for {
+		var event client.BootEvent
+		err := decoder.Decode(&event)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		if event.Kind != "status" || seen[event.Data] {
+			t.Fatalf("event = %+v", event)
+		}
+		seen[event.Data] = true
+	}
+	if len(seen) != eventCount {
+		t.Fatalf("decoded events = %d, want %d", len(seen), eventCount)
+	}
+}
+
+func TestBootEventWriterReturnsDisconnectError(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	response := &contextResponseWriter{header: http.Header{}, ctx: ctx}
+	result := make(chan error, 1)
+	go func() {
+		result <- newBootEventWriter(response).Write(client.BootEvent{Kind: "status"})
+	}()
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("write error = %v, want disconnect cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("producer did not return after disconnect")
+	}
+}
+
+type blockingResponseWriter struct {
+	header  http.Header
+	started chan struct{}
+	release chan struct{}
+	buf     bytes.Buffer
+}
+
+func (w *blockingResponseWriter) Header() http.Header { return w.header }
+func (w *blockingResponseWriter) WriteHeader(int)     {}
+func (w *blockingResponseWriter) Write(p []byte) (int, error) {
+	select {
+	case w.started <- struct{}{}:
+	default:
+	}
+	<-w.release
+	return w.buf.Write(p)
+}
+
+type contextResponseWriter struct {
+	header http.Header
+	ctx    context.Context
+}
+
+func (w *contextResponseWriter) Header() http.Header { return w.header }
+func (w *contextResponseWriter) WriteHeader(int)     {}
+func (w *contextResponseWriter) Write([]byte) (int, error) {
+	<-w.ctx.Done()
+	return 0, w.ctx.Err()
 }
 
 func jsonBody(t *testing.T, value any) *bytes.Reader {


### PR DESCRIPTION
Closes #61

Boot progress no longer takes a package-global lock around network I/O. Each boot response owns one serialized writer used for validation, download progress, backend events, errors, and the terminal ready event. Closing a response suppresses late callbacks, while write/disconnect errors propagate to the producer.

Tests prove a blocked response does not delay another stream, 100 concurrent events remain valid unique NDJSON records, and disconnect cancellation releases the producer with a structured context error.

Validation:
- `go test -race ./internal/ccvmd -run 'TestBootEventWriter' -count=50`\n- `go vet ./internal/ccvmd`\n- `go test ./...`