### PR TITLE
Avoid VM provider callbacks under manager lock

### DIFF
--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -90,6 +90,107 @@ func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	}
 }
 
+func TestManagerStatusProviderDoesNotBlockManagementAndReconcilesShutdown(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
+	providerStarted := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	alpha := newFakeInstance()
+	beta := newFakeInstance()
+	host.queueInstance(alpha)
+	host.queueInstance(beta)
+	manager := testManager(host)
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "alpha", Image: "alpine"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "beta", Image: "alpine"}); err != nil {
+		t.Fatal(err)
+	}
+	alpha.networkIPv4 = func() string {
+		close(providerStarted)
+		<-releaseProvider
+		return "10.0.2.15"
+	}
+
+	statusDone := make(chan client.InstanceState, 1)
+	go func() { statusDone <- manager.StatusOf("alpha") }()
+	<-providerStarted
+	if state := manager.StatusOf("beta"); state.ID != "beta" || state.Status != "running" {
+		t.Fatalf("unrelated instance status while provider blocked = %+v", state)
+	}
+	if err := manager.ShutdownInstance(ctx, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	close(releaseProvider)
+	if state := <-statusDone; state.ID != "alpha" || state.Status != "stopped" || state.NetworkIPv4 != "" {
+		t.Fatalf("status after concurrent shutdown = %+v", state)
+	}
+	if err := manager.ShutdownInstance(ctx, "beta"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestManagerVirtioFSProviderDoesNotBlockOtherInstances(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
+	providerStarted := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	alpha := newFakeInstance()
+	alpha.virtioFSStats = func() []virtio.FSStats {
+		close(providerStarted)
+		<-releaseProvider
+		return []virtio.FSStats{{}}
+	}
+	host.queueInstance(alpha)
+	host.queueInstance(newFakeInstance())
+	manager := testManager(host)
+	defer manager.ShutdownAll(ctx)
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "alpha", Image: "alpine"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "beta", Image: "alpine"}); err != nil {
+		t.Fatal(err)
+	}
+	statsDone := make(chan []virtio.FSStats, 1)
+	go func() { statsDone <- manager.VirtioFSStats("alpha") }()
+	<-providerStarted
+	if state := manager.StatusOf("beta"); state.ID != "beta" || state.Status != "running" {
+		t.Fatalf("unrelated instance status while stats blocked = %+v", state)
+	}
+	close(releaseProvider)
+	if stats := <-statsDone; len(stats) != 1 {
+		t.Fatalf("stats count = %d, want 1", len(stats))
+	}
+}
+
+func TestManagerCapacityProviderDoesNotRunUnderManagerLock(t *testing.T) {
+	ctx := context.Background()
+	base := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
+	host := &blockingCapabilitiesHost{fakeHost: base}
+	base.queueInstance(newFakeInstance())
+	base.queueInstance(newFakeInstance())
+	manager := testManager(host)
+	defer manager.ShutdownAll(ctx)
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "beta", Image: "alpine"}); err != nil {
+		t.Fatal(err)
+	}
+	host.started = make(chan struct{})
+	host.release = make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "alpha", Image: "alpine"})
+		startDone <- err
+	}()
+	<-host.started
+	if state := manager.StatusOf("beta"); state.ID != "beta" || state.Status != "running" {
+		t.Fatalf("instance status while capacity provider blocked = %+v", state)
+	}
+	close(host.release)
+	if err := <-startDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestManagerBlankStartRemembersImageForRunIn(t *testing.T) {
 	ctx := context.Background()
 	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2, SupportsL2: true})
@@ -377,6 +478,23 @@ type fakeHost struct {
 	hostCapabilitiesN int
 }
 
+type blockingCapabilitiesHost struct {
+	*fakeHost
+	started chan struct{}
+	release chan struct{}
+}
+
+func (h *blockingCapabilitiesHost) HostCapabilities(ctx context.Context) VMHostCapabilities {
+	if h.started != nil {
+		close(h.started)
+		select {
+		case <-h.release:
+		case <-ctx.Done():
+		}
+	}
+	return h.fakeHost.HostCapabilities(ctx)
+}
+
 type fakeRunInCall struct {
 	inst         Instance
 	runningImage string
@@ -538,6 +656,8 @@ type fakeInstance struct {
 	snapshots      map[string]imagefs.Directory
 	stats          []virtio.FSStats
 	ipv4           string
+	networkIPv4    func() string
+	virtioFSStats  func() []virtio.FSStats
 	execStream     func(client.ExecRequest, func(client.ExecEvent) error) error
 }
 
@@ -621,14 +741,24 @@ func (i *fakeInstance) SnapshotImage(imageName string) (imagefs.Directory, error
 
 func (i *fakeInstance) NetworkIPv4() string {
 	i.mu.Lock()
-	defer i.mu.Unlock()
-	return i.ipv4
+	fn := i.networkIPv4
+	ipv4 := i.ipv4
+	i.mu.Unlock()
+	if fn != nil {
+		return fn()
+	}
+	return ipv4
 }
 
 func (i *fakeInstance) VirtioFSStats() []virtio.FSStats {
 	i.mu.Lock()
-	defer i.mu.Unlock()
-	return append([]virtio.FSStats(nil), i.stats...)
+	fn := i.virtioFSStats
+	stats := append([]virtio.FSStats(nil), i.stats...)
+	i.mu.Unlock()
+	if fn != nil {
+		return fn()
+	}
+	return stats
 }
 
 func testManager(host VMHost) *Manager {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -208,6 +208,7 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	if err := m.supports(); err != nil {
 		return client.InstanceState{}, err
 	}
+	maxVMs := m.host.HostCapabilities(ctx).MaxVMs
 
 	m.mu.Lock()
 	if m.running == nil {
@@ -217,16 +218,16 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		m.starting = make(map[string]struct{})
 	}
 	if m.running[id] != nil {
-		state := m.statusLocked(id)
+		snapshot := m.statusSnapshotLocked(id)
 		m.mu.Unlock()
-		return state, fmt.Errorf("VM %q is already running", id)
+		return m.resolveStatusSnapshot(snapshot), fmt.Errorf("VM %q is already running", id)
 	}
 	if _, ok := m.starting[id]; ok {
-		state := m.statusLocked(id)
+		snapshot := m.statusSnapshotLocked(id)
 		m.mu.Unlock()
-		return state, fmt.Errorf("VM %q is already starting", id)
+		return m.resolveStatusSnapshot(snapshot), fmt.Errorf("VM %q is already starting", id)
 	}
-	if err := m.checkCapacityLocked(); err != nil {
+	if err := m.checkCapacityLocked(maxVMs); err != nil {
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
@@ -292,6 +293,7 @@ func (m *Manager) StartBlankInstanceStream(
 	if err := m.supports(); err != nil {
 		return client.InstanceState{}, err
 	}
+	maxVMs := m.host.HostCapabilities(ctx).MaxVMs
 
 	m.mu.Lock()
 	if m.running == nil {
@@ -301,16 +303,16 @@ func (m *Manager) StartBlankInstanceStream(
 		m.starting = make(map[string]struct{})
 	}
 	if m.running[id] != nil {
-		state := m.statusLocked(id)
+		snapshot := m.statusSnapshotLocked(id)
 		m.mu.Unlock()
-		return state, fmt.Errorf("VM %q is already running", id)
+		return m.resolveStatusSnapshot(snapshot), fmt.Errorf("VM %q is already running", id)
 	}
 	if _, ok := m.starting[id]; ok {
-		state := m.statusLocked(id)
+		snapshot := m.statusSnapshotLocked(id)
 		m.mu.Unlock()
-		return state, fmt.Errorf("VM %q is already starting", id)
+		return m.resolveStatusSnapshot(snapshot), fmt.Errorf("VM %q is already starting", id)
 	}
-	if err := m.checkCapacityLocked(); err != nil {
+	if err := m.checkCapacityLocked(maxVMs); err != nil {
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
@@ -655,18 +657,20 @@ func (m *Manager) Status() client.InstanceState {
 func (m *Manager) StatusOf(id string) client.InstanceState {
 	id = instanceID(id)
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.statusLocked(id)
+	snapshot := m.statusSnapshotLocked(id)
+	m.mu.Unlock()
+	return m.resolveStatusSnapshot(snapshot)
 }
 
 func (m *Manager) VirtioFSStats(id string) []virtio.FSStats {
 	id = instanceID(id)
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.running == nil || m.running[id] == nil || m.running[id].instance == nil {
+		m.mu.Unlock()
 		return nil
 	}
 	provider, ok := m.running[id].instance.(virtioFSStatsProvider)
+	m.mu.Unlock()
 	if !ok {
 		return nil
 	}
@@ -675,8 +679,8 @@ func (m *Manager) VirtioFSStats(id string) []virtio.FSStats {
 
 func (m *Manager) Statuses() []client.InstanceState {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if len(m.running) == 0 {
+		m.mu.Unlock()
 		return nil
 	}
 	ids := make([]string, 0, len(m.running))
@@ -684,9 +688,17 @@ func (m *Manager) Statuses() []client.InstanceState {
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)
-	out := make([]client.InstanceState, 0, len(ids))
+	snapshots := make([]managerStatusSnapshot, 0, len(ids))
 	for _, id := range ids {
-		out = append(out, m.statusLocked(id))
+		snapshots = append(snapshots, m.statusSnapshotLocked(id))
+	}
+	m.mu.Unlock()
+	out := make([]client.InstanceState, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		state := m.resolveStatusSnapshot(snapshot)
+		if state.Status != "stopped" {
+			out = append(out, state)
+		}
 	}
 	return out
 }
@@ -698,15 +710,22 @@ func (m *Manager) Capabilities() client.CapabilitiesResponse {
 	return m.capabilities()
 }
 
-func (m *Manager) statusLocked(id string) client.InstanceState {
+type managerStatusSnapshot struct {
+	id       string
+	machine  *Machine
+	state    client.InstanceState
+	provider networkIPv4Provider
+}
+
+func (m *Manager) statusSnapshotLocked(id string) managerStatusSnapshot {
 	id = instanceID(id)
 	if m.running == nil || m.running[id] == nil {
 		if m.starting != nil {
 			if _, ok := m.starting[id]; ok {
-				return client.InstanceState{ID: id, Status: "starting"}
+				return managerStatusSnapshot{id: id, state: client.InstanceState{ID: id, Status: "starting"}}
 			}
 		}
-		return client.InstanceState{ID: id, Status: "stopped"}
+		return managerStatusSnapshot{id: id, state: client.InstanceState{ID: id, Status: "stopped"}}
 	}
 	machine := m.running[id]
 	state := client.InstanceState{
@@ -721,10 +740,25 @@ func (m *Manager) statusLocked(id string) client.InstanceState {
 		NestedVirt: machine.nestedVirt,
 		StartedAt:  machine.startedAt.Format(time.RFC3339),
 	}
+	snapshot := managerStatusSnapshot{id: id, machine: machine, state: state}
 	if provider, ok := machine.instance.(networkIPv4Provider); ok {
-		state.NetworkIPv4 = provider.NetworkIPv4()
+		snapshot.provider = provider
 	}
-	return state
+	return snapshot
+}
+
+func (m *Manager) resolveStatusSnapshot(snapshot managerStatusSnapshot) client.InstanceState {
+	if snapshot.provider == nil {
+		return snapshot.state
+	}
+	ipv4 := snapshot.provider.NetworkIPv4()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.running == nil || m.running[snapshot.id] != snapshot.machine {
+		return m.statusSnapshotLocked(snapshot.id).state
+	}
+	snapshot.state.NetworkIPv4 = ipv4
+	return snapshot.state
 }
 
 func (m *Manager) watch(machine *Machine) {
@@ -741,10 +775,9 @@ func (m *Manager) watch(machine *Machine) {
 	machine.exitedAt = time.Now().UTC()
 }
 
-func (m *Manager) checkCapacityLocked() error {
-	caps := m.host.HostCapabilities(context.Background())
-	if caps.MaxVMs > 0 && len(m.running)+len(m.starting) >= caps.MaxVMs {
-		return fmt.Errorf("maximum running VM instances reached: %d", caps.MaxVMs)
+func (m *Manager) checkCapacityLocked(maxVMs int) error {
+	if maxVMs > 0 && len(m.running)+len(m.starting) >= maxVMs {
+		return fmt.Errorf("maximum running VM instances reached: %d", maxVMs)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #95

## Summary
- snapshot manager-owned status state under `Manager.mu`, then query network providers after unlocking
- reconcile status against the same machine pointer so concurrent shutdown cannot return stale provider data
- call virtio-fs stats and host-capacity providers without holding the manager mutex
- preserve capacity admission atomically by applying the externally obtained limit while reserving `starting` under the lock

## Tests
- `go test ./...`
- focused manager concurrency tests under `-race`
- `go vet ./internal/vm`
- Linux amd64 and Windows amd64 VM package cross-compilation

Note: a full `go test -race ./internal/vm` also encounters an existing unrelated virtio-fs test logger race from concurrent writes to a `bytes.Buffer`; the focused changed-path race tests pass.