### PR TITLE
Close active port forwards during shutdown

### DIFF
--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -1812,6 +1812,7 @@ type tcpConn struct {
 	readDeadline   time.Time
 	writeDeadline  time.Time
 	closed         bool
+	writeClosed    bool
 
 	// Retransmission support
 	sendBuf     *tcpSendBuffer   // segments awaiting ACK
@@ -2229,11 +2230,14 @@ func (c *tcpConn) handleSegment(h ipv4Header, hdr tcpHeader) error {
 		if hdr.flags&tcpFlagFIN != 0 {
 			c.guestSeq++
 			c.state = tcpStateFinWait
+			writeClosed := c.writeClosed
 			c.mu.Unlock()
 			c.enqueueData(nil) // signal EOF to readers
 			// Send ACK immediately for FIN
 			c.sendAckImmediate()
-			c.sendFin()
+			if !writeClosed {
+				c.sendFin()
+			}
 			return nil
 		}
 		c.mu.Unlock()
@@ -2665,7 +2669,7 @@ func (c *tcpConn) Write(b []byte) (int, error) {
 
 		c.mu.Lock()
 		for {
-			if c.closed {
+			if c.closed || c.writeClosed {
 				c.mu.Unlock()
 				return written, net.ErrClosed
 			}
@@ -2923,7 +2927,7 @@ func (c *tcpConn) Close() error {
 		c.mu.Unlock()
 		return nil
 	}
-	needFin := c.state == tcpStateEstablished
+	needFin := c.state == tcpStateEstablished && !c.writeClosed
 	tracef("netstack.tcpConn Close", "needFin=%t", needFin)
 	c.state = tcpStateClosed
 	c.closed = true
@@ -2956,6 +2960,24 @@ func (c *tcpConn) Close() error {
 	c.stack.tcpMu.Lock()
 	delete(c.stack.tcpConns, c.key)
 	c.stack.tcpMu.Unlock()
+	return nil
+}
+
+// CloseWrite sends FIN while leaving the read side available for the peer's
+// response. This is used by bidirectional proxies to preserve TCP half-close.
+func (c *tcpConn) CloseWrite() error {
+	c.mu.Lock()
+	if c.closed || c.writeClosed {
+		c.mu.Unlock()
+		return nil
+	}
+	if c.state != tcpStateEstablished {
+		c.mu.Unlock()
+		return net.ErrClosed
+	}
+	c.writeClosed = true
+	c.mu.Unlock()
+	c.sendFin()
 	return nil
 }
 

--- a/internal/netstack/tcp_test.go
+++ b/internal/netstack/tcp_test.go
@@ -2,9 +2,52 @@ package netstack
 
 import (
 	"encoding/binary"
+	"errors"
+	"io"
 	"net"
 	"testing"
+	"time"
 )
+
+func TestTCPConnCloseWriteKeepsReadSideOpen(t *testing.T) {
+	h := newBenchmarkHarness(t)
+	key := tcpFourTuple{
+		srcIP:   [4]byte{10, 42, 0, 2},
+		dstIP:   [4]byte{10, 42, 0, 1},
+		srcPort: 8080,
+		dstPort: 49152,
+	}
+	conn := newTCPConn(h.stack, nil, key, 1, 0xffff, [4]byte{10, 42, 0, 1}, nil)
+	conn.state = tcpStateEstablished
+	h.stack.tcpMu.Lock()
+	h.stack.tcpConns[key] = conn
+	h.stack.tcpMu.Unlock()
+	defer conn.Close()
+
+	if err := conn.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case frame := <-h.tcpFrames:
+		if frame.flags&tcpFlagFIN == 0 {
+			t.Fatalf("CloseWrite flags = %#x, want FIN", frame.flags)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseWrite did not send FIN")
+	}
+	if _, err := conn.Write([]byte("late write")); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("write after CloseWrite error = %v, want net.ErrClosed", err)
+	}
+
+	conn.enqueueData([]byte("response"))
+	buf := make([]byte, len("response"))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "response" {
+		t.Fatalf("read after CloseWrite = %q, want response", buf)
+	}
+}
 
 func TestParseTCPOptionsExtractsMSSAndWindowScale(t *testing.T) {
 	options := []byte{

--- a/internal/vm/network_common.go
+++ b/internal/vm/network_common.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -28,9 +29,15 @@ type networkRuntime struct {
 	dev       *virtio.Net
 	txHook    func([]byte)
 	mu        sync.Mutex
+	ctx       context.Context
+	cancel    context.CancelFunc
+	closing   bool
 	listeners []net.Listener
+	active    map[net.Conn]struct{}
 	forwards  map[string]client.PortForward
 	wg        sync.WaitGroup
+	closeOnce sync.Once
+	closeErr  error
 }
 
 type netstackVirtioBackend struct {
@@ -125,6 +132,7 @@ func newNetworkRuntime(cfg networkDeviceConfig) (_ *networkRuntime, retErr error
 		iface:  iface,
 		txHook: cfg.TXHook,
 	}
+	runtime.ctx, runtime.cancel = context.WithCancel(context.Background())
 	dev := virtio.NewNet(cfg.Base, cfg.Size, cfg.IRQ, cfg.MAC, &netstackVirtioBackend{runtime: runtime})
 	dev.CompleteTXChecksum = false
 	runtime.dev = dev
@@ -172,13 +180,34 @@ func (n *networkRuntime) Close() error {
 	if n == nil {
 		return nil
 	}
+	n.closeOnce.Do(func() {
+		n.closeErr = n.close()
+	})
+	return n.closeErr
+}
+
+func (n *networkRuntime) close() error {
 	var err error
 	n.mu.Lock()
+	n.closing = true
 	listeners := append([]net.Listener(nil), n.listeners...)
 	n.listeners = nil
+	connections := make([]net.Conn, 0, len(n.active))
+	for conn := range n.active {
+		connections = append(connections, conn)
+	}
+	cancel := n.cancel
 	n.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	for _, ln := range listeners {
 		if closeErr := ln.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}
+	for _, conn := range connections {
+		if closeErr := conn.Close(); closeErr != nil && err == nil && !errors.Is(closeErr, net.ErrClosed) {
 			err = closeErr
 		}
 	}
@@ -252,6 +281,10 @@ func (n *networkRuntime) AddPortForward(forward client.PortForward) error {
 	key := strings.Join([]string{protocol, hostAddr, strconv.Itoa(forward.HostPort), guestAddr, strconv.Itoa(forward.GuestPort)}, "\x00")
 
 	n.mu.Lock()
+	if n.closing {
+		n.mu.Unlock()
+		return net.ErrClosed
+	}
 	if existing, ok := n.forwards[key]; ok {
 		n.mu.Unlock()
 		if existing == forward {
@@ -266,6 +299,11 @@ func (n *networkRuntime) AddPortForward(forward client.PortForward) error {
 		return fmt.Errorf("listen port forward %s:%d: %w", hostAddr, forward.HostPort, err)
 	}
 	n.mu.Lock()
+	if n.closing {
+		n.mu.Unlock()
+		_ = ln.Close()
+		return net.ErrClosed
+	}
 	if n.forwards == nil {
 		n.forwards = make(map[string]client.PortForward)
 	}
@@ -295,31 +333,90 @@ func (n *networkRuntime) acceptPortForward(ln net.Listener, guestAddress string)
 		if err != nil {
 			return
 		}
-		n.wg.Add(1)
+		if !n.registerPortForwardConn(hostConn) {
+			_ = hostConn.Close()
+			return
+		}
 		go n.handlePortForwardConn(hostConn, guestAddress)
 	}
 }
 
 func (n *networkRuntime) handlePortForwardConn(hostConn net.Conn, guestAddress string) {
 	defer n.wg.Done()
+	defer n.unregisterPortForwardConn(hostConn)
 	defer hostConn.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	baseCtx := n.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
 	defer cancel()
 	guestConn, err := n.stack.DialInternalContext(ctx, "tcp", guestAddress)
 	if err != nil {
 		return
 	}
+	if !n.registerActiveConn(guestConn) {
+		_ = guestConn.Close()
+		return
+	}
+	defer n.unregisterPortForwardConn(guestConn)
 	defer guestConn.Close()
 
+	proxyPortForward(hostConn, guestConn)
+}
+
+func (n *networkRuntime) registerPortForwardConn(conn net.Conn) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.closing {
+		return false
+	}
+	if n.active == nil {
+		n.active = make(map[net.Conn]struct{})
+	}
+	n.active[conn] = struct{}{}
+	n.wg.Add(1)
+	return true
+}
+
+func (n *networkRuntime) registerActiveConn(conn net.Conn) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.closing {
+		return false
+	}
+	if n.active == nil {
+		n.active = make(map[net.Conn]struct{})
+	}
+	n.active[conn] = struct{}{}
+	return true
+}
+
+func (n *networkRuntime) unregisterPortForwardConn(conn net.Conn) {
+	n.mu.Lock()
+	delete(n.active, conn)
+	n.mu.Unlock()
+}
+
+func proxyPortForward(hostConn, guestConn net.Conn) {
 	errCh := make(chan error, 2)
-	go func() {
-		_, err := io.Copy(guestConn, hostConn)
+	copyDirection := func(dst, src net.Conn) {
+		_, err := io.Copy(dst, src)
+		if err == nil {
+			if closeWriter, ok := dst.(interface{ CloseWrite() error }); ok {
+				err = closeWriter.CloseWrite()
+			} else {
+				err = dst.Close()
+			}
+		}
 		errCh <- err
-	}()
-	go func() {
-		_, err := io.Copy(hostConn, guestConn)
-		errCh <- err
-	}()
+	}
+	go copyDirection(guestConn, hostConn)
+	go copyDirection(hostConn, guestConn)
+	if err := <-errCh; err != nil {
+		_ = hostConn.Close()
+		_ = guestConn.Close()
+	}
 	<-errCh
 }

--- a/internal/vm/network_common_test.go
+++ b/internal/vm/network_common_test.go
@@ -1,0 +1,130 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNetworkRuntimeCloseTerminatesIdleActiveForward(t *testing.T) {
+	runtimeConn, peerConn := net.Pipe()
+	defer peerConn.Close()
+	runtime := &networkRuntime{}
+	runtime.ctx, runtime.cancel = context.WithCancel(context.Background())
+	if !runtime.registerPortForwardConn(runtimeConn) {
+		t.Fatal("active connection was not registered")
+	}
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		defer runtime.wg.Done()
+		defer runtime.unregisterPortForwardConn(runtimeConn)
+		_, _ = io.Copy(io.Discard, runtimeConn)
+	}()
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runtime.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("network shutdown did not terminate idle active forward")
+	}
+	select {
+	case <-handlerDone:
+	default:
+		t.Fatal("forward copy goroutine survived network shutdown")
+	}
+	if _, err := peerConn.Write([]byte("still open")); err == nil {
+		t.Fatal("forward peer remained writable after network shutdown")
+	}
+}
+
+func TestProxyPortForwardPreservesHalfCloseResponse(t *testing.T) {
+	hostProxy, hostClient := tcpConnectionPair(t)
+	guestProxy, guestServer := tcpConnectionPair(t)
+	defer hostClient.Close()
+	defer guestServer.Close()
+
+	proxyDone := make(chan struct{})
+	go func() {
+		proxyPortForward(hostProxy, guestProxy)
+		_ = hostProxy.Close()
+		_ = guestProxy.Close()
+		close(proxyDone)
+	}()
+
+	request := []byte("request body")
+	if _, err := hostClient.Write(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := hostClient.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	gotRequest, err := io.ReadAll(guestServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotRequest, request) {
+		t.Fatalf("forwarded request = %q, want %q", gotRequest, request)
+	}
+
+	response := []byte("response after request EOF")
+	if _, err := guestServer.Write(response); err != nil {
+		t.Fatal(err)
+	}
+	if err := guestServer.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	gotResponse, err := io.ReadAll(hostClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotResponse, response) {
+		t.Fatalf("forwarded response = %q, want %q", gotResponse, response)
+	}
+	select {
+	case <-proxyDone:
+	case <-time.After(time.Second):
+		t.Fatal("forward did not finish after both peers closed their write sides")
+	}
+}
+
+func tcpConnectionPair(t *testing.T) (*net.TCPConn, *net.TCPConn) {
+	t.Helper()
+	listener, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan *net.TCPConn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptTCP()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+	client, err := net.DialTCP("tcp4", nil, listener.Addr().(*net.TCPAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case server := <-accepted:
+		return server, client
+	case err := <-acceptErr:
+		_ = client.Close()
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		_ = client.Close()
+		t.Fatal("timed out accepting TCP test connection")
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Closes #103

## Summary
- track both accepted host sockets and internal guest sockets for every active forward
- cancel in-flight guest dials and close active sockets before waiting for forwarding goroutines
- prevent new listeners, handlers, connections, or wait-group additions once teardown begins
- preserve TCP half-close so a guest can respond after the host finishes its request body

## Tests
- `go test ./...`
- focused race tests for idle-forward shutdown, bidirectional half-close, and internal TCP CloseWrite
- `go vet ./internal/netstack ./internal/vm`
- Linux amd64 and Windows amd64 VM package cross-compilation