### PR TITLE
Cancel in-flight VM starts during shutdown

### DIFF
--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2,9 +2,11 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"j5.nz/cc/client"
@@ -207,6 +209,58 @@ func TestManagerAssignsDistinctNetworkLeasesBeforeStart(t *testing.T) {
 	}
 }
 
+func TestManagerShutdownCancelsAndRejectsLateStart(t *testing.T) {
+	ctx := context.Background()
+	inst := newFakeInstance()
+	host := &lateStartHost{
+		fakeHost: newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 1}),
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+		instance: inst,
+	}
+	manager := testManager(host)
+	startDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "alpha", Image: "alpine"})
+		startDone <- err
+	}()
+	<-host.started
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- manager.ShutdownAll(ctx) }()
+	<-host.canceled
+	if state := manager.StatusOf("alpha"); state.ID != "alpha" || state.Status != "stopped" {
+		t.Fatalf("state during shutdown = %+v", state)
+	}
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("shutdown returned before canceled start completed: %v", err)
+	default:
+	}
+	close(host.release)
+	if err := <-startDone; !errors.Is(err, ErrManagerClosing) {
+		t.Fatalf("late start error = %v, want ErrManagerClosing", err)
+	}
+	if err := <-shutdownDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-inst.done:
+	default:
+		t.Fatal("instance returned after shutdown was not closed")
+	}
+	if state := manager.StatusOf("alpha"); state.ID != "alpha" || state.Status != "stopped" {
+		t.Fatalf("state after shutdown = %+v", state)
+	}
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "beta", Image: "alpine"}); !errors.Is(err, ErrManagerClosing) {
+		t.Fatalf("post-shutdown start error = %v, want ErrManagerClosing", err)
+	}
+	if got := host.calls.Load(); got != 1 {
+		t.Fatalf("backend start calls = %d, want 1", got)
+	}
+}
+
 func TestManagerAssignsNetworkLeasesForBuiltinDefaultNetwork(t *testing.T) {
 	ctx := context.Background()
 	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
@@ -375,6 +429,24 @@ type fakeHost struct {
 	execInStreams     []fakeExecInCall
 	closeCalled       bool
 	hostCapabilitiesN int
+}
+
+type lateStartHost struct {
+	*fakeHost
+	started  chan struct{}
+	canceled chan struct{}
+	release  chan struct{}
+	instance Instance
+	calls    atomic.Int32
+}
+
+func (h *lateStartHost) StartStream(ctx context.Context, _ client.CreateInstanceRequest, _ func(client.BootEvent) error) (Instance, error) {
+	h.calls.Add(1)
+	close(h.started)
+	<-ctx.Done()
+	close(h.canceled)
+	<-h.release
+	return h.instance, nil
 }
 
 type fakeRunInCall struct {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -21,6 +21,8 @@ import (
 
 const DefaultInstanceID = "default"
 
+var ErrManagerClosing = errors.New("VM manager is shutting down")
+
 type Backend = vmhost.Backend
 
 type VMHost = vmhost.VMHost
@@ -65,8 +67,15 @@ type Manager struct {
 	supports      func() error
 	capabilities  func() client.CapabilitiesResponse
 	running       map[string]*Machine
-	starting      map[string]struct{}
+	starting      map[string]*managerStart
 	networkLeases map[string]managerNetworkLease
+	closing       bool
+}
+
+type managerStart struct {
+	cancel     context.CancelFunc
+	done       chan struct{}
+	cleanupErr error
 }
 
 type Machine struct {
@@ -210,11 +219,15 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	}
 
 	m.mu.Lock()
+	if m.closing {
+		m.mu.Unlock()
+		return client.InstanceState{}, ErrManagerClosing
+	}
 	if m.running == nil {
 		m.running = make(map[string]*Machine)
 	}
 	if m.starting == nil {
-		m.starting = make(map[string]struct{})
+		m.starting = make(map[string]*managerStart)
 	}
 	if m.running[id] != nil {
 		state := m.statusLocked(id)
@@ -230,14 +243,15 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
-	m.starting[id] = struct{}{}
+	startCtx, cancelStart := context.WithCancel(ctx)
+	start := &managerStart{cancel: cancelStart, done: make(chan struct{})}
+	m.starting[id] = start
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
-	inst, err := m.host.StartStream(ctx, req, onEvent)
+	inst, err := m.host.StartStream(startCtx, req, onEvent)
 	if err != nil {
-		m.clearStarting(id)
-		m.releaseNetworkLease(id)
+		m.finishStart(id, start)
 		return client.InstanceState{}, err
 	}
 
@@ -256,12 +270,25 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	}
 
 	m.mu.Lock()
+	if m.closing || m.starting[id] != start {
+		if m.starting[id] == start {
+			delete(m.starting, id)
+		}
+		delete(m.networkLeases, id)
+		m.mu.Unlock()
+		cancelStart()
+		start.cleanupErr = inst.Close()
+		close(start.done)
+		return client.InstanceState{}, errors.Join(ErrManagerClosing, start.cleanupErr)
+	}
 	if m.running == nil {
 		m.running = make(map[string]*Machine)
 	}
 	delete(m.starting, id)
 	m.running[id] = machine
 	m.mu.Unlock()
+	cancelStart()
+	close(start.done)
 
 	go m.watch(machine)
 
@@ -294,11 +321,15 @@ func (m *Manager) StartBlankInstanceStream(
 	}
 
 	m.mu.Lock()
+	if m.closing {
+		m.mu.Unlock()
+		return client.InstanceState{}, ErrManagerClosing
+	}
 	if m.running == nil {
 		m.running = make(map[string]*Machine)
 	}
 	if m.starting == nil {
-		m.starting = make(map[string]struct{})
+		m.starting = make(map[string]*managerStart)
 	}
 	if m.running[id] != nil {
 		state := m.statusLocked(id)
@@ -314,7 +345,9 @@ func (m *Manager) StartBlankInstanceStream(
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
-	m.starting[id] = struct{}{}
+	startCtx, cancelStart := context.WithCancel(ctx)
+	start := &managerStart{cancel: cancelStart, done: make(chan struct{})}
+	m.starting[id] = start
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
@@ -323,19 +356,17 @@ func (m *Manager) StartBlankInstanceStream(
 	if !snapshotStartup {
 		req.Shares = nil
 	}
-	inst, err := m.host.StartBlankStream(ctx, req, onEvent)
+	inst, err := m.host.StartBlankStream(startCtx, req, onEvent)
 	if err != nil {
-		m.clearStarting(id)
-		m.releaseNetworkLease(id)
+		m.finishStart(id, start)
 		return client.InstanceState{}, err
 	}
 	if !snapshotStartup {
 		for _, share := range shares {
-			if err := inst.AddShare(ctx, share); err != nil {
-				_ = inst.Close()
-				m.clearStarting(id)
-				m.releaseNetworkLease(id)
-				return client.InstanceState{}, err
+			if err := inst.AddShare(startCtx, share); err != nil {
+				start.cleanupErr = inst.Close()
+				m.finishStart(id, start)
+				return client.InstanceState{}, errors.Join(err, start.cleanupErr)
 			}
 		}
 	}
@@ -355,12 +386,25 @@ func (m *Manager) StartBlankInstanceStream(
 	}
 
 	m.mu.Lock()
+	if m.closing || m.starting[id] != start {
+		if m.starting[id] == start {
+			delete(m.starting, id)
+		}
+		delete(m.networkLeases, id)
+		m.mu.Unlock()
+		cancelStart()
+		start.cleanupErr = inst.Close()
+		close(start.done)
+		return client.InstanceState{}, errors.Join(ErrManagerClosing, start.cleanupErr)
+	}
 	if m.running == nil {
 		m.running = make(map[string]*Machine)
 	}
 	delete(m.starting, id)
 	m.running[id] = machine
 	m.mu.Unlock()
+	cancelStart()
+	close(start.done)
 
 	go m.watch(machine)
 
@@ -374,10 +418,17 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 func (m *Manager) ShutdownAll(ctx context.Context) error {
 	_ = ctx
 	m.mu.Lock()
+	m.closing = true
 	running := m.running
 	m.running = nil
-	m.starting = nil
+	starts := make([]*managerStart, 0, len(m.starting))
+	for _, start := range m.starting {
+		starts = append(starts, start)
+	}
 	m.mu.Unlock()
+	for _, start := range starts {
+		start.cancel()
+	}
 
 	var errs []error
 	for id, machine := range running {
@@ -388,6 +439,16 @@ func (m *Manager) ShutdownAll(ctx context.Context) error {
 			errs = append(errs, fmt.Errorf("shutdown VM %q: %w", id, err))
 		}
 	}
+	for _, start := range starts {
+		<-start.done
+		if start.cleanupErr != nil {
+			errs = append(errs, fmt.Errorf("clean up canceled VM start: %w", start.cleanupErr))
+		}
+	}
+	m.mu.Lock()
+	m.starting = nil
+	m.networkLeases = nil
+	m.mu.Unlock()
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
@@ -701,6 +762,9 @@ func (m *Manager) Capabilities() client.CapabilitiesResponse {
 func (m *Manager) statusLocked(id string) client.InstanceState {
 	id = instanceID(id)
 	if m.running == nil || m.running[id] == nil {
+		if m.closing {
+			return client.InstanceState{ID: id, Status: "stopped"}
+		}
 		if m.starting != nil {
 			if _, ok := m.starting[id]; ok {
 				return client.InstanceState{ID: id, Status: "starting"}
@@ -749,10 +813,15 @@ func (m *Manager) checkCapacityLocked() error {
 	return nil
 }
 
-func (m *Manager) clearStarting(id string) {
+func (m *Manager) finishStart(id string, start *managerStart) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.starting, id)
+	if m.starting[id] == start {
+		delete(m.starting, id)
+	}
+	delete(m.networkLeases, id)
+	m.mu.Unlock()
+	start.cancel()
+	close(start.done)
 }
 
 func (m *Manager) ensureNetworkLeaseLocked(id, image string, cfg *client.NetworkConfig) *client.NetworkConfig {


### PR DESCRIPTION
Closes #93

## Summary
- track each pending start with its own cancellation context and completion signal
- mark the manager permanently closing before canceling starts or closing running instances
- reject late registration, close any instance returned after shutdown begins, and release its network lease
- wait for canceled-start cleanup before shutdown returns and propagate cleanup failures
- report deterministic stopped state during and after manager shutdown

## Tests
- `go test ./...`
- start/shutdown race test repeated 20 times under `-race`
- `go vet ./internal/vm`
- Linux amd64 and Windows amd64 VM package cross-compilation