### PR TITLE
Publish startup snapshots atomically

### DIFF
--- a/internal/hv/hvf/snapshot_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64.go
@@ -19,6 +19,7 @@ import (
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/hv/snapshotstore"
 	"j5.nz/cc/internal/serial"
 	"j5.nz/cc/internal/timing"
 	"j5.nz/cc/internal/virtio"
@@ -476,10 +477,12 @@ func (s *snapshotTrigger) capture(vm *VM, vcpuIndex int, value uint64) error {
 		timingLog("snapshot trigger captured vcpu=%d value=%#x without file dump", vcpuIndex, value)
 		return nil
 	}
-	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return fmt.Errorf("create snapshot dir: %w", err)
+	capture, err := snapshotstore.Begin(s.dir)
+	if err != nil {
+		return err
 	}
+	defer capture.Abort()
+	outDir := capture.Dir()
 	if err := os.WriteFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
 		return fmt.Errorf("write snapshot memory: %w", err)
 	}
@@ -503,7 +506,6 @@ func (s *snapshotTrigger) capture(vm *VM, vcpuIndex int, value uint64) error {
 	manifest.GICICC = snapshotGICICC(vm, vcpuIndex)
 	manifest.Devices = snapshotDeviceStates(s.devices)
 	manifest.MMIOWrites = s.mmio.snapshot()
-	var err error
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal snapshot manifest: %w", err)
@@ -511,7 +513,11 @@ func (s *snapshotTrigger) capture(vm *VM, vcpuIndex int, value uint64) error {
 	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
 		return fmt.Errorf("write snapshot manifest: %w", err)
 	}
-	timingLog("snapshot trigger wrote %s", outDir)
+	final, err := capture.Publish("memory.bin", "manifest.json")
+	if err != nil {
+		return err
+	}
+	timingLog("snapshot trigger wrote %s", final)
 	return nil
 }
 

--- a/internal/hv/kvm/snapshot_linux_amd64.go
+++ b/internal/hv/kvm/snapshot_linux_amd64.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/amd64vm"
+	"j5.nz/cc/internal/hv/snapshotstore"
 	"j5.nz/cc/internal/serial"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
@@ -198,10 +199,12 @@ func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vso
 	if vm == nil || len(vm.vcpus) != 1 {
 		return fmt.Errorf("KVM startup snapshots require exactly one vCPU")
 	}
-	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return fmt.Errorf("create snapshot dir: %w", err)
+	capture, err := snapshotstore.Begin(s.dir)
+	if err != nil {
+		return err
 	}
+	defer capture.Abort()
+	outDir := capture.Dir()
 	if err := writeSparseFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
 		return fmt.Errorf("write snapshot memory: %w", err)
 	}
@@ -246,7 +249,8 @@ func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vso
 	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
 		return fmt.Errorf("write snapshot manifest: %w", err)
 	}
-	return nil
+	_, err = capture.Publish("memory.bin", "manifest.json")
+	return err
 }
 
 func writeSparseFile(path string, data []byte, perm os.FileMode) error {

--- a/internal/hv/snapshotstore/store.go
+++ b/internal/hv/snapshotstore/store.go
@@ -1,0 +1,135 @@
+package snapshotstore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	stagingPrefix = ".snapshot-staging-"
+	finalPrefix   = "snapshot-"
+	staleAfter    = 24 * time.Hour
+)
+
+type Capture struct {
+	root      string
+	staging   string
+	final     string
+	published bool
+}
+
+// Begin creates a private capture directory. It is deliberately hidden from
+// snapshot-* discovery until Publish atomically installs it.
+func Begin(root string) (*Capture, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, fmt.Errorf("snapshot root is required")
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, fmt.Errorf("create snapshot root: %w", err)
+	}
+	cleanupStale(root, time.Now())
+
+	staging, err := os.MkdirTemp(root, stagingPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("create snapshot staging directory: %w", err)
+	}
+	suffix := strings.TrimPrefix(filepath.Base(staging), stagingPrefix)
+	name := finalPrefix + time.Now().UTC().Format("20060102T150405.000000000Z") + "-" + suffix
+	return &Capture{root: root, staging: staging, final: filepath.Join(root, name)}, nil
+}
+
+func (c *Capture) Dir() string {
+	if c == nil {
+		return ""
+	}
+	return c.staging
+}
+
+// Abort removes an unpublished capture. It is safe to call after Publish.
+func (c *Capture) Abort() error {
+	if c == nil || c.published || c.staging == "" {
+		return nil
+	}
+	return os.RemoveAll(c.staging)
+}
+
+// Publish validates and syncs every component before atomically making the
+// capture visible. Required component names must be direct children.
+func (c *Capture) Publish(required ...string) (string, error) {
+	if c == nil || c.staging == "" || c.final == "" {
+		return "", fmt.Errorf("snapshot capture is not initialized")
+	}
+	if c.published {
+		return c.final, nil
+	}
+	for _, name := range required {
+		if name == "" || filepath.Base(name) != name {
+			return "", fmt.Errorf("invalid snapshot component %q", name)
+		}
+		info, err := os.Lstat(filepath.Join(c.staging, name))
+		if err != nil {
+			return "", fmt.Errorf("validate snapshot component %q: %w", name, err)
+		}
+		if !info.Mode().IsRegular() || info.Size() == 0 {
+			return "", fmt.Errorf("snapshot component %q is not a non-empty regular file", name)
+		}
+	}
+
+	entries, err := os.ReadDir(c.staging)
+	if err != nil {
+		return "", fmt.Errorf("read snapshot staging directory: %w", err)
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return "", fmt.Errorf("inspect snapshot component %q: %w", entry.Name(), err)
+		}
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("snapshot component %q is not a regular file", entry.Name())
+		}
+		if err := syncFile(filepath.Join(c.staging, entry.Name())); err != nil {
+			return "", fmt.Errorf("sync snapshot component %q: %w", entry.Name(), err)
+		}
+	}
+	if err := syncDir(c.staging); err != nil {
+		return "", fmt.Errorf("sync snapshot staging directory: %w", err)
+	}
+	if err := os.Rename(c.staging, c.final); err != nil {
+		return "", fmt.Errorf("publish snapshot: %w", err)
+	}
+	c.published = true
+	if err := syncDir(c.root); err != nil {
+		return "", fmt.Errorf("sync snapshot root: %w", err)
+	}
+	return c.final, nil
+}
+
+func syncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+func cleanupStale(root string, now time.Time) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), stagingPrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || now.Sub(info.ModTime()) < staleAfter {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(root, entry.Name()))
+	}
+}

--- a/internal/hv/snapshotstore/store.go
+++ b/internal/hv/snapshotstore/store.go
@@ -109,7 +109,9 @@ func (c *Capture) Publish(required ...string) (string, error) {
 }
 
 func syncFile(path string) error {
-	f, err := os.Open(path)
+	// FlushFileBuffers requires a writable handle on Windows. Snapshot
+	// components are still private staging files at this point.
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/hv/snapshotstore/store_test.go
+++ b/internal/hv/snapshotstore/store_test.go
@@ -1,0 +1,67 @@
+package snapshotstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCaptureIsVisibleOnlyAfterCompletePublication(t *testing.T) {
+	root := t.TempDir()
+	capture, err := Begin(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = capture.Abort() })
+
+	if matches, err := filepath.Glob(filepath.Join(root, "snapshot-*")); err != nil || len(matches) != 0 {
+		t.Fatalf("incomplete capture discovery = %v, err = %v", matches, err)
+	}
+	if err := os.WriteFile(filepath.Join(capture.Dir(), "memory.bin"), []byte("memory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := capture.Publish("memory.bin", "manifest.json"); err == nil {
+		t.Fatal("published capture without required manifest")
+	}
+	if matches, err := filepath.Glob(filepath.Join(root, "snapshot-*")); err != nil || len(matches) != 0 {
+		t.Fatalf("failed capture discovery = %v, err = %v", matches, err)
+	}
+	if err := os.WriteFile(filepath.Join(capture.Dir(), "manifest.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	final, err := capture.Publish("memory.bin", "manifest.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(root, "snapshot-*")); err != nil || len(matches) != 1 || matches[0] != final {
+		t.Fatalf("published capture discovery = %v, err = %v", matches, err)
+	}
+}
+
+func TestBeginRemovesOnlyStaleStagingDirectories(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, stagingPrefix+"stale")
+	active := filepath.Join(root, stagingPrefix+"active")
+	for _, path := range []string{stale, active} {
+		if err := os.Mkdir(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-staleAfter - time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	capture, err := Begin(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = capture.Abort() })
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale staging stat error = %v", err)
+	}
+	if _, err := os.Stat(active); err != nil {
+		t.Fatalf("active staging was removed: %v", err)
+	}
+}

--- a/internal/hv/snapshotstore/syncdir_unix.go
+++ b/internal/hv/snapshotstore/syncdir_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package snapshotstore
+
+import "os"
+
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/internal/hv/snapshotstore/syncdir_windows.go
+++ b/internal/hv/snapshotstore/syncdir_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package snapshotstore
+
+// Windows does not expose portable directory fsync through os.File. Component
+// files are flushed before MoveFileEx-backed os.Rename publishes the capture.
+func syncDir(string) error { return nil }

--- a/internal/hv/whp/snapshot_windows_amd64.go
+++ b/internal/hv/whp/snapshot_windows_amd64.go
@@ -16,6 +16,7 @@ import (
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/amd64vm"
+	"j5.nz/cc/internal/hv/snapshotstore"
 	"j5.nz/cc/internal/serial"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
@@ -159,10 +160,12 @@ func (s *snapshotTrigger) capture(vm *VM, platform *bootPlatform, value uint64) 
 	if s == nil || strings.TrimSpace(s.dir) == "" {
 		return nil
 	}
-	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return fmt.Errorf("create snapshot dir: %w", err)
+	capture, err := snapshotstore.Begin(s.dir)
+	if err != nil {
+		return err
 	}
+	defer capture.Abort()
+	outDir := capture.Dir()
 	if err := os.WriteFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
 		return fmt.Errorf("write snapshot memory: %w", err)
 	}
@@ -196,7 +199,8 @@ func (s *snapshotTrigger) capture(vm *VM, platform *bootPlatform, value uint64) 
 	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
 		return fmt.Errorf("write snapshot manifest: %w", err)
 	}
-	return nil
+	_, err = capture.Publish("memory.bin", "manifest.json")
+	return err
 }
 
 func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {

--- a/internal/hv/whp/snapshot_windows_arm64.go
+++ b/internal/hv/whp/snapshot_windows_arm64.go
@@ -18,6 +18,7 @@ import (
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/hv/snapshotstore"
 	"j5.nz/cc/internal/serial"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
@@ -226,10 +227,12 @@ func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vso
 	if s == nil || strings.TrimSpace(s.dir) == "" {
 		return nil
 	}
-	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return fmt.Errorf("create snapshot dir: %w", err)
+	capture, err := snapshotstore.Begin(s.dir)
+	if err != nil {
+		return err
 	}
+	defer capture.Abort()
+	outDir := capture.Dir()
 	if err := os.WriteFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
 		return fmt.Errorf("write snapshot memory: %w", err)
 	}
@@ -262,7 +265,8 @@ func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vso
 	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644); err != nil {
 		return fmt.Errorf("write snapshot manifest: %w", err)
 	}
-	return nil
+	_, err = capture.Publish("memory.bin", "manifest.json")
+	return err
 }
 
 func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {


### PR DESCRIPTION
Closes #116

## Summary
- capture KVM, HVF, and WHP snapshots in hidden private staging directories
- validate and flush every component before atomic publication
- ignore partial captures during `snapshot-*` discovery and garbage-collect stale staging directories
- share publication behavior across all startup snapshot backends

## Verification
- `go test ./...`
- `go test -race ./internal/hv/snapshotstore ./internal/hv/hvf`
- `go vet ./internal/hv/snapshotstore`
- compiled KVM linux/amd64 and WHP windows/amd64 + windows/arm64 test binaries

The broader HVF vet run still reports the existing `container_darwin_arm64.go:1700` deferred `time.Since` warning, outside this change.