### PR TITLE
Allow retry after instance close failure

### DIFF
--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2,10 +2,14 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/imagefs"
@@ -207,6 +211,84 @@ func TestManagerAssignsDistinctNetworkLeasesBeforeStart(t *testing.T) {
 	}
 }
 
+func TestManagerRetriesFailedCloseAndSharesConcurrentResult(t *testing.T) {
+	ctx := context.Background()
+	transientErr := errors.New("transient close failure")
+	inst := &flakyCloseInstance{
+		fakeInstance: newFakeInstance(),
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+		firstErr:     transientErr,
+	}
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 1})
+	host.queueInstance(inst)
+	manager := testManager(host)
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{
+		ID:      "alpha",
+		Image:   "alpine",
+		Network: &client.NetworkConfig{Enabled: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() { firstDone <- manager.ShutdownInstance(ctx, "alpha") }()
+	<-inst.firstStarted
+	go func() { secondDone <- manager.ShutdownInstance(ctx, "alpha") }()
+	waitForStopObservers(t, manager, "alpha", 2)
+	close(inst.releaseFirst)
+	for i, result := range []<-chan error{firstDone, secondDone} {
+		if err := <-result; !errors.Is(err, transientErr) {
+			t.Fatalf("concurrent shutdown %d error = %v, want transient failure", i+1, err)
+		}
+	}
+	if got := inst.closeCalls.Load(); got != 1 {
+		t.Fatalf("Close calls after shared failure = %d, want 1", got)
+	}
+	if state := manager.StatusOf("alpha"); state.ID != "alpha" || state.Status != "running" {
+		t.Fatalf("state after failed close = %+v", state)
+	}
+	if _, err := manager.RunIn(ctx, "alpha", client.RunRequest{Command: []string{"true"}}); err != nil {
+		t.Fatalf("instance remained unusable after failed close: %v", err)
+	}
+
+	if err := manager.ShutdownInstance(ctx, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if got := inst.closeCalls.Load(); got != 2 {
+		t.Fatalf("Close calls after retry = %d, want 2", got)
+	}
+	if state := manager.StatusOf("alpha"); state.ID != "alpha" || state.Status != "stopped" {
+		t.Fatalf("state after successful retry = %+v", state)
+	}
+	manager.mu.Lock()
+	_, leaseExists := manager.networkLeases["alpha"]
+	manager.mu.Unlock()
+	if leaseExists {
+		t.Fatal("network lease remained after successful close retry")
+	}
+}
+
+func waitForStopObservers(t *testing.T, manager *Manager, id string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		manager.mu.Lock()
+		machine := manager.running[id]
+		got := 0
+		if machine != nil && machine.stop != nil {
+			got = machine.stop.observers
+		}
+		manager.mu.Unlock()
+		if got >= want {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("shutdown observers did not reach %d", want)
+}
+
 func TestManagerAssignsNetworkLeasesForBuiltinDefaultNetwork(t *testing.T) {
 	ctx := context.Background()
 	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2})
@@ -365,7 +447,7 @@ func TestManagerSnapshotConsoleForwardAndStats(t *testing.T) {
 type fakeHost struct {
 	mu                sync.Mutex
 	caps              VMHostCapabilities
-	next              []*fakeInstance
+	next              []Instance
 	starts            []client.CreateInstanceRequest
 	blankStarts       []client.StartInstanceRequest
 	runs              []client.RunRequest
@@ -396,7 +478,7 @@ func newFakeHost(caps VMHostCapabilities) *fakeHost {
 	return &fakeHost{caps: caps}
 }
 
-func (h *fakeHost) queueInstance(inst *fakeInstance) {
+func (h *fakeHost) queueInstance(inst Instance) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.next = append(h.next, inst)
@@ -485,7 +567,7 @@ func (h *fakeHost) ExecInInstanceStream(_ context.Context, inst Instance, runnin
 	return emitFakeExecEvents(onEvent, "host exec in stream")
 }
 
-func (h *fakeHost) popInstanceLocked() *fakeInstance {
+func (h *fakeHost) popInstanceLocked() Instance {
 	if len(h.next) == 0 {
 		return newFakeInstance()
 	}
@@ -539,6 +621,23 @@ type fakeInstance struct {
 	stats          []virtio.FSStats
 	ipv4           string
 	execStream     func(client.ExecRequest, func(client.ExecEvent) error) error
+}
+
+type flakyCloseInstance struct {
+	*fakeInstance
+	firstStarted chan struct{}
+	releaseFirst chan struct{}
+	firstErr     error
+	closeCalls   atomic.Int32
+}
+
+func (i *flakyCloseInstance) Close() error {
+	if i.closeCalls.Add(1) == 1 {
+		close(i.firstStarted)
+		<-i.releaseFirst
+		return i.firstErr
+	}
+	return i.fakeInstance.Close()
 }
 
 func newFakeInstance() *fakeInstance {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -70,21 +70,26 @@ type Manager struct {
 }
 
 type Machine struct {
-	id           string
-	image        string
-	initSystem   string
-	kernel       string
-	memoryMB     uint64
-	balloonMB    uint64
-	cpus         int
-	nestedVirt   bool
-	startedAt    time.Time
-	instance     Instance
-	lastErr      error
-	exitedAt     time.Time
-	shutdownCh   chan struct{}
-	shutdownOnce sync.Once
-	stopping     bool
+	id         string
+	image      string
+	initSystem string
+	kernel     string
+	memoryMB   uint64
+	balloonMB  uint64
+	cpus       int
+	nestedVirt bool
+	startedAt  time.Time
+	instance   Instance
+	lastErr    error
+	exitedAt   time.Time
+	stopping   bool
+	stop       *machineStopOperation
+}
+
+type machineStopOperation struct {
+	done      chan struct{}
+	err       error
+	observers int
 }
 
 type managerNetworkLease struct {
@@ -252,7 +257,6 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		nestedVirt: req.NestedVirt,
 		startedAt:  time.Now().UTC(),
 		instance:   inst,
-		shutdownCh: make(chan struct{}),
 	}
 
 	m.mu.Lock()
@@ -351,7 +355,6 @@ func (m *Manager) StartBlankInstanceStream(
 		nestedVirt: req.NestedVirt,
 		startedAt:  time.Now().UTC(),
 		instance:   inst,
-		shutdownCh: make(chan struct{}),
 	}
 
 	m.mu.Lock()
@@ -372,19 +375,19 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 }
 
 func (m *Manager) ShutdownAll(ctx context.Context) error {
-	_ = ctx
 	m.mu.Lock()
 	running := m.running
 	m.running = nil
 	m.starting = nil
+	stops := make(map[string]*machineStopOperation, len(running))
+	for id, machine := range running {
+		stops[id] = m.beginMachineStopLocked(machine)
+	}
 	m.mu.Unlock()
 
 	var errs []error
-	for id, machine := range running {
-		machine.shutdownOnce.Do(func() {
-			close(machine.shutdownCh)
-		})
-		if err := machine.instance.Close(); err != nil {
+	for id, stop := range stops {
+		if err := waitMachineStop(ctx, stop); err != nil {
 			errs = append(errs, fmt.Errorf("shutdown VM %q: %w", id, err))
 		}
 	}
@@ -395,7 +398,11 @@ func (m *Manager) ShutdownAll(ctx context.Context) error {
 }
 
 func (m *Manager) ShutdownInstance(ctx context.Context, id string) error {
-	_ = ctx
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
 	id = instanceID(id)
 
 	m.mu.Lock()
@@ -404,27 +411,63 @@ func (m *Manager) ShutdownInstance(ctx context.Context, id string) error {
 		m.mu.Unlock()
 		return fmt.Errorf("no VM %q is running", id)
 	}
-	if machine.stopping {
-		m.mu.Unlock()
-		return fmt.Errorf("VM %q is already shutting down", id)
+	stop := m.beginMachineStopLocked(machine)
+	m.mu.Unlock()
+	return waitMachineStop(ctx, stop)
+}
+
+func (m *Manager) beginMachineStopLocked(machine *Machine) *machineStopOperation {
+	if machine.stop != nil {
+		select {
+		case <-machine.stop.done:
+			if machine.stop.err == nil {
+				machine.stop.observers++
+				return machine.stop
+			}
+		default:
+			machine.stop.observers++
+			return machine.stop
+		}
 	}
+	stop := &machineStopOperation{done: make(chan struct{}), observers: 1}
+	machine.stop = stop
 	machine.stopping = true
-	machine.shutdownOnce.Do(func() {
-		close(machine.shutdownCh)
-	})
-	m.mu.Unlock()
+	go m.runMachineStop(machine, stop)
+	return stop
+}
 
-	if err := machine.instance.Close(); err != nil {
-		return err
-	}
-
+func (m *Manager) runMachineStop(machine *Machine, stop *machineStopOperation) {
+	err := machine.instance.Close()
 	m.mu.Lock()
-	if m.running != nil && m.running[id] == machine {
-		delete(m.running, id)
+	stop.err = err
+	if err == nil {
+		if m.running != nil && m.running[machine.id] == machine {
+			delete(m.running, machine.id)
+		}
+		delete(m.networkLeases, machine.id)
+	} else if machine.stop == stop {
+		machine.stopping = false
 	}
-	delete(m.networkLeases, id)
+	close(stop.done)
 	m.mu.Unlock()
-	return nil
+}
+
+func waitMachineStop(ctx context.Context, stop *machineStopOperation) error {
+	if ctx == nil {
+		<-stop.done
+		return stop.err
+	}
+	select {
+	case <-stop.done:
+		return stop.err
+	default:
+	}
+	select {
+	case <-stop.done:
+		return stop.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (m *Manager) Run(ctx context.Context, req client.RunRequest) (client.ExecResponse, error) {
@@ -529,11 +572,6 @@ func (m *Manager) StreamIn(ctx context.Context, id string, req client.ExecReques
 func (m *Manager) instanceIsStopping(id string, machine *Machine) bool {
 	if machine == nil {
 		return false
-	}
-	select {
-	case <-machine.shutdownCh:
-		return true
-	default:
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
Closes #92

## Summary
- represent instance shutdown as a shared result-bearing operation instead of a one-shot boolean/channel
- make concurrent `ShutdownInstance` and `ShutdownAll` callers join the same `Close` call
- restore instance usability after a failed close and allow the next shutdown request to retry
- remove the instance and network lease exactly once after successful cleanup
- allow callers to stop waiting via their context without canceling the shared cleanup operation

## Tests
- `go test ./...`
- retry/concurrent-result test repeated 20 times under `-race`
- `go vet ./internal/vm`
- Linux amd64 and Windows amd64 VM package cross-compilation