### PR TITLE
Harden CVMFS cache publication

### DIFF
--- a/internal/cvmfs/cache_lock_unix.go
+++ b/internal/cvmfs/cache_lock_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package cvmfs
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockCacheFile(path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/cvmfs/cache_lock_windows.go
+++ b/internal/cvmfs/cache_lock_windows.go
@@ -1,0 +1,24 @@
+package cvmfs
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockCacheFile(path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	var overlapped windows.Overlapped
+	handle := windows.Handle(file.Fd())
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/cvmfs/cache_mode_unix.go
+++ b/internal/cvmfs/cache_mode_unix.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+package cvmfs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+func secureCacheDirectoryMode(path string, info fs.FileInfo) error {
+	if info.Mode().Perm() == 0o700 {
+		return nil
+	}
+	return os.Chmod(path, 0o700)
+}
+
+func validateCacheFileMode(path string, info fs.FileInfo) error {
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("CVMFS cache entry %q has public mode %04o", path, info.Mode().Perm())
+	}
+	return nil
+}

--- a/internal/cvmfs/cache_mode_windows.go
+++ b/internal/cvmfs/cache_mode_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cvmfs
+
+import "io/fs"
+
+// Go's portable Windows FileMode reports synthesized POSIX bits rather than
+// the file's ACL. Ownership and ACL validation need a separate Windows policy;
+// do not reject private cache entries based on those synthesized bits.
+func secureCacheDirectoryMode(string, fs.FileInfo) error { return nil }
+func validateCacheFileMode(string, fs.FileInfo) error    { return nil }

--- a/internal/cvmfs/cache_owner_unix.go
+++ b/internal/cvmfs/cache_owner_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package cvmfs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+func validateCacheOwner(info fs.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("owner information is unavailable")
+	}
+	if stat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("owned by uid %d, current uid is %d", stat.Uid, os.Geteuid())
+	}
+	return nil
+}

--- a/internal/cvmfs/cache_owner_windows.go
+++ b/internal/cvmfs/cache_owner_windows.go
@@ -1,0 +1,9 @@
+package cvmfs
+
+import "io/fs"
+
+// Windows cache directories are made private using their mode at creation.
+// Go's portable FileInfo does not expose an owner SID for subsequent checks.
+func validateCacheOwner(info fs.FileInfo) error {
+	return nil
+}

--- a/internal/cvmfs/cache_test.go
+++ b/internal/cvmfs/cache_test.go
@@ -1,0 +1,178 @@
+package cvmfs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAtomicCachePublication(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	target := filepath.Join(root, "objects", "aa", "bb", "object")
+	oldData := []byte("complete-old-entry")
+	newData := []byte("complete-new-entry")
+	if err := writeAtomicFile(target, func(dst io.Writer) error {
+		_, err := dst.Write(oldData)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	written := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- writeAtomicFile(target, func(dst io.Writer) error {
+			if _, err := dst.Write(newData[:5]); err != nil {
+				return err
+			}
+			close(written)
+			<-release
+			_, err := dst.Write(newData[5:])
+			return err
+		})
+	}()
+	<-written
+
+	data, err := readPrivateCacheFile(root, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, oldData) {
+		t.Fatalf("data visible before commit = %q, want %q", data, oldData)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	data, err = readPrivateCacheFile(root, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, newData) {
+		t.Fatalf("published data = %q, want %q", data, newData)
+	}
+}
+
+func TestFailedCacheWritePreservesPublishedEntry(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	target := filepath.Join(root, "state", "repo", "manifest")
+	want := []byte("Cpublished")
+	if err := writeAtomicFile(target, func(dst io.Writer) error {
+		_, err := dst.Write(want)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("download interrupted")
+	err := writeAtomicFile(target, func(dst io.Writer) error {
+		_, _ = dst.Write([]byte("Cpartial"))
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("write error = %v, want %v", err, wantErr)
+	}
+	data, err := readPrivateCacheFile(root, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, want) {
+		t.Fatalf("data after failed write = %q, want %q", data, want)
+	}
+}
+
+func TestCachePublicationSerializesWritersPerEntry(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	target := filepath.Join(root, "files", "repo", "aa", "bb", "file")
+	var active atomic.Int32
+	var maximum atomic.Int32
+	start := make(chan struct{})
+	done := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func(value byte) {
+			<-start
+			done <- writeAtomicFile(target, func(dst io.Writer) error {
+				current := active.Add(1)
+				defer active.Add(-1)
+				for old := maximum.Load(); current > old && !maximum.CompareAndSwap(old, current); old = maximum.Load() {
+				}
+				_, err := dst.Write(bytes.Repeat([]byte{value}, 64*1024))
+				return err
+			})
+		}(byte('a' + i))
+	}
+	close(start)
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := maximum.Load(); got != 1 {
+		t.Fatalf("maximum concurrent writers = %d, want 1", got)
+	}
+	data, err := readPrivateCacheFile(root, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 64*1024 || (data[0] != 'a' && data[0] != 'b') || !bytes.Equal(data, bytes.Repeat(data[:1], len(data))) {
+		t.Fatal("published entry contains interleaved or incomplete writer data")
+	}
+}
+
+func TestCacheStateIsOwnerPrivate(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	target := cvmfsFileCachePath(root, "repo", "/file")
+	if err := writeAtomicFile(target, func(dst io.Writer) error {
+		_, err := dst.Write([]byte("Cmanifest"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{root, filepath.Join(root, "files"), filepath.Dir(target)} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o700 {
+			t.Fatalf("directory %q mode = %04o, want 0700", path, got)
+		}
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("entry mode = %04o, want 0600", got)
+	}
+
+	if err := os.Chmod(target, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient()
+	client.CacheDir = root
+	if _, _, err := client.CachedFileSize("cvmfs://repo/file"); err == nil {
+		t.Fatal("public cache entry was accepted")
+	}
+}
+
+func TestCacheReaderRejectsSymlinkEntry(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	target := filepath.Join(root, "objects", "aa", "bb", "object")
+	if err := ensurePrivateCacheDir(root, filepath.Dir(target)); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("attacker-controlled"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readPrivateCacheFile(root, target); err == nil {
+		t.Fatal("symlink cache entry was accepted")
+	}
+}

--- a/internal/cvmfs/cache_test.go
+++ b/internal/cvmfs/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 )
@@ -124,6 +125,9 @@ func TestCachePublicationSerializesWritersPerEntry(t *testing.T) {
 }
 
 func TestCacheStateIsOwnerPrivate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows cache privacy is represented by ACLs, not Unix mode bits")
+	}
 	root := filepath.Join(t.TempDir(), "cache")
 	target := cvmfsFileCachePath(root, "repo", "/file")
 	if err := writeAtomicFile(target, func(dst io.Writer) error {

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -2128,10 +2128,8 @@ func validatePrivateCacheDir(dir string) error {
 	if err := validateCacheOwner(info); err != nil {
 		return fmt.Errorf("validate CVMFS cache directory %q: %w", dir, err)
 	}
-	if info.Mode().Perm() != 0o700 {
-		if err := os.Chmod(dir, 0o700); err != nil {
-			return fmt.Errorf("secure CVMFS cache directory %q: %w", dir, err)
-		}
+	if err := secureCacheDirectoryMode(dir, info); err != nil {
+		return fmt.Errorf("secure CVMFS cache directory %q: %w", dir, err)
 	}
 	return nil
 }
@@ -2162,8 +2160,8 @@ func openPrivateCacheFile(cacheRoot, cachePath string) (*os.File, error) {
 	if err := validateCacheOwner(info); err != nil {
 		return nil, fmt.Errorf("validate CVMFS cache entry %q: %w", cachePath, err)
 	}
-	if info.Mode().Perm()&0o077 != 0 {
-		return nil, fmt.Errorf("CVMFS cache entry %q has public mode %04o", cachePath, info.Mode().Perm())
+	if err := validateCacheFileMode(cachePath, info); err != nil {
+		return nil, err
 	}
 	file, err := os.Open(cachePath)
 	if err != nil {

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -47,6 +47,16 @@ const (
 
 var errStopWalk = errors.New("stop walk")
 
+var cachePublicationLocks = struct {
+	sync.Mutex
+	locks map[string]*cachePublicationLock
+}{locks: make(map[string]*cachePublicationLock)}
+
+type cachePublicationLock struct {
+	refs int
+	mu   sync.Mutex
+}
+
 type Target struct {
 	Raw       string
 	Mirror    string
@@ -363,9 +373,9 @@ func (c *Client) PrefetchFile(target string) (uint64, error) {
 		return uint64(info.Size()), nil
 	}
 	cachePath := cvmfsFileCachePath(c.CacheDir, parsed.Repo, parsed.Path)
-	if info, err := os.Stat(cachePath); err == nil {
-		c.traceDone(id, started, "PrefetchFile", target, "", cachePath, int(info.Size()), 0, nil)
-		return uint64(info.Size()), nil
+	if size, err := privateCacheFileSize(c.CacheDir, cachePath); err == nil {
+		c.traceDone(id, started, "PrefetchFile", target, "", cachePath, int(size), 0, nil)
+		return uint64(size), nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		c.traceDone(id, started, "PrefetchFile", target, "", cachePath, 0, 0, err)
 		return 0, err
@@ -402,17 +412,14 @@ func (c *Client) CachedFileSize(target string) (uint64, bool, error) {
 	if cachePath == "" {
 		return 0, false, nil
 	}
-	info, err := os.Stat(cachePath)
+	size, err := privateCacheFileSize(c.CacheDir, cachePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0, false, nil
 		}
 		return 0, false, err
 	}
-	if info.IsDir() {
-		return 0, false, fmt.Errorf("%q is a directory", cachePath)
-	}
-	return uint64(info.Size()), true, nil
+	return uint64(size), true, nil
 }
 
 func (c *Client) WriteFileTo(target string, dst io.Writer) (uint64, error) {
@@ -434,7 +441,7 @@ func (c *Client) WriteFileTo(target string, dst io.Writer) (uint64, error) {
 		return uint64(n), err
 	}
 	cachePath := cvmfsFileCachePath(c.CacheDir, parsed.Repo, parsed.Path)
-	if file, err := os.Open(cachePath); err == nil {
+	if file, err := openPrivateCacheFile(c.CacheDir, cachePath); err == nil {
 		defer file.Close()
 		n, err := io.Copy(dst, file)
 		c.traceDone(id, started, "WriteFileTo", target, "", cachePath, int(n), 0, err)
@@ -476,7 +483,7 @@ func (c *Client) ReadFileRange(target string, offset, length int64) ([]byte, boo
 		return data, eof, nil
 	}
 	cachePath := cvmfsFileCachePath(c.CacheDir, parsed.Repo, parsed.Path)
-	if file, err := os.Open(cachePath); err == nil {
+	if file, err := openPrivateCacheFile(c.CacheDir, cachePath); err == nil {
 		defer file.Close()
 		info, statErr := file.Stat()
 		if statErr != nil {
@@ -809,8 +816,8 @@ func (r *repository) PrefetchFile(filePath string) (uint64, error) {
 		}
 		return uint64(len(data)), nil
 	}
-	if info, err := os.Stat(cachePath); err == nil {
-		return uint64(info.Size()), nil
+	if size, err := privateCacheFileSize(r.client.CacheDir, cachePath); err == nil {
+		return uint64(size), nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return 0, err
 	}
@@ -1092,7 +1099,7 @@ func (r *repository) streamDataObject(hash string, partial bool, dst io.Writer, 
 		return r.objectURL(mirror, hash, suffix)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
 		reader := r.client.activityReader("HTTPObject", "", url, cachePath, resp.Body)
-		var cacheWriter io.WriteCloser
+		var cacheWriter *atomicFile
 		if cacheCompressed && cachePath != "" {
 			cacheFile, err := createAtomicFile(cachePath)
 			if err != nil {
@@ -1105,6 +1112,9 @@ func (r *repository) streamDataObject(hash string, partial bool, dst io.Writer, 
 
 		zr, err := zlib.NewReader(reader)
 		if err != nil {
+			if cacheWriter != nil {
+				_ = cacheWriter.Abort()
+			}
 			r.client.traceDone(id, started, "HTTPObject", "", url, cachePath, 0, resp.StatusCode, err)
 			return err
 		}
@@ -1118,7 +1128,7 @@ func (r *repository) streamDataObject(hash string, partial bool, dst io.Writer, 
 			if err == nil {
 				err = cacheWriter.Close()
 			} else {
-				_ = cacheWriter.Close()
+				_ = cacheWriter.Abort()
 			}
 			cacheWriter = nil
 		}
@@ -1148,7 +1158,7 @@ func (r *repository) streamDataObjectRange(hash string, partial bool, offset, le
 		return r.objectURL(mirror, hash, suffix)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
 		reader := r.client.activityReader("HTTPObjectRange", "", url, cachePath, resp.Body)
-		var cacheWriter io.WriteCloser
+		var cacheWriter *atomicFile
 		if cachePath != "" {
 			cacheFile, err := createAtomicFile(cachePath)
 			if err != nil {
@@ -1162,7 +1172,7 @@ func (r *repository) streamDataObjectRange(hash string, partial bool, offset, le
 		zr, err := zlib.NewReader(reader)
 		if err != nil {
 			if cacheWriter != nil {
-				_ = cacheWriter.Close()
+				_ = cacheWriter.Abort()
 			}
 			r.client.traceDone(id, started, "HTTPObjectRange", "", url, cachePath, 0, resp.StatusCode, err)
 			return err
@@ -1180,7 +1190,7 @@ func (r *repository) streamDataObjectRange(hash string, partial bool, offset, le
 			if err == nil {
 				err = cacheWriter.Close()
 			} else {
-				_ = cacheWriter.Close()
+				_ = cacheWriter.Abort()
 			}
 			cacheWriter = nil
 		}
@@ -1391,7 +1401,7 @@ func (r *repository) readCachedManifest() ([]byte, error) {
 	if r.client == nil || strings.TrimSpace(r.client.CacheDir) == "" {
 		return nil, os.ErrNotExist
 	}
-	return os.ReadFile(filepath.Join(r.client.CacheDir, "state", r.repo, "manifest"))
+	return readPrivateCacheFile(r.client.CacheDir, filepath.Join(r.client.CacheDir, "state", r.repo, "manifest"))
 }
 
 func (r *repository) writeCachedManifest(data []byte) error {
@@ -1399,10 +1409,10 @@ func (r *repository) writeCachedManifest(data []byte) error {
 		return nil
 	}
 	manifestPath := filepath.Join(r.client.CacheDir, "state", r.repo, "manifest")
-	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
-		return fmt.Errorf("create cvmfs manifest cache dir: %w", err)
-	}
-	return os.WriteFile(manifestPath, data, 0o644)
+	return writeAtomicFile(manifestPath, func(dst io.Writer) error {
+		_, err := dst.Write(data)
+		return err
+	})
 }
 
 func (r *repository) openCatalog(hash string) (*catalog, error) {
@@ -1499,7 +1509,7 @@ func (r *repository) readCachedObject(hash, suffix string) ([]byte, error) {
 	if r.client == nil || strings.TrimSpace(r.client.CacheDir) == "" {
 		return nil, os.ErrNotExist
 	}
-	return os.ReadFile(cvmfsObjectCachePath(r.client.CacheDir, hash, suffix))
+	return readPrivateCacheFile(r.client.CacheDir, cvmfsObjectCachePath(r.client.CacheDir, hash, suffix))
 }
 
 func (r *repository) writeCachedObject(hash, suffix string, data []byte) error {
@@ -1507,31 +1517,10 @@ func (r *repository) writeCachedObject(hash, suffix string, data []byte) error {
 		return nil
 	}
 	cachePath := cvmfsObjectCachePath(r.client.CacheDir, hash, suffix)
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-		return fmt.Errorf("create cvmfs cache dir: %w", err)
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(cachePath), "cvmfs-object-*")
-	if err != nil {
-		return fmt.Errorf("create cvmfs cache temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	defer func() {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-	}()
-	if _, err := tmp.Write(data); err != nil {
-		return fmt.Errorf("write cvmfs cache temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close cvmfs cache temp file: %w", err)
-	}
-	if err := os.Rename(tmpPath, cachePath); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return nil
-		}
-		return fmt.Errorf("commit cvmfs cache object: %w", err)
-	}
-	return nil
+	return writeAtomicFile(cachePath, func(dst io.Writer) error {
+		_, err := dst.Write(data)
+		return err
+	})
 }
 
 func (r *repository) objectURL(mirror, hash, suffix string) string {
@@ -1648,14 +1637,24 @@ func (c *Client) writeTrace(event traceEvent) {
 	if tracePath == "" {
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(tracePath), 0o755); err != nil {
-		return
+	cacheRoot := strings.TrimSpace(c.CacheDir)
+	if cacheRoot != "" && pathWithinBase(cacheRoot, tracePath) {
+		if err := ensurePrivateCacheDir(cacheRoot, filepath.Dir(tracePath)); err != nil {
+			return
+		}
+	} else {
+		if err := os.MkdirAll(filepath.Dir(tracePath), 0o700); err != nil {
+			return
+		}
 	}
-	file, err := os.OpenFile(tracePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	file, err := os.OpenFile(tracePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
 	defer file.Close()
+	if err := file.Chmod(0o600); err != nil {
+		return
+	}
 	_ = json.NewEncoder(file).Encode(event)
 }
 
@@ -1926,7 +1925,7 @@ func (c *Client) readCachedFile(parsed Target) ([]byte, error) {
 	if strings.TrimSpace(c.CacheDir) == "" {
 		return nil, os.ErrNotExist
 	}
-	return os.ReadFile(cvmfsFileCachePath(c.CacheDir, parsed.Repo, parsed.Path))
+	return readPrivateCacheFile(c.CacheDir, cvmfsFileCachePath(c.CacheDir, parsed.Repo, parsed.Path))
 }
 
 func (c *Client) writeCachedFile(parsed Target, data []byte) error {
@@ -1941,15 +1940,12 @@ func (c *Client) writeCachedFile(parsed Target, data []byte) error {
 }
 
 func writeAtomicFile(cachePath string, write func(dst io.Writer) error) error {
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-		return fmt.Errorf("create cvmfs file cache dir: %w", err)
-	}
 	tmp, err := createAtomicFile(cachePath)
 	if err != nil {
 		return err
 	}
 	if err := write(tmp); err != nil {
-		_ = tmp.Close()
+		_ = tmp.Abort()
 		return fmt.Errorf("write cvmfs file cache temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
@@ -1962,17 +1958,33 @@ type atomicFile struct {
 	file       *os.File
 	targetPath string
 	closed     bool
+	unlock     func()
 }
 
 func createAtomicFile(targetPath string) (*atomicFile, error) {
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+	cacheRoot, err := cacheRootForPath(targetPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensurePrivateCacheDir(cacheRoot, filepath.Dir(targetPath)); err != nil {
 		return nil, fmt.Errorf("create cvmfs cache dir: %w", err)
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(targetPath), "cvmfs-cache-*")
+	unlock, err := lockCachePublication(targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("lock cvmfs cache entry: %w", err)
+	}
+	failed := true
+	defer func() {
+		if failed {
+			unlock()
+		}
+	}()
+	tmp, err := os.CreateTemp(filepath.Dir(targetPath), ".cvmfs-cache-*")
 	if err != nil {
 		return nil, fmt.Errorf("create cvmfs cache temp file: %w", err)
 	}
-	return &atomicFile{file: tmp, targetPath: targetPath}, nil
+	failed = false
+	return &atomicFile{file: tmp, targetPath: targetPath, unlock: unlock}, nil
 }
 
 func (a *atomicFile) Write(p []byte) (int, error) {
@@ -1984,10 +1996,20 @@ func (a *atomicFile) Close() error {
 		return nil
 	}
 	a.closed = true
+	defer a.unlock()
 	tmpPath := a.file.Name()
+	if err := a.file.Sync(); err != nil {
+		_ = a.file.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("sync cvmfs cache temp file: %w", err)
+	}
 	if err := a.file.Close(); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("close cvmfs cache temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("secure cvmfs cache temp file: %w", err)
 	}
 	if err := os.Rename(tmpPath, a.targetPath); err != nil {
 		_ = os.Remove(tmpPath)
@@ -1997,6 +2019,184 @@ func (a *atomicFile) Close() error {
 		return fmt.Errorf("commit cvmfs cache: %w", err)
 	}
 	return nil
+}
+
+func (a *atomicFile) Abort() error {
+	if a.closed {
+		return nil
+	}
+	a.closed = true
+	defer a.unlock()
+	tmpPath := a.file.Name()
+	closeErr := a.file.Close()
+	removeErr := os.Remove(tmpPath)
+	if closeErr != nil {
+		return closeErr
+	}
+	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return removeErr
+	}
+	return nil
+}
+
+func lockCachePublication(path string) (func(), error) {
+	path = filepath.Clean(path)
+	cachePublicationLocks.Lock()
+	lock := cachePublicationLocks.locks[path]
+	if lock == nil {
+		lock = &cachePublicationLock{}
+		cachePublicationLocks.locks[path] = lock
+	}
+	lock.refs++
+	cachePublicationLocks.Unlock()
+
+	lock.mu.Lock()
+	unlockFile, err := lockCacheFile(path + ".lock")
+	if err != nil {
+		lock.mu.Unlock()
+		cachePublicationLocks.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(cachePublicationLocks.locks, path)
+		}
+		cachePublicationLocks.Unlock()
+		return nil, err
+	}
+	return func() {
+		unlockFile()
+		lock.mu.Unlock()
+		cachePublicationLocks.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(cachePublicationLocks.locks, path)
+		}
+		cachePublicationLocks.Unlock()
+	}, nil
+}
+
+func cacheRootForPath(targetPath string) (string, error) {
+	clean := filepath.Clean(targetPath)
+	for dir := filepath.Dir(clean); dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+		switch filepath.Base(dir) {
+		case "files", "objects", "state":
+			return filepath.Dir(dir), nil
+		}
+	}
+	return "", fmt.Errorf("CVMFS cache path %q is outside a cache namespace", targetPath)
+}
+
+func ensurePrivateCacheDir(cacheRoot, targetDir string) error {
+	cacheRoot = filepath.Clean(cacheRoot)
+	targetDir = filepath.Clean(targetDir)
+	if !pathWithinBase(cacheRoot, targetDir) {
+		return fmt.Errorf("cache directory %q escapes root %q", targetDir, cacheRoot)
+	}
+	if err := os.MkdirAll(cacheRoot, 0o700); err != nil {
+		return err
+	}
+	if err := validatePrivateCacheDir(cacheRoot); err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(cacheRoot, targetDir)
+	if err != nil {
+		return err
+	}
+	current := cacheRoot
+	if rel == "." {
+		return nil
+	}
+	for _, component := range strings.Split(rel, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		if err := os.Mkdir(current, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		if err := validatePrivateCacheDir(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePrivateCacheDir(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("CVMFS cache path %q is not a directory", dir)
+	}
+	if err := validateCacheOwner(info); err != nil {
+		return fmt.Errorf("validate CVMFS cache directory %q: %w", dir, err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("secure CVMFS cache directory %q: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func readPrivateCacheFile(cacheRoot, cachePath string) ([]byte, error) {
+	file, err := openPrivateCacheFile(cacheRoot, cachePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}
+
+func openPrivateCacheFile(cacheRoot, cachePath string) (*os.File, error) {
+	if strings.TrimSpace(cacheRoot) == "" || strings.TrimSpace(cachePath) == "" {
+		return nil, os.ErrNotExist
+	}
+	if err := ensurePrivateCacheDir(cacheRoot, filepath.Dir(cachePath)); err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("CVMFS cache entry %q is not a regular file", cachePath)
+	}
+	if err := validateCacheOwner(info); err != nil {
+		return nil, fmt.Errorf("validate CVMFS cache entry %q: %w", cachePath, err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("CVMFS cache entry %q has public mode %04o", cachePath, info.Mode().Perm())
+	}
+	file, err := os.Open(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !os.SameFile(info, openedInfo) {
+		_ = file.Close()
+		return nil, fmt.Errorf("CVMFS cache entry %q changed while opening", cachePath)
+	}
+	return file, nil
+}
+
+func privateCacheFileSize(cacheRoot, cachePath string) (int64, error) {
+	file, err := openPrivateCacheFile(cacheRoot, cachePath)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
+}
+
+func pathWithinBase(base, target string) bool {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(target))
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 type countingWriter struct {


### PR DESCRIPTION
Closes #114

## Summary
- publish manifests, objects, and file entries through private temporary files and atomic rename
- serialize each cache key across goroutines and processes, aborting interrupted streams without exposing partial data
- validate cache directory ownership, modes, and entry type before reuse; keep default trace/cache state owner-private
- apply the same validation to cached size, stream, and range-read paths

## Tests
- `go test ./...`
- `go test -race ./internal/cvmfs`
- `go vet ./internal/cvmfs`
- Linux amd64 and Windows amd64 cross-compiled package tests