### PR TITLE
Enforce WebSocket origin policy

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -1635,7 +1635,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		writeJSON(w, http.StatusOK, resp)
 	})
 	mux.Handle("/vm/run", websocket.Server{
-		Handshake: func(*websocket.Config, *http.Request) error { return nil },
+		Handshake: validateWebSocketOrigin,
 		Handler: func(ws *websocket.Conn) {
 			serveRunWebSocket(ws, func(ctx context.Context, req client.ExecRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
 				return srvState.vms.Stream(ctx, req, inputs, onEvent)
@@ -1643,7 +1643,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 		},
 	})
 	mux.Handle("/vm/run/stream", websocket.Server{
-		Handshake: func(*websocket.Config, *http.Request) error { return nil },
+		Handshake: validateWebSocketOrigin,
 		Handler: func(ws *websocket.Conn) {
 			serveRunRequestWebSocket(ws, srvState, opts.NormalizeRunRequest, func(ctx context.Context, req client.RunRequest, inputs <-chan client.ExecInput, onEvent func(client.ExecEvent) error) error {
 				runCtx, cancel := runRequestContext(ctx, req)
@@ -1688,6 +1688,68 @@ func registerPprofHandlers(mux *http.ServeMux) {
 	mux.Handle("GET /debug/pprof/heap", pprof.Handler("heap"))
 	mux.Handle("GET /debug/pprof/mutex", pprof.Handler("mutex"))
 	mux.Handle("GET /debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+}
+
+type websocketOriginError struct {
+	Origin string
+	Host   string
+}
+
+func (e *websocketOriginError) Error() string {
+	return fmt.Sprintf("websocket origin %q does not match request host %q", e.Origin, e.Host)
+}
+
+func validateWebSocketOrigin(_ *websocket.Config, r *http.Request) error {
+	origins := r.Header.Values("Origin")
+	if len(origins) == 0 {
+		return nil
+	}
+	if len(origins) != 1 {
+		return &websocketOriginError{Origin: strings.Join(origins, ", "), Host: r.Host}
+	}
+	origin, err := url.Parse(origins[0])
+	if err != nil || origin.Host == "" || origin.User != nil || origin.RawQuery != "" || origin.Fragment != "" || (origin.Path != "" && origin.Path != "/") {
+		return &websocketOriginError{Origin: origins[0], Host: r.Host}
+	}
+	expectedScheme := "http"
+	if r.TLS != nil {
+		expectedScheme = "https"
+	}
+	if !strings.EqualFold(origin.Scheme, expectedScheme) {
+		return &websocketOriginError{Origin: origins[0], Host: r.Host}
+	}
+	originAuthority, err := canonicalWebSocketAuthority(origin.Host, expectedScheme)
+	if err != nil {
+		return &websocketOriginError{Origin: origins[0], Host: r.Host}
+	}
+	hostAuthority, err := canonicalWebSocketAuthority(r.Host, expectedScheme)
+	if err != nil || originAuthority != hostAuthority {
+		return &websocketOriginError{Origin: origins[0], Host: r.Host}
+	}
+	return nil
+}
+
+func canonicalWebSocketAuthority(authority, scheme string) (string, error) {
+	parsed, err := url.Parse("//" + authority)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" {
+		return "", fmt.Errorf("invalid authority")
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	if host == "" {
+		return "", fmt.Errorf("empty host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	}
+	port := parsed.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(host, port), nil
 }
 
 func sharedRuntimeRoot() string {

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -3,12 +3,15 @@ package ccvmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"golang.org/x/net/websocket"
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/vm"
 )
@@ -197,6 +200,80 @@ func TestSanitizeExecEventForJSONUsesTextOrBinary(t *testing.T) {
 	}
 	if !bytes.Equal(decoded.Data, []byte{0xff, 0x00}) {
 		t.Fatalf("decoded data = %v", decoded.Data)
+	}
+}
+
+func TestValidateWebSocketOrigin(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		host    string
+		origins []string
+		wantErr bool
+	}{
+		{name: "non-browser client", target: "http://localhost/vm/run", host: "localhost"},
+		{name: "same origin", target: "http://localhost/vm/run", host: "localhost", origins: []string{"http://localhost"}},
+		{name: "normalized default port", target: "http://localhost/vm/run", host: "localhost:80", origins: []string{"http://LOCALHOST.:80"}},
+		{name: "same secure origin", target: "https://localhost/vm/run", host: "localhost:443", origins: []string{"https://localhost"}},
+		{name: "cross origin", target: "http://localhost/vm/run", host: "localhost", origins: []string{"http://attacker.example"}, wantErr: true},
+		{name: "dns rebinding host", target: "http://127.0.0.1/vm/run", host: "127.0.0.1", origins: []string{"http://attacker.example"}, wantErr: true},
+		{name: "scheme mismatch", target: "http://localhost/vm/run", host: "localhost", origins: []string{"https://localhost"}, wantErr: true},
+		{name: "null origin", target: "http://localhost/vm/run", host: "localhost", origins: []string{"null"}, wantErr: true},
+		{name: "origin path", target: "http://localhost/vm/run", host: "localhost", origins: []string{"http://localhost/path"}, wantErr: true},
+		{name: "multiple origins", target: "http://localhost/vm/run", host: "localhost", origins: []string{"http://localhost", "http://localhost"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			req.Host = tt.host
+			for _, origin := range tt.origins {
+				req.Header.Add("Origin", origin)
+			}
+			err := validateWebSocketOrigin(nil, req)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("validate origin: %v", err)
+				}
+				return
+			}
+			var originErr *websocketOriginError
+			if !errors.As(err, &originErr) {
+				t.Fatalf("origin error = %v", err)
+			}
+			if originErr.Host != tt.host {
+				t.Fatalf("origin error host = %q", originErr.Host)
+			}
+		})
+	}
+}
+
+func TestWebSocketRoutesEnforceOriginPolicy(t *testing.T) {
+	watchdog := newWatchdogController(func() {})
+	defer watchdog.Stop()
+	srv := httptest.NewServer(newMux(&server{vms: vm.NewManagerWithHost(nil)}, watchdog, func() {}, ServerOptions{}))
+	defer srv.Close()
+	wsBase := "ws" + strings.TrimPrefix(srv.URL, "http")
+	for _, path := range []string{"/vm/run", "/vm/run/stream"} {
+		t.Run(path, func(t *testing.T) {
+			crossOrigin, err := websocket.NewConfig(wsBase+path, "http://attacker.example")
+			if err != nil {
+				t.Fatalf("cross-origin config: %v", err)
+			}
+			if conn, err := websocket.DialConfig(crossOrigin); err == nil {
+				_ = conn.Close()
+				t.Fatal("cross-origin upgrade succeeded")
+			}
+
+			sameOrigin, err := websocket.NewConfig(wsBase+path, srv.URL)
+			if err != nil {
+				t.Fatalf("same-origin config: %v", err)
+			}
+			conn, err := websocket.DialConfig(sameOrigin)
+			if err != nil {
+				t.Fatalf("same-origin upgrade: %v", err)
+			}
+			_ = conn.Close()
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #57

Both ccvmd WebSocket control routes now enforce same-origin browser upgrades. Origin scheme and normalized authority (case, trailing dot, IP form, and default port) must match the request TLS state and Host header. Cross-origin, malformed, null, path-bearing, and multiple origins are rejected. Non-browser clients that omit Origin remain supported, and outer authorization middleware still runs before the mux/upgrade.

Tests cover Host/DNS-rebinding mismatches and normalization with structured policy errors, plus real rejected and accepted upgrades on both routes.

Validation:
- `go test -race ./internal/ccvmd -run 'TestValidateWebSocketOrigin|TestWebSocketRoutesEnforceOriginPolicy' -count=50`\n- `go vet ./internal/ccvmd`\n- `go test ./...`