### PR TITLE
Add vet, Staticcheck, and race CI gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,42 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends dosfstools musl-tools
 
+      - name: Run vet
+        if: runner.os != 'Windows'
+        run: go vet ./...
+
+      - name: Run vet (Windows)
+        if: runner.os == 'Windows'
+        # Hyper-V bindings intentionally convert syscall uintptr values at the
+        # audited ABI boundary. Keep every other vet analyzer enabled.
+        run: go vet -unsafeptr=false ./...
+
+      - name: Install Staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2026.1
+
+      - name: Run correctness static analysis
+        # SA1019 flags archive/tar.TypeRegA compatibility handling; SA6002 is
+        # an allocation advisory. Neither is a correctness failure.
+        run: staticcheck -checks='SA*,-SA1019,-SA6002' ./...
+
       - name: Run tests
         run: go test -short ./... -count=1 -timeout 30m
+
+  race-test:
+    name: Lifecycle and ownership race tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run targeted race tests
+        run: go test -race -short ./internal/ccvmd ./internal/netstack ./internal/virtio ./internal/vm/... -count=1 -timeout 15m
 
   kvm-test:
     name: KVM and rootfs tests (${{ matrix.name }})

--- a/internal/cmd/init/main.go
+++ b/internal/cmd/init/main.go
@@ -634,7 +634,6 @@ func readStage2Config() ([]byte, error) {
 }
 
 func connectStage2Control(port uint32) (*os.File, error) {
-	var lastErr error
 	start := time.Now()
 	lastLog := start
 	for attempt := 0; ; attempt++ {
@@ -645,7 +644,6 @@ func connectStage2Control(port uint32) (*os.File, error) {
 			}
 			return control, nil
 		}
-		lastErr = err
 		if attempt == 0 {
 			writeKernel("ccx3-init: stage2 waiting for vsock control: " + err.Error())
 			lastLog = time.Now()
@@ -655,7 +653,6 @@ func connectStage2Control(port uint32) (*os.File, error) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return nil, lastErr
 }
 
 func bootInitSystem(cfg config, bootStart time.Time) error {

--- a/internal/freebsd/rootfs/rootfs.go
+++ b/internal/freebsd/rootfs/rootfs.go
@@ -159,21 +159,21 @@ func buildManagedRootFromBase(root imagefs.Directory, closeRoot func() error, in
 	network = normalizeFreeBSDNetwork(network)
 	overlay := imagefs.NewOverlay(root)
 	if err := rootplan.AddFiles(overlay, []rootplan.File{
-		{"/sbin/init", 0o755, []byte(fmt.Sprintf(managedInitScript, network.Interface, network.GuestIPv4, network.GatewayIPv4))},
-		{"/sbin/cc-freebsd-init", 0o755, initBin},
-		{"/etc/fstab", 0o644, []byte("/dev/nda0 / ufs rw 1 1\n")},
-		{"/etc/rc.conf", 0o644, []byte(fmt.Sprintf("hostname=\"%s\"\nifconfig_%s=\"inet %s netmask 255.255.255.0\"\ndefaultrouter=\"%s\"\n", network.Hostname, network.Interface, network.GuestIPv4, network.GatewayIPv4))},
-		{"/etc/resolv.conf", 0o644, []byte("nameserver " + network.DNSIPv4 + "\n")},
-		{"/etc/hosts", 0o644, []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
-		{"/etc/services", 0o644, []byte(bsdNetworkServices)},
+		{Path: "/sbin/init", Mode: 0o755, Data: []byte(fmt.Sprintf(managedInitScript, network.Interface, network.GuestIPv4, network.GatewayIPv4))},
+		{Path: "/sbin/cc-freebsd-init", Mode: 0o755, Data: initBin},
+		{Path: "/etc/fstab", Mode: 0o644, Data: []byte("/dev/nda0 / ufs rw 1 1\n")},
+		{Path: "/etc/rc.conf", Mode: 0o644, Data: []byte(fmt.Sprintf("hostname=\"%s\"\nifconfig_%s=\"inet %s netmask 255.255.255.0\"\ndefaultrouter=\"%s\"\n", network.Hostname, network.Interface, network.GuestIPv4, network.GatewayIPv4))},
+		{Path: "/etc/resolv.conf", Mode: 0o644, Data: []byte("nameserver " + network.DNSIPv4 + "\n")},
+		{Path: "/etc/hosts", Mode: 0o644, Data: []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
+		{Path: "/etc/services", Mode: 0o644, Data: []byte(bsdNetworkServices)},
 	}); err != nil {
 		_ = closeRoot()
 		return nil, nil, err
 	}
 	if err := rootplan.AddDevices(overlay, []rootplan.Device{
-		{"/dev/console", fs.ModeDevice | fs.ModeCharDevice | 0o600, 0},
-		{"/dev/null", fs.ModeDevice | fs.ModeCharDevice | 0o666, 2},
-		{"/dev/zero", fs.ModeDevice | fs.ModeCharDevice | 0o666, 12},
+		{Path: "/dev/console", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o600, RDev: 0},
+		{Path: "/dev/null", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: 2},
+		{Path: "/dev/zero", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: 12},
 	}); err != nil {
 		_ = closeRoot()
 		return nil, nil, err

--- a/internal/hv/hvf/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings_darwin_arm64.go
@@ -385,8 +385,8 @@ func NewVMWithOptions(ctx context.Context, opts VMOptions) (*VM, error) {
 		start := time.Now()
 		vmCfg := hvVMConfigCreate()
 		timing.Since(ctx, "hvf.new_vm.vm_config_create", start)
-		start = time.Now()
 		if opts.NestedVirt {
+			start = time.Now()
 			if hvVMConfigSetEL2Enabled == nil {
 				osRelease(uintptr(vmCfg))
 				errCh <- fmt.Errorf("enable nested virtualization: EL2 is not available in this Hypervisor.framework")
@@ -406,6 +406,7 @@ func NewVMWithOptions(ctx context.Context, opts VMOptions) (*VM, error) {
 				errCh <- fmt.Errorf("enable nested virtualization: %w", ret)
 				return
 			}
+			timing.Since(ctx, "hvf.new_vm.vm_config_set_el2", start)
 		}
 		start = time.Now()
 		ret := createVMWithRetry(vmCfg)

--- a/internal/hv/hvf/container_darwin_arm64.go
+++ b/internal/hv/hvf/container_darwin_arm64.go
@@ -1560,9 +1560,6 @@ func runContainer(ctx context.Context, req ContainerRunRequest, readyCh chan<- e
 			}
 		}
 		if pendingResult != nil && ctx.Err() != nil {
-			if includeTraceOnExit {
-				transcript = transcript + "\n[virtio-fs trace]\n" + fsTrace.String()
-			}
 			return *pendingResult, nil
 		}
 
@@ -1697,7 +1694,9 @@ func handleContainerDataAbort(ctx context.Context, vm *VM, vcpuIndex int, uart *
 	recorder := timing.FromContext(ctx)
 	if recorder != nil {
 		totalStart := time.Now()
-		defer recorder.Record("hvf.data_abort.total", time.Since(totalStart))
+		defer func() {
+			recorder.Record("hvf.data_abort.total", time.Since(totalStart))
+		}()
 	}
 	info, err := DecodeDataAbort(exitInfo.Exception.Syndrome)
 	if err != nil {

--- a/internal/kernel/alpine/package_reader.go
+++ b/internal/kernel/alpine/package_reader.go
@@ -272,6 +272,7 @@ func (m *Manager) lookupPackageEntry(ctx context.Context, repo, packageName stri
 	timing.Since(ctx, "kernel.lookup_package_entry.read_apk_index", start)
 	start = time.Now()
 	entry, err := m.packageEntryFromIndex(repo, packageName, indexData)
+	timing.Since(ctx, "kernel.lookup_package_entry.parse_entry", start)
 	if err != nil {
 		return indexEntry{}, err
 	}

--- a/internal/netbsd/rootfs/rootfs.go
+++ b/internal/netbsd/rootfs/rootfs.go
@@ -173,17 +173,17 @@ func buildManagedRootFromBase(root imagefs.Directory, closeRoot func() error, in
 	}
 	overlay := imagefs.NewOverlay(root)
 	if err := rootplan.AddFiles(overlay, []rootplan.File{
-		{"/sbin/init", 0o755, []byte(fmt.Sprintf(managedInitScript, network.Interface, network.GuestIPv4, network.GatewayIPv4, network.GatewayMAC, network.GatewayIPv4))},
-		{"/sbin/cc-netbsd-init", 0o755, initBin},
-		{"/etc/fstab", 0o644, []byte(fmt.Sprintf("/dev/%s / ffs rw 1 1\n", rootDevice))},
-		{"/etc/rc.conf", 0o644, []byte(fmt.Sprintf("rc_configured=YES\nhostname=\"%s\"\ndefaultroute=\"%s\"\n", network.Hostname, network.GatewayIPv4))},
-		{"/etc/ifconfig." + network.Interface, 0o644, []byte(fmt.Sprintf("inet %s netmask 255.255.255.0\n", network.GuestIPv4))},
-		{"/etc/resolv.conf", 0o644, []byte("nameserver " + network.DNSIPv4 + "\n")},
-		{"/etc/hosts", 0o644, []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
-		{"/etc/services", 0o644, []byte(bsdNetworkServices)},
-		{"/etc/protocols", 0o644, []byte(bsdNetworkProtocols)},
-		{"/etc/netconfig", 0o644, []byte(netBSDNetconfig)},
-		{"/root/.profile", 0o644, []byte(`export PKG_PATH=${PKG_PATH:-https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All}
+		{Path: "/sbin/init", Mode: 0o755, Data: []byte(fmt.Sprintf(managedInitScript, network.Interface, network.GuestIPv4, network.GatewayIPv4, network.GatewayMAC, network.GatewayIPv4))},
+		{Path: "/sbin/cc-netbsd-init", Mode: 0o755, Data: initBin},
+		{Path: "/etc/fstab", Mode: 0o644, Data: []byte(fmt.Sprintf("/dev/%s / ffs rw 1 1\n", rootDevice))},
+		{Path: "/etc/rc.conf", Mode: 0o644, Data: []byte(fmt.Sprintf("rc_configured=YES\nhostname=\"%s\"\ndefaultroute=\"%s\"\n", network.Hostname, network.GatewayIPv4))},
+		{Path: "/etc/ifconfig." + network.Interface, Mode: 0o644, Data: []byte(fmt.Sprintf("inet %s netmask 255.255.255.0\n", network.GuestIPv4))},
+		{Path: "/etc/resolv.conf", Mode: 0o644, Data: []byte("nameserver " + network.DNSIPv4 + "\n")},
+		{Path: "/etc/hosts", Mode: 0o644, Data: []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
+		{Path: "/etc/services", Mode: 0o644, Data: []byte(bsdNetworkServices)},
+		{Path: "/etc/protocols", Mode: 0o644, Data: []byte(bsdNetworkProtocols)},
+		{Path: "/etc/netconfig", Mode: 0o644, Data: []byte(netBSDNetconfig)},
+		{Path: "/root/.profile", Mode: 0o644, Data: []byte(`export PKG_PATH=${PKG_PATH:-https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All}
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/pkg/bin:/usr/pkg/sbin
 `)},
 	}); err != nil {
@@ -230,25 +230,25 @@ func netBSDDeviceMajorsForArch(arch string) netBSDDeviceMajors {
 func netBSDManagedDevices(arch string) []rootplan.Device {
 	maj := netBSDDeviceMajorsForArch(arch)
 	return []rootplan.Device{
-		{"/dev/console", fs.ModeDevice | fs.ModeCharDevice | 0o600, rdev(maj.consChar, 0)},
-		{"/dev/constty", fs.ModeDevice | fs.ModeCharDevice | 0o600, rdev(maj.consChar, 1)},
-		{"/dev/tty", fs.ModeDevice | fs.ModeCharDevice | 0o666, rdev(maj.cttyChar, 0)},
-		{"/dev/null", fs.ModeDevice | fs.ModeCharDevice | 0o666, rdev(maj.memChar, 2)},
-		{"/dev/zero", fs.ModeDevice | fs.ModeCharDevice | 0o666, rdev(maj.memChar, 12)},
-		{"/dev/random", fs.ModeDevice | fs.ModeCharDevice | 0o444, rdev(maj.rndChar, 0)},
-		{"/dev/urandom", fs.ModeDevice | fs.ModeCharDevice | 0o644, rdev(maj.rndChar, 1)},
-		{"/dev/ld0", fs.ModeDevice | 0o640, rdev(maj.ldBlock, 3)},
-		{"/dev/ld0a", fs.ModeDevice | 0o640, rdev(maj.ldBlock, 0)},
-		{"/dev/ld0d", fs.ModeDevice | 0o640, rdev(maj.ldBlock, 3)},
-		{"/dev/rld0", fs.ModeDevice | fs.ModeCharDevice | 0o640, rdev(maj.ldChar, 3)},
-		{"/dev/rld0a", fs.ModeDevice | fs.ModeCharDevice | 0o640, rdev(maj.ldChar, 0)},
-		{"/dev/rld0d", fs.ModeDevice | fs.ModeCharDevice | 0o640, rdev(maj.ldChar, 3)},
-		{"/dev/ld4", fs.ModeDevice | 0o640, rdev(maj.ldBlock, 35)},
-		{"/dev/ld4a", fs.ModeDevice | 0o640, rdev(maj.ldBlock, 32)},
-		{"/dev/ld4d", fs.ModeDevice | 0o640, rdev(maj.ldBlock, 35)},
-		{"/dev/rld4", fs.ModeDevice | fs.ModeCharDevice | 0o640, rdev(maj.ldChar, 35)},
-		{"/dev/rld4a", fs.ModeDevice | fs.ModeCharDevice | 0o640, rdev(maj.ldChar, 32)},
-		{"/dev/rld4d", fs.ModeDevice | fs.ModeCharDevice | 0o640, rdev(maj.ldChar, 35)},
+		{Path: "/dev/console", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o600, RDev: rdev(maj.consChar, 0)},
+		{Path: "/dev/constty", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o600, RDev: rdev(maj.consChar, 1)},
+		{Path: "/dev/tty", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: rdev(maj.cttyChar, 0)},
+		{Path: "/dev/null", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: rdev(maj.memChar, 2)},
+		{Path: "/dev/zero", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: rdev(maj.memChar, 12)},
+		{Path: "/dev/random", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o444, RDev: rdev(maj.rndChar, 0)},
+		{Path: "/dev/urandom", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o644, RDev: rdev(maj.rndChar, 1)},
+		{Path: "/dev/ld0", Mode: fs.ModeDevice | 0o640, RDev: rdev(maj.ldBlock, 3)},
+		{Path: "/dev/ld0a", Mode: fs.ModeDevice | 0o640, RDev: rdev(maj.ldBlock, 0)},
+		{Path: "/dev/ld0d", Mode: fs.ModeDevice | 0o640, RDev: rdev(maj.ldBlock, 3)},
+		{Path: "/dev/rld0", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o640, RDev: rdev(maj.ldChar, 3)},
+		{Path: "/dev/rld0a", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o640, RDev: rdev(maj.ldChar, 0)},
+		{Path: "/dev/rld0d", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o640, RDev: rdev(maj.ldChar, 3)},
+		{Path: "/dev/ld4", Mode: fs.ModeDevice | 0o640, RDev: rdev(maj.ldBlock, 35)},
+		{Path: "/dev/ld4a", Mode: fs.ModeDevice | 0o640, RDev: rdev(maj.ldBlock, 32)},
+		{Path: "/dev/ld4d", Mode: fs.ModeDevice | 0o640, RDev: rdev(maj.ldBlock, 35)},
+		{Path: "/dev/rld4", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o640, RDev: rdev(maj.ldChar, 35)},
+		{Path: "/dev/rld4a", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o640, RDev: rdev(maj.ldChar, 32)},
+		{Path: "/dev/rld4d", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o640, RDev: rdev(maj.ldChar, 35)},
 	}
 }
 

--- a/internal/openbsd/rootfs/rootfs.go
+++ b/internal/openbsd/rootfs/rootfs.go
@@ -156,13 +156,13 @@ func buildManagedRootFromBase(base imagefs.Directory, closeBase func() error, in
 		return nil, nil, err
 	}
 	if err := rootplan.AddDevices(overlay, []rootplan.Device{
-		{"/dev/console", fs.ModeDevice | fs.ModeCharDevice | 0o600, 0},
-		{"/dev/null", fs.ModeDevice | fs.ModeCharDevice | 0o666, 514},
-		{"/dev/zero", fs.ModeDevice | fs.ModeCharDevice | 0o666, 515},
-		{"/dev/random", fs.ModeDevice | fs.ModeCharDevice | 0o644, 565},
-		{"/dev/urandom", fs.ModeDevice | fs.ModeCharDevice | 0o644, 566},
-		{"/dev/sd0a", fs.ModeDevice | 0o640, 1024},
-		{"/dev/sd0b", fs.ModeDevice | 0o640, 1025},
+		{Path: "/dev/console", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o600, RDev: 0},
+		{Path: "/dev/null", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: 514},
+		{Path: "/dev/zero", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: 515},
+		{Path: "/dev/random", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o644, RDev: 565},
+		{Path: "/dev/urandom", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o644, RDev: 566},
+		{Path: "/dev/sd0a", Mode: fs.ModeDevice | 0o640, RDev: 1024},
+		{Path: "/dev/sd0b", Mode: fs.ModeDevice | 0o640, RDev: 1025},
 	}); err != nil {
 		_ = closeBase()
 		return nil, nil, err
@@ -177,12 +177,12 @@ func buildManagedRootFromBase(base imagefs.Directory, closeBase func() error, in
 func buildManagedRootFromPreparedBase(root imagefs.Directory, closeRoot func() error, initBin []byte, network machine.NetworkSpec) (imagefs.Directory, func() error, error) {
 	overlay := imagefs.NewOverlay(root)
 	if err := rootplan.AddFiles(overlay, []rootplan.File{
-		{"/sbin/cc-openbsd-init", 0o755, initBin},
-		{"/etc/fstab", 0o644, []byte("/dev/sd0a / ffs rw,noatime 1 1\n")},
-		{"/etc/myname", 0o644, []byte(network.Hostname + "\n")},
-		{"/etc/resolv.conf", 0o644, []byte("nameserver " + network.DNSIPv4 + "\n")},
-		{"/etc/hosts", 0o644, []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
-		{"/etc/services", 0o644, []byte(bsdNetworkServices)},
+		{Path: "/sbin/cc-openbsd-init", Mode: 0o755, Data: initBin},
+		{Path: "/etc/fstab", Mode: 0o644, Data: []byte("/dev/sd0a / ffs rw,noatime 1 1\n")},
+		{Path: "/etc/myname", Mode: 0o644, Data: []byte(network.Hostname + "\n")},
+		{Path: "/etc/resolv.conf", Mode: 0o644, Data: []byte("nameserver " + network.DNSIPv4 + "\n")},
+		{Path: "/etc/hosts", Mode: 0o644, Data: []byte(fmt.Sprintf("127.0.0.1 localhost\n%s %s\n", network.GuestIPv4, network.Hostname))},
+		{Path: "/etc/services", Mode: 0o644, Data: []byte(bsdNetworkServices)},
 	}); err != nil {
 		_ = closeRoot()
 		return nil, nil, err
@@ -250,13 +250,13 @@ func buildBaseRoot(ctx context.Context, baseSetPath string, init []byte) (imagef
 		return nil, nil, err
 	}
 	if err := rootplan.AddDevices(overlay, []rootplan.Device{
-		{"/dev/console", fs.ModeDevice | fs.ModeCharDevice | 0o600, 0},
-		{"/dev/null", fs.ModeDevice | fs.ModeCharDevice | 0o666, 514},
-		{"/dev/zero", fs.ModeDevice | fs.ModeCharDevice | 0o666, 515},
-		{"/dev/random", fs.ModeDevice | fs.ModeCharDevice | 0o644, 565},
-		{"/dev/urandom", fs.ModeDevice | fs.ModeCharDevice | 0o644, 566},
-		{"/dev/sd0a", fs.ModeDevice | 0o640, 1024},
-		{"/dev/sd0b", fs.ModeDevice | 0o640, 1025},
+		{Path: "/dev/console", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o600, RDev: 0},
+		{Path: "/dev/null", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: 514},
+		{Path: "/dev/zero", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o666, RDev: 515},
+		{Path: "/dev/random", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o644, RDev: 565},
+		{Path: "/dev/urandom", Mode: fs.ModeDevice | fs.ModeCharDevice | 0o644, RDev: 566},
+		{Path: "/dev/sd0a", Mode: fs.ModeDevice | 0o640, RDev: 1024},
+		{Path: "/dev/sd0b", Mode: fs.ModeDevice | 0o640, RDev: 1025},
 	}); err != nil {
 		_ = tfs.Close()
 		return nil, nil, err

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -2643,7 +2643,8 @@ func (f *FS) Stats() FSStats {
 	defer f.mu.Unlock()
 	tag := strings.TrimRight(string(f.tag[:]), "\x00")
 	ops := make([]FUSEOpStats, 0, len(f.fuseOpStats))
-	for opcode, stat := range f.fuseOpStats {
+	for opcode := range f.fuseOpStats {
+		stat := &f.fuseOpStats[opcode]
 		count := stat.timingStat.count.Load()
 		if count == 0 {
 			continue
@@ -2670,8 +2671,8 @@ func (f *FS) Stats() FSStats {
 		return ops[i].Count > ops[j].Count
 	})
 	stages := make([]TimingStats, 0, len(f.stageStats))
-	for stage, stat := range f.stageStats {
-		if stats, ok := timingStatsSnapshot(fsStageName(stage), &stat); ok {
+	for stage := range f.stageStats {
+		if stats, ok := timingStatsSnapshot(fsStageName(stage), &f.stageStats[stage]); ok {
 			stages = append(stages, stats)
 		}
 	}

--- a/internal/vm/sidecar/daemon_test.go
+++ b/internal/vm/sidecar/daemon_test.go
@@ -1,6 +1,7 @@
 package sidecar
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -31,7 +32,7 @@ func TestWaitCommand(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start exit helper: %v", err)
 	}
-	if err := WaitCommand(cmd, time.Second); err != nil {
+	if err := WaitCommand(cmd, 30*time.Second); err != nil {
 		t.Fatalf("wait exit helper: %v", err)
 	}
 
@@ -39,13 +40,13 @@ func TestWaitCommand(t *testing.T) {
 	if err := slow.Start(); err != nil {
 		t.Fatalf("start sleep helper: %v", err)
 	}
-	start := time.Now()
 	err := WaitCommand(slow, 10*time.Millisecond)
-	if err == nil {
-		t.Fatalf("wait sleep unexpectedly succeeded")
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("wait timed-out helper error = %T, want process exit error", err)
 	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("wait sleep took %s, want timeout kill", elapsed)
+	if slow.ProcessState == nil || slow.ProcessState.Success() {
+		t.Fatalf("timed-out helper process state = %v, want unsuccessful termination", slow.ProcessState)
 	}
 }
 


### PR DESCRIPTION
Closes #109

## Summary
- run `go vet` and Staticcheck correctness analyzers across the six-platform test matrix
- add targeted race coverage for ccvmd, networking, virtio ownership, VM lifecycle, and sidecars
- fix current unreachable code, copied atomics, deferred timing, ignored timing samples, and unkeyed root-plan literals
- make the sidecar timeout test assert process lifecycle state instead of a fragile one-second runtime

## Narrow suppressions
- Windows disables only vet `unsafeptr` because Hyper-V bindings intentionally convert syscall uintptr values at the audited ABI boundary
- Staticcheck excludes SA1019 for deliberate `tar.TypeRegA` compatibility handling and SA6002 because it is an allocation advisory, not correctness analysis

## Verification
- `go test ./...`
- targeted race shard locally
- vet and selected Staticcheck checks for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64
- workflow YAML parse and diff checks