### PR TITLE
Enforce guest source network identity

### DIFF
--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -280,14 +280,17 @@ type NetStack struct {
 	debugAddr     string
 
 	// Simple counters.
-	udpRxPackets atomic.Uint64
-	udpTxPackets atomic.Uint64
-
-	closeOnce sync.Once
+	udpRxPackets     atomic.Uint64
+	udpTxPackets     atomic.Uint64
+	sourceViolations [5]atomic.Uint64
+	closeOnce        sync.Once
 }
 
 // New constructs a NetStack with defaults.
 func New(l *slog.Logger) *NetStack {
+	if l == nil {
+		l = slog.Default()
+	}
 	now := time.Now().UnixNano()
 	stack := &NetStack{
 		log:                 l,
@@ -747,6 +750,12 @@ func (ns *NetStack) handleEthernetFrameWithReuse(frame []byte, releaseUnsafe boo
 			src.String(), dst.String(), etherType.String(), len(payload), releaseUnsafe)
 	}
 
+	expectedMAC := macFromUint64(macAddr(ns.guestMAC.Load()))
+	if violation := ValidateGuestSource(frame, expectedMAC, net.IP(ns.guestIPv4[:])); violation != SourceValid {
+		ns.recordSourceViolation(violation, src)
+		return nil
+	}
+
 	ns.recordGuestMAC(src)
 
 	// Apply simple L2 filter: accept broadcast, host MAC, and configured guest
@@ -771,6 +780,19 @@ func (ns *NetStack) handleEthernetFrameWithReuse(frame []byte, releaseUnsafe boo
 	default:
 		tracef("netstack.handleEthernetFrame drop unsupported", "ethertype=%s", etherType.String())
 		return nil
+	}
+}
+
+func (ns *NetStack) recordSourceViolation(violation SourceViolation, sourceMAC net.HardwareAddr) {
+	if violation <= SourceValid || int(violation) >= len(ns.sourceViolations) {
+		return
+	}
+	count := ns.sourceViolations[violation].Add(1)
+	// Log the first violation and powers of two thereafter. Counters preserve
+	// every event while a hostile guest cannot flood logs per packet.
+	if count&(count-1) == 0 {
+		ns.log.Warn("dropping guest frame with invalid source identity",
+			"reason", violation.String(), "source_mac", sourceMAC.String(), "count", count)
 	}
 }
 
@@ -3782,6 +3804,10 @@ type debugStatus struct {
 	HostMAC                  string   `json:"hostMAC"`
 	ConfiguredMAC            string   `json:"configuredGuestMAC"`
 	ObservedMAC              string   `json:"observedGuestMAC"`
+	SourceMACViolations      uint64   `json:"sourceMACViolations"`
+	SourceARPViolations      uint64   `json:"sourceARPViolations"`
+	SourceIPv4Violations     uint64   `json:"sourceIPv4Violations"`
+	MalformedSourceFrames    uint64   `json:"malformedSourceFrames"`
 }
 
 func (ns *NetStack) collectDebugStatus() debugStatus {
@@ -3821,6 +3847,10 @@ func (ns *NetStack) collectDebugStatus() debugStatus {
 	if mac := macFromUint64(macAddr(ns.observedGuestMAC.Load())); len(mac) == 6 {
 		status.ObservedMAC = mac.String()
 	}
+	status.SourceMACViolations = ns.sourceViolations[SourceMACViolation].Load()
+	status.SourceARPViolations = ns.sourceViolations[SourceARPViolation].Load()
+	status.SourceIPv4Violations = ns.sourceViolations[SourceIPv4Violation].Load()
+	status.MalformedSourceFrames = ns.sourceViolations[SourceMalformed].Load()
 
 	ns.tcpMu.Lock()
 	for port := range ns.tcpListen {

--- a/internal/netstack/netstack_test.go
+++ b/internal/netstack/netstack_test.go
@@ -54,6 +54,43 @@ func TestSetHostMACRejectsMulticast(t *testing.T) {
 	}
 }
 
+func TestNetworkInterfaceDropsSpoofedGuestSources(t *testing.T) {
+	h := newBenchmarkHarness(t)
+	deliveries := 0
+	if err := h.stack.BindUDPCallback("10.42.0.1:9000", func(_ *udpCallbackEndpoint, _ []byte, _ net.UDPAddr) {
+		deliveries++
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	valid := buildBenchmarkUDPFrame(40000, 9000, []byte("valid"))
+	if err := h.nic.DeliverGuestPacket(valid, true); err != nil {
+		t.Fatal(err)
+	}
+	if deliveries != 1 {
+		t.Fatalf("valid packet deliveries = %d, want 1", deliveries)
+	}
+
+	spoofedIP := append([]byte(nil), valid...)
+	copy(spoofedIP[ethernetHeaderLen+12:ethernetHeaderLen+16], net.IPv4(10, 42, 0, 3).To4())
+	if err := h.nic.DeliverGuestPacket(spoofedIP, true); err != nil {
+		t.Fatal(err)
+	}
+	spoofedMAC := append([]byte(nil), valid...)
+	copy(spoofedMAC[6:12], []byte{0x02, 0x42, 0x0a, 0x2a, 0, 3})
+	if err := h.nic.DeliverGuestPacket(spoofedMAC, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if deliveries != 1 {
+		t.Fatalf("spoofed packets reached host endpoint: deliveries = %d", deliveries)
+	}
+	status := h.stack.collectDebugStatus()
+	if status.SourceIPv4Violations != 1 || status.SourceMACViolations != 1 {
+		t.Fatalf("source violation counters = IPv4:%d MAC:%d, want 1 each", status.SourceIPv4Violations, status.SourceMACViolations)
+	}
+}
+
 func TestServiceProxyBridgesUDP(t *testing.T) {
 	host, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/netstack/source_validation.go
+++ b/internal/netstack/source_validation.go
@@ -1,0 +1,110 @@
+package netstack
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+type SourceViolation uint8
+
+const (
+	SourceValid SourceViolation = iota
+	SourceMalformed
+	SourceMACViolation
+	SourceARPViolation
+	SourceIPv4Violation
+)
+
+func (v SourceViolation) String() string {
+	switch v {
+	case SourceMalformed:
+		return "malformed"
+	case SourceMACViolation:
+		return "mac"
+	case SourceARPViolation:
+		return "arp"
+	case SourceIPv4Violation:
+		return "ipv4"
+	default:
+		return "valid"
+	}
+}
+
+// ValidateGuestSource binds a guest-originated Ethernet frame to its assigned
+// MAC and IPv4 lease. ARP probes and DHCP discovery are the only zero-address
+// exceptions.
+func ValidateGuestSource(frame []byte, expectedMAC net.HardwareAddr, expectedIPv4 net.IP) SourceViolation {
+	if len(frame) < ethernetHeaderLen || len(expectedMAC) != 6 || expectedIPv4.To4() == nil {
+		return SourceMalformed
+	}
+	if !equalHardwareAddr(frame[6:12], expectedMAC) {
+		return SourceMACViolation
+	}
+
+	switch binary.BigEndian.Uint16(frame[12:14]) {
+	case uint16(etherTypeARP):
+		return validateARPSource(frame[ethernetHeaderLen:], expectedMAC, expectedIPv4.To4())
+	case uint16(etherTypeIPv4):
+		return validateIPv4Source(frame[ethernetHeaderLen:], expectedIPv4.To4())
+	case 0x86dd: // IPv6 has no assigned identity in the IPv4-only guest lease.
+		return SourceIPv4Violation
+	default:
+		return SourceValid
+	}
+}
+
+func validateARPSource(packet []byte, expectedMAC net.HardwareAddr, expectedIPv4 net.IP) SourceViolation {
+	if len(packet) < 28 ||
+		binary.BigEndian.Uint16(packet[0:2]) != arpHardwareEthernet ||
+		binary.BigEndian.Uint16(packet[2:4]) != arpProtoIPv4 ||
+		packet[4] != 6 || packet[5] != 4 {
+		return SourceMalformed
+	}
+	if !equalHardwareAddr(packet[8:14], expectedMAC) {
+		return SourceARPViolation
+	}
+	senderIP := net.IP(packet[14:18])
+	if senderIP.Equal(expectedIPv4) {
+		return SourceValid
+	}
+	// RFC 5227 address probes use an unspecified sender while probing the
+	// address that the endpoint has been assigned.
+	if senderIP.Equal(net.IPv4zero) && net.IP(packet[24:28]).Equal(expectedIPv4) {
+		return SourceValid
+	}
+	return SourceARPViolation
+}
+
+func validateIPv4Source(packet []byte, expectedIPv4 net.IP) SourceViolation {
+	if len(packet) < ipv4HeaderLen || packet[0]>>4 != 4 {
+		return SourceMalformed
+	}
+	headerLen := int(packet[0]&0x0f) * 4
+	if headerLen < ipv4HeaderLen || headerLen > len(packet) {
+		return SourceMalformed
+	}
+	sourceIP := net.IP(packet[12:16])
+	if sourceIP.Equal(expectedIPv4) {
+		return SourceValid
+	}
+	if !sourceIP.Equal(net.IPv4zero) || packet[9] != byte(udpProtocolNumber) || len(packet) < headerLen+udpHeaderLen {
+		return SourceIPv4Violation
+	}
+	udp := packet[headerLen:]
+	if binary.BigEndian.Uint16(udp[0:2]) == 68 && binary.BigEndian.Uint16(udp[2:4]) == 67 {
+		return SourceValid
+	}
+	return SourceIPv4Violation
+}
+
+func equalHardwareAddr(a, b []byte) bool {
+	if len(a) != 6 || len(b) != 6 {
+		return false
+	}
+	for i := 0; i < 6; i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/netstack/source_validation_test.go
+++ b/internal/netstack/source_validation_test.go
@@ -1,0 +1,83 @@
+package netstack
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+func TestValidateGuestSource(t *testing.T) {
+	mac := net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}
+	ip := net.IPv4(10, 42, 0, 2)
+
+	tests := []struct {
+		name  string
+		frame []byte
+		want  SourceViolation
+	}{
+		{name: "assigned IPv4", frame: sourceValidationIPv4Frame(mac, ip, 1, 0, 0), want: SourceValid},
+		{name: "spoofed Ethernet source", frame: sourceValidationIPv4Frame(net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0, 3}, ip, 1, 0, 0), want: SourceMACViolation},
+		{name: "spoofed IPv4 source", frame: sourceValidationIPv4Frame(mac, net.IPv4(10, 42, 0, 3), 1, 0, 0), want: SourceIPv4Violation},
+		{name: "unassigned IPv6", frame: sourceValidationEtherTypeFrame(mac, 0x86dd), want: SourceIPv4Violation},
+		{name: "DHCP discovery", frame: sourceValidationIPv4Frame(mac, net.IPv4zero, byte(udpProtocolNumber), 68, 67), want: SourceValid},
+		{name: "non-DHCP unspecified IPv4", frame: sourceValidationIPv4Frame(mac, net.IPv4zero, byte(udpProtocolNumber), 1234, 67), want: SourceIPv4Violation},
+		{name: "assigned ARP", frame: sourceValidationARPFrame(mac, ip, net.IPv4(10, 42, 0, 1)), want: SourceValid},
+		{name: "ARP probe", frame: sourceValidationARPFrame(mac, net.IPv4zero, ip), want: SourceValid},
+		{name: "spoofed ARP sender MAC", frame: func() []byte {
+			frame := sourceValidationARPFrame(mac, ip, net.IPv4(10, 42, 0, 1))
+			frame[ethernetHeaderLen+8] ^= 1
+			return frame
+		}(), want: SourceARPViolation},
+		{name: "spoofed ARP sender IP", frame: sourceValidationARPFrame(mac, net.IPv4(10, 42, 0, 3), net.IPv4(10, 42, 0, 1)), want: SourceARPViolation},
+		{name: "malformed", frame: []byte{1, 2, 3}, want: SourceMalformed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateGuestSource(tt.frame, mac, ip); got != tt.want {
+				t.Fatalf("ValidateGuestSource() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func sourceValidationEtherTypeFrame(mac net.HardwareAddr, etherType uint16) []byte {
+	frame := make([]byte, ethernetHeaderLen)
+	copy(frame[0:6], []byte{0x02, 0x42, 0x0a, 0x2a, 0, 1})
+	copy(frame[6:12], mac)
+	binary.BigEndian.PutUint16(frame[12:14], etherType)
+	return frame
+}
+
+func sourceValidationIPv4Frame(mac net.HardwareAddr, sourceIP net.IP, protocol byte, sourcePort, destinationPort uint16) []byte {
+	frame := make([]byte, ethernetHeaderLen+ipv4HeaderLen+udpHeaderLen)
+	copy(frame[0:6], []byte{0x02, 0x42, 0x0a, 0x2a, 0, 1})
+	copy(frame[6:12], mac)
+	binary.BigEndian.PutUint16(frame[12:14], uint16(etherTypeIPv4))
+	packet := frame[ethernetHeaderLen:]
+	packet[0] = 0x45
+	packet[9] = protocol
+	copy(packet[12:16], sourceIP.To4())
+	copy(packet[16:20], net.IPv4(10, 42, 0, 1).To4())
+	binary.BigEndian.PutUint16(packet[20:22], sourcePort)
+	binary.BigEndian.PutUint16(packet[22:24], destinationPort)
+	return frame
+}
+
+func sourceValidationARPFrame(mac net.HardwareAddr, senderIP, targetIP net.IP) []byte {
+	frame := make([]byte, ethernetHeaderLen+28)
+	for i := 0; i < 6; i++ {
+		frame[i] = 0xff
+	}
+	copy(frame[6:12], mac)
+	binary.BigEndian.PutUint16(frame[12:14], uint16(etherTypeARP))
+	packet := frame[ethernetHeaderLen:]
+	binary.BigEndian.PutUint16(packet[0:2], arpHardwareEthernet)
+	binary.BigEndian.PutUint16(packet[2:4], arpProtoIPv4)
+	packet[4], packet[5] = 6, 4
+	binary.BigEndian.PutUint16(packet[6:8], 1)
+	copy(packet[8:14], mac)
+	copy(packet[14:18], senderIP.To4())
+	copy(packet[24:28], targetIP.To4())
+	return frame
+}

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"j5.nz/cc/internal/guestinit"
 	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/kernel/ubuntu"
+	"j5.nz/cc/internal/netstack"
 	"j5.nz/cc/internal/oci"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vm/mounts"
@@ -443,9 +445,10 @@ func darwinSidecarLeaseFromConfig(id string, cfg *client.NetworkConfig) (darwinS
 }
 
 type darwinSidecarSwitch struct {
-	mu        sync.Mutex
-	leases    map[string]darwinSidecarLease
-	endpoints map[string]darwinSidecarEndpoint
+	mu               sync.Mutex
+	leases           map[string]darwinSidecarLease
+	endpoints        map[string]darwinSidecarEndpoint
+	sourceViolations [5]uint64
 }
 
 type darwinSidecarLease struct {
@@ -508,6 +511,8 @@ func (s *darwinSidecarSwitch) Register(id string) darwinSidecarLease {
 func (s *darwinSidecarSwitch) Attach(endpoint darwinSidecarEndpoint) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	endpoint.ip = append(net.IP(nil), endpoint.ip...)
+	endpoint.mac = append(net.HardwareAddr(nil), endpoint.mac...)
 	delete(s.leases, endpoint.id)
 	s.endpoints[endpoint.id] = endpoint
 }
@@ -524,7 +529,13 @@ func (s *darwinSidecarSwitch) Unregister(id string) {
 }
 
 func (s *darwinSidecarSwitch) Forward(sourceID string, frame []byte) {
-	if len(frame) < 14 {
+	source, ok := s.sourceEndpoint(sourceID)
+	if !ok {
+		s.recordSourceViolation(sourceID, netstack.SourceMalformed)
+		return
+	}
+	if violation := netstack.ValidateGuestSource(frame, source.mac, source.ip); violation != netstack.SourceValid {
+		s.recordSourceViolation(sourceID, violation)
 		return
 	}
 	dst := append(net.HardwareAddr(nil), frame[0:6]...)
@@ -544,6 +555,41 @@ func (s *darwinSidecarSwitch) Forward(sourceID string, frame []byte) {
 	if target := s.endpointByMAC(sourceID, dst); target.rx != nil {
 		target.rx(frame)
 	}
+}
+
+func (s *darwinSidecarSwitch) sourceEndpoint(id string) (darwinSidecarEndpoint, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	endpoint, ok := s.endpoints[id]
+	if !ok {
+		return darwinSidecarEndpoint{}, false
+	}
+	endpoint.ip = append(net.IP(nil), endpoint.ip...)
+	endpoint.mac = append(net.HardwareAddr(nil), endpoint.mac...)
+	return endpoint, true
+}
+
+func (s *darwinSidecarSwitch) recordSourceViolation(sourceID string, violation netstack.SourceViolation) {
+	if violation <= netstack.SourceValid || int(violation) >= len(s.sourceViolations) {
+		return
+	}
+	s.mu.Lock()
+	s.sourceViolations[violation]++
+	count := s.sourceViolations[violation]
+	s.mu.Unlock()
+	if count&(count-1) == 0 {
+		slog.Warn("dropping sidecar frame with invalid source identity",
+			"source_id", sourceID, "reason", violation.String(), "count", count)
+	}
+}
+
+func (s *darwinSidecarSwitch) sourceViolationCount(violation netstack.SourceViolation) uint64 {
+	if violation <= netstack.SourceValid || int(violation) >= len(s.sourceViolations) {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sourceViolations[violation]
 }
 
 func (s *darwinSidecarSwitch) endpointByIP(sourceID string, ip net.IP) darwinSidecarEndpoint {

--- a/internal/vm/sidecar_resources_darwin_arm64_test.go
+++ b/internal/vm/sidecar_resources_darwin_arm64_test.go
@@ -2,7 +2,13 @@
 
 package vm
 
-import "testing"
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"j5.nz/cc/internal/netstack"
+)
 
 func TestDarwinSidecarSwitchAllocatesDistinctLeases(t *testing.T) {
 	defaultDarwinSidecarSwitch.Unregister("freebsd")
@@ -32,4 +38,53 @@ func TestDarwinSidecarSwitchKeepsPendingLeaseForSameID(t *testing.T) {
 	if leaseA.mac.String() != leaseB.mac.String() {
 		t.Fatalf("pending lease MAC changed from %s to %s", leaseA.mac, leaseB.mac)
 	}
+}
+
+func TestDarwinSidecarSwitchDropsSpoofedSources(t *testing.T) {
+	switcher := &darwinSidecarSwitch{
+		leases:    make(map[string]darwinSidecarLease),
+		endpoints: make(map[string]darwinSidecarEndpoint),
+	}
+	macA := net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0, 2}
+	macB := net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0, 3}
+	ipA := net.IPv4(10, 42, 0, 2)
+	ipB := net.IPv4(10, 42, 0, 3)
+	received := 0
+	switcher.Attach(darwinSidecarEndpoint{id: "a", ip: ipA, mac: macA})
+	switcher.Attach(darwinSidecarEndpoint{id: "b", ip: ipB, mac: macB, rx: func([]byte) { received++ }})
+
+	switcher.Forward("a", darwinSidecarIPv4Frame(macB, macA, ipA))
+	if received != 1 {
+		t.Fatalf("valid frame deliveries = %d, want 1", received)
+	}
+	switcher.Forward("a", darwinSidecarIPv4Frame(macB, macA, ipB))
+	if received != 1 {
+		t.Fatalf("spoofed IPv4 frame reached target: deliveries = %d", received)
+	}
+	if got := switcher.sourceViolationCount(netstack.SourceIPv4Violation); got != 1 {
+		t.Fatalf("IPv4 violation count = %d, want 1", got)
+	}
+
+	spoofedMAC := net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0, 4}
+	switcher.Forward("a", darwinSidecarIPv4Frame(macB, spoofedMAC, ipA))
+	if received != 1 {
+		t.Fatalf("spoofed MAC frame reached target: deliveries = %d", received)
+	}
+	if got := switcher.sourceViolationCount(netstack.SourceMACViolation); got != 1 {
+		t.Fatalf("MAC violation count = %d, want 1", got)
+	}
+}
+
+func darwinSidecarIPv4Frame(destinationMAC, sourceMAC net.HardwareAddr, sourceIP net.IP) []byte {
+	const ethernetHeaderSize = 14
+	const ipv4HeaderSize = 20
+	frame := make([]byte, ethernetHeaderSize+ipv4HeaderSize)
+	copy(frame[0:6], destinationMAC)
+	copy(frame[6:12], sourceMAC)
+	binary.BigEndian.PutUint16(frame[12:14], 0x0800)
+	frame[14] = 0x45
+	frame[23] = 1
+	copy(frame[26:30], sourceIP.To4())
+	copy(frame[30:34], net.IPv4(10, 42, 0, 1).To4())
+	return frame
 }


### PR DESCRIPTION
Closes #101

## Summary
- validate guest Ethernet, ARP, and IPv4 source identities against the assigned lease
- enforce the same validator at the host netstack and Darwin inter-VM switch boundaries
- permit legitimate RFC 5227 ARP probes and DHCP client discovery while rejecting unassigned IPv6 identity
- expose per-reason host-path counters and power-of-two rate-limited logs for both ingress paths

## Verification
- `go test ./...`
- repeated race tests for source validation, host delivery, and Darwin switch forwarding
- full `go test -race ./internal/netstack`
- `go vet ./internal/netstack ./internal/vm`
- linux/amd64 and windows/amd64 netstack test cross-compiles

Repository-wide vet findings are addressed separately by #158.