### PR TITLE
Prevent guest tar symlink escapes

### DIFF
--- a/internal/managed/guestagent/agent.go
+++ b/internal/managed/guestagent/agent.go
@@ -698,13 +698,29 @@ func extractTarToPath(r io.Reader, rootDir, dst string, dstDir bool) error {
 	return ExtractTarToPath(r, rootDir, dst, dstDir)
 }
 
+var ErrUnsafeTarExtractionPath = errors.New("unsafe tar extraction path")
+
 func ExtractTarToPath(r io.Reader, rootDir, dst string, dstDir bool) error {
 	if strings.TrimSpace(dst) == "" {
 		return fmt.Errorf("destination path is required")
 	}
 	dst = rootPath(rootDir, dst)
-	if info, err := os.Stat(dst); err == nil && info.IsDir() {
-		dstDir = true
+	if info, err := os.Lstat(dst); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: destination is a symlink: %s", ErrUnsafeTarExtractionPath, dst)
+		}
+		if info.IsDir() {
+			dstDir = true
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	extractionRoot := filepath.Dir(dst)
+	if dstDir {
+		extractionRoot = dst
+	}
+	if err := os.MkdirAll(extractionRoot, 0o755); err != nil {
+		return err
 	}
 	tr := tar.NewReader(r)
 	sawEntry := false
@@ -727,19 +743,25 @@ func ExtractTarToPath(r io.Reader, rootDir, dst string, dstDir bool) error {
 		}
 		switch header.Typeflag {
 		case tar.TypeDir:
+			if err := ensureTarParents(extractionRoot, filepath.Dir(target)); err != nil {
+				return err
+			}
 			if err := ensureTarTargetCompatible(target, true); err != nil {
 				return err
 			}
-			if err := os.MkdirAll(target, os.FileMode(header.Mode).Perm()); err != nil {
+			if err := os.Mkdir(target, os.FileMode(header.Mode).Perm()); err != nil && !os.IsExist(err) {
 				return err
 			}
 			_ = os.Chmod(target, os.FileMode(header.Mode).Perm())
 			dirs = append(dirs, tarDirMtime{path: target, mtime: header.ModTime})
 		case tar.TypeSymlink:
-			if err := ensureTarTargetCompatible(target, false); err != nil {
+			if err := ensureTarParents(extractionRoot, filepath.Dir(target)); err != nil {
 				return err
 			}
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			if err := validateTarSymlinkTarget(extractionRoot, target, header.Linkname); err != nil {
+				return err
+			}
+			if err := ensureTarTargetCompatible(target, false); err != nil {
 				return err
 			}
 			if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
@@ -749,13 +771,13 @@ func ExtractTarToPath(r io.Reader, rootDir, dst string, dstDir bool) error {
 				return err
 			}
 		case tar.TypeReg, tar.TypeRegA:
+			if err := ensureTarParents(extractionRoot, filepath.Dir(target)); err != nil {
+				return err
+			}
 			if err := ensureTarTargetCompatible(target, false); err != nil {
 				return err
 			}
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-				return err
-			}
-			file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(header.Mode).Perm())
+			file, err := openTarRegularFile(target, os.FileMode(header.Mode).Perm())
 			if err != nil {
 				return err
 			}
@@ -786,6 +808,9 @@ func ensureTarTargetCompatible(target string, incomingDir bool) error {
 	if err != nil {
 		return err
 	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: target is a symlink: %s", ErrUnsafeTarExtractionPath, target)
+	}
 	existingDir := info.IsDir()
 	switch {
 	case incomingDir && !existingDir:
@@ -795,6 +820,49 @@ func ensureTarTargetCompatible(target string, incomingDir bool) error {
 	default:
 		return nil
 	}
+}
+
+func ensureTarParents(root, parent string) error {
+	rel, err := filepath.Rel(root, parent)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: target parent escapes destination: %s", ErrUnsafeTarExtractionPath, parent)
+	}
+	if rel == "." {
+		return nil
+	}
+	current := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(current, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: target parent is a symlink: %s", ErrUnsafeTarExtractionPath, current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("tar target parent is not a directory: %s", current)
+		}
+	}
+	return nil
+}
+
+func validateTarSymlinkTarget(root, target, linkname string) error {
+	if filepath.IsAbs(linkname) {
+		return fmt.Errorf("%w: absolute symlink target %q", ErrUnsafeTarExtractionPath, linkname)
+	}
+	resolved := filepath.Clean(filepath.Join(filepath.Dir(target), filepath.FromSlash(linkname)))
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: symlink target escapes destination: %q", ErrUnsafeTarExtractionPath, linkname)
+	}
+	return nil
 }
 
 func tarTarget(dst string, dstDir bool, name string) (string, error) {

--- a/internal/managed/guestagent/agent_test.go
+++ b/internal/managed/guestagent/agent_test.go
@@ -5,6 +5,7 @@ package guestagent
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -175,6 +176,106 @@ func TestExtractTarToPathConflictSemantics(t *testing.T) {
 			t.Fatalf("dst dir stat = %v info=%v", err, info)
 		}
 	})
+}
+
+func TestExtractTarToPathRejectsArchiveSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	dst := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatalf("make outside dir: %v", err)
+	}
+	outPath := filepath.Join(outside, "marker")
+	if err := os.WriteFile(outPath, []byte("unchanged"), 0o600); err != nil {
+		t.Fatalf("write outside marker: %v", err)
+	}
+	archive := maliciousSymlinkTar(t, true)
+	err := ExtractTarToPath(bytes.NewReader(archive), "", dst, true)
+	if !errors.Is(err, ErrUnsafeTarExtractionPath) {
+		t.Fatalf("extract error = %v, want unsafe path", err)
+	}
+	if got := readTestFile(t, outPath); got != "unchanged" {
+		t.Fatalf("outside content = %q", got)
+	}
+}
+
+func TestExtractTarToPathRejectsPreexistingSymlinkParent(t *testing.T) {
+	base := t.TempDir()
+	dst := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(dst, "root"), 0o755); err != nil {
+		t.Fatalf("make destination: %v", err)
+	}
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatalf("make outside dir: %v", err)
+	}
+	outPath := filepath.Join(outside, "marker")
+	if err := os.WriteFile(outPath, []byte("unchanged"), 0o600); err != nil {
+		t.Fatalf("write outside marker: %v", err)
+	}
+	if err := os.Symlink("../../outside", filepath.Join(dst, "root", "link")); err != nil {
+		t.Fatalf("make escaping symlink: %v", err)
+	}
+	archive := maliciousSymlinkTar(t, false)
+	err := ExtractTarToPath(bytes.NewReader(archive), "", dst, true)
+	if !errors.Is(err, ErrUnsafeTarExtractionPath) {
+		t.Fatalf("extract error = %v, want unsafe path", err)
+	}
+	if got := readTestFile(t, outPath); got != "unchanged" {
+		t.Fatalf("outside content = %q", got)
+	}
+}
+
+func TestExtractTarToPathPreservesRegularFileMetadata(t *testing.T) {
+	mtime := time.Unix(1_700_000_000, 0)
+	payload := []byte("payload")
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	if err := tw.WriteHeader(&tar.Header{Name: "file", Typeflag: tar.TypeReg, Mode: 0o750, Size: int64(len(payload)), ModTime: mtime}); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	dst := t.TempDir()
+	if err := ExtractTarToPath(bytes.NewReader(archive.Bytes()), "", dst, true); err != nil {
+		t.Fatalf("extract regular file: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dst, "file"))
+	if err != nil {
+		t.Fatalf("stat extracted file: %v", err)
+	}
+	if info.Mode().Perm() != 0o750 || info.ModTime().Unix() != mtime.Unix() {
+		t.Fatalf("file metadata = mode %#o mtime %d", info.Mode().Perm(), info.ModTime().Unix())
+	}
+	if got := readTestFile(t, filepath.Join(dst, "file")); got != string(payload) {
+		t.Fatalf("file content = %q", got)
+	}
+}
+
+func maliciousSymlinkTar(t *testing.T, includeSymlink bool) []byte {
+	t.Helper()
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	if includeSymlink {
+		if err := tw.WriteHeader(&tar.Header{Name: "root/link", Typeflag: tar.TypeSymlink, Linkname: "../../outside", Mode: 0o777}); err != nil {
+			t.Fatalf("write symlink header: %v", err)
+		}
+	}
+	payload := []byte("overwritten")
+	if err := tw.WriteHeader(&tar.Header{Name: "root/link/marker", Typeflag: tar.TypeReg, Mode: 0o600, Size: int64(len(payload))}); err != nil {
+		t.Fatalf("write file header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("write file payload: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	return archive.Bytes()
 }
 
 func TestParseSignal(t *testing.T) {

--- a/internal/managed/guestagent/tar_open_unix.go
+++ b/internal/managed/guestagent/tar_open_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package guestagent
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openTarRegularFile(path string, mode os.FileMode) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_CREAT|unix.O_TRUNC|unix.O_WRONLY|unix.O_NOFOLLOW, uint32(mode.Perm()))
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}

--- a/internal/managed/guestagent/tar_open_windows.go
+++ b/internal/managed/guestagent/tar_open_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package guestagent
+
+import "os"
+
+func openTarRegularFile(path string, mode os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+}


### PR DESCRIPTION
Closes #112

Guest tar extraction now rejects symlink destinations, walks and creates archive parent components individually without following symlinks, rejects pre-existing and archive-created symlink parents, and rejects link targets that escape the extraction root. Unix regular-file extraction uses `O_NOFOLLOW` for the final component. Unsafe paths return the structured `ErrUnsafeTarExtractionPath`.

Tests cover symlink-then-file and pre-existing-parent attacks with outside-file invariants, plus regular file content/mode/mtime and existing symlink-copy behavior.

Validation:
- `go test -race ./internal/managed/guestagent -run 'TestExtractTarToPath|TestWriteAndExtractTar' -count=50`\n- `go vet ./internal/managed/guestagent ./internal/cmd/init`\n- `go test ./...`\n- Linux/arm64 and Windows/arm64 guestagent test-binary compile checks