### PR TITLE
Confine snapshot memory paths

### DIFF
--- a/internal/hv/hvf/snapshot_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64.go
@@ -760,10 +760,9 @@ func loadSnapshot(path string) (snapshotManifest, []byte, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return snapshotManifest{}, nil, fmt.Errorf("decode snapshot manifest: %w", err)
 	}
-	baseDir := filepath.Dir(manifestPath)
-	memPath := manifest.MemoryFile
-	if !filepath.IsAbs(memPath) {
-		memPath = filepath.Join(baseDir, memPath)
+	memPath, err := vmruntime.ResolveSnapshotMemoryPath(manifestPath, manifest.MemoryFile)
+	if err != nil {
+		return snapshotManifest{}, nil, err
 	}
 	memFile, err := os.Open(memPath)
 	if err != nil {

--- a/internal/hv/kvm/snapshot_linux_amd64.go
+++ b/internal/hv/kvm/snapshot_linux_amd64.go
@@ -516,9 +516,9 @@ func loadKVMSnapshot(path string) (kvmSnapshotManifest, string, error) {
 	if manifest.Format != "ccx3-kvm-snapshot-v0" {
 		return kvmSnapshotManifest{}, "", fmt.Errorf("unsupported KVM snapshot format %q", manifest.Format)
 	}
-	memPath := manifest.MemoryFile
-	if !filepath.IsAbs(memPath) {
-		memPath = filepath.Join(filepath.Dir(manifestPath), memPath)
+	memPath, err := vmruntime.ResolveSnapshotMemoryPath(manifestPath, manifest.MemoryFile)
+	if err != nil {
+		return kvmSnapshotManifest{}, "", err
 	}
 	info, err := os.Stat(memPath)
 	if err != nil {

--- a/internal/hv/whp/snapshot_windows_amd64.go
+++ b/internal/hv/whp/snapshot_windows_amd64.go
@@ -420,9 +420,9 @@ func loadWHPSnapshot(path string) (whpSnapshotManifest, string, error) {
 	if manifest.Format != "ccx3-whp-snapshot-v0" {
 		return whpSnapshotManifest{}, "", fmt.Errorf("unsupported WHP snapshot format %q", manifest.Format)
 	}
-	memPath := manifest.MemoryFile
-	if !filepath.IsAbs(memPath) {
-		memPath = filepath.Join(filepath.Dir(manifestPath), memPath)
+	memPath, err := vmruntime.ResolveSnapshotMemoryPath(manifestPath, manifest.MemoryFile)
+	if err != nil {
+		return whpSnapshotManifest{}, "", err
 	}
 	info, err := os.Stat(memPath)
 	if err != nil {

--- a/internal/hv/whp/snapshot_windows_arm64.go
+++ b/internal/hv/whp/snapshot_windows_arm64.go
@@ -534,9 +534,9 @@ func loadArm64WHPSnapshot(path string) (whpArm64SnapshotManifest, string, error)
 	if manifest.Format != "ccx3-whp-arm64-snapshot-v0" {
 		return whpArm64SnapshotManifest{}, "", fmt.Errorf("unsupported WHP arm64 snapshot format %q", manifest.Format)
 	}
-	memPath := manifest.MemoryFile
-	if !filepath.IsAbs(memPath) {
-		memPath = filepath.Join(filepath.Dir(manifestPath), memPath)
+	memPath, err := vmruntime.ResolveSnapshotMemoryPath(manifestPath, manifest.MemoryFile)
+	if err != nil {
+		return whpArm64SnapshotManifest{}, "", err
 	}
 	info, err := os.Stat(memPath)
 	if err != nil {

--- a/internal/vmruntime/snapshot.go
+++ b/internal/vmruntime/snapshot.go
@@ -1,0 +1,52 @@
+package vmruntime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type SnapshotMemoryPathError struct {
+	Path   string
+	Reason string
+}
+
+func (e *SnapshotMemoryPathError) Error() string {
+	return fmt.Sprintf("unsafe snapshot memory path %q: %s", e.Path, e.Reason)
+}
+
+func ResolveSnapshotMemoryPath(manifestPath, memoryFile string) (string, error) {
+	if memoryFile == "" {
+		return "", &SnapshotMemoryPathError{Path: memoryFile, Reason: "path is empty"}
+	}
+	if filepath.IsAbs(memoryFile) || filepath.VolumeName(memoryFile) != "" {
+		return "", &SnapshotMemoryPathError{Path: memoryFile, Reason: "path is absolute"}
+	}
+	clean := filepath.Clean(memoryFile)
+	if clean != memoryFile || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", &SnapshotMemoryPathError{Path: memoryFile, Reason: "path is not a clean relative path"}
+	}
+	baseDir := filepath.Dir(manifestPath)
+	resolvedBase, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve snapshot directory: %w", err)
+	}
+	candidate := filepath.Join(baseDir, clean)
+	resolvedCandidate, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve snapshot memory path: %w", err)
+	}
+	rel, err := filepath.Rel(resolvedBase, resolvedCandidate)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", &SnapshotMemoryPathError{Path: memoryFile, Reason: "resolved path escapes snapshot directory"}
+	}
+	info, err := os.Stat(resolvedCandidate)
+	if err != nil {
+		return "", fmt.Errorf("stat snapshot memory path: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", &SnapshotMemoryPathError{Path: memoryFile, Reason: "path is not a regular file"}
+	}
+	return resolvedCandidate, nil
+}

--- a/internal/vmruntime/snapshot_test.go
+++ b/internal/vmruntime/snapshot_test.go
@@ -1,0 +1,66 @@
+package vmruntime
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSnapshotMemoryPath(t *testing.T) {
+	snapshotDir := t.TempDir()
+	manifestPath := filepath.Join(snapshotDir, "manifest.json")
+	memoryPath := filepath.Join(snapshotDir, "memory.bin")
+	if err := os.WriteFile(memoryPath, []byte("memory"), 0o600); err != nil {
+		t.Fatalf("write memory: %v", err)
+	}
+	resolved, err := ResolveSnapshotMemoryPath(manifestPath, "memory.bin")
+	if err != nil {
+		t.Fatalf("resolve memory: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(memoryPath)
+	if err != nil {
+		t.Fatalf("resolve expected memory: %v", err)
+	}
+	if resolved != want {
+		t.Fatalf("resolved path = %q, want %q", resolved, want)
+	}
+}
+
+func TestResolveSnapshotMemoryPathRejectsUnsafePaths(t *testing.T) {
+	parent := t.TempDir()
+	snapshotDir := filepath.Join(parent, "snapshot")
+	if err := os.Mkdir(snapshotDir, 0o700); err != nil {
+		t.Fatalf("make snapshot dir: %v", err)
+	}
+	manifestPath := filepath.Join(snapshotDir, "manifest.json")
+	outside := filepath.Join(parent, "outside.bin")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	link := filepath.Join(snapshotDir, "linked-memory.bin")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("make escaping symlink: %v", err)
+	}
+
+	for _, memoryFile := range []string{
+		outside,
+		"../outside.bin",
+		"sub/../memory.bin",
+		"linked-memory.bin",
+	} {
+		t.Run(memoryFile, func(t *testing.T) {
+			_, err := ResolveSnapshotMemoryPath(manifestPath, memoryFile)
+			var pathErr *SnapshotMemoryPathError
+			if !errors.As(err, &pathErr) {
+				t.Fatalf("path error = %v, want SnapshotMemoryPathError", err)
+			}
+			if pathErr.Path != memoryFile {
+				t.Fatalf("rejected path = %q, want %q", pathErr.Path, memoryFile)
+			}
+		})
+	}
+	if got, err := os.ReadFile(outside); err != nil || string(got) != "outside" {
+		t.Fatalf("outside file = %q, %v", got, err)
+	}
+}


### PR DESCRIPTION
Closes #111

All KVM, HVF, and WHP snapshot loaders now use one shared `ResolveSnapshotMemoryPath` validator. It requires a clean relative path, resolves the manifest directory and candidate symlinks, rejects paths that escape the snapshot directory, and requires a regular file. Rejections expose structured `SnapshotMemoryPathError` fields. Existing `memory.bin` snapshots continue to resolve.

Tests cover valid paths, native absolute paths, parent traversal, non-clean relative paths, final symlink escape, and an outside-file invariant.

Validation:
- `go test -race ./internal/vmruntime ./internal/hv/hvf -run 'TestResolveSnapshotMemoryPath|Snapshot' -count=20`\n- `go vet ./internal/vmruntime`\n- `go test ./...`\n- Linux/amd64 KVM and Windows amd64/arm64 WHP test-binary compile checks\n\nA broader HVF vet invocation stops on the unrelated existing warning at `internal/hv/hvf/container_darwin_arm64.go:1700` (`time.Since` call not deferred).