### PR TITLE
Require mTLS for remote ccvmd listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,47 @@ Quick KVM check:
 test -r /dev/kvm -a -w /dev/kvm && echo "KVM is accessible"
 ```
 
+## Remote daemon TLS
+
+The default `ccvm` listener is local-only. Any wildcard, non-loopback IP, or
+hostname other than `localhost` requires mutual TLS and fails before startup
+without it. This applies to health, control, debug, streaming, and WebSocket
+routes; a bearer-token wrapper or firewall rule is not treated as remote
+authentication.
+
+Put the listener configuration in an owner-only JSON file:
+
+```json
+{
+  "certificate_file": "server.crt",
+  "private_key_file": "server.key",
+  "client_ca_file": "clients.pem"
+}
+```
+
+Relative paths are resolved beside the configuration file. On Unix, both the
+configuration and private key must be inaccessible to group and other users.
+Start a remote listener with:
+
+```sh
+ccvm --addr 100.64.0.10:8080 --tls-config /secure/ccvm-tls.json
+```
+
+`ccvm` requires TLS 1.3 and a verified client certificate. Any certificate
+chaining to `client_ca_file` has full daemon API authority, so use a dedicated
+client CA, issue short-lived certificates, and keep its signing key outside the
+daemon host. Tailscale can provide reachability but does not replace this
+application-layer authentication.
+
+The server certificate, private key, and client CA bundle are reloaded for each
+new TLS connection, and TLS session resumption is disabled so new connections
+always reauthenticate. Rotate files with atomic replacement. For CA rotation,
+publish an overlap bundle containing old and new client CAs, rotate clients,
+then remove the old CA. Existing TLS connections keep their authenticated
+state; new connections fail closed if the rotated files are missing or invalid.
+Changing the configured file paths requires a daemon restart. TLS termination
+at a reverse proxy is not accepted by this listener mode.
+
 ## Build
 
 ```sh

--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -2,6 +2,7 @@ package ccvmd
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 
 	"j5.nz/cc/client"
@@ -11,6 +12,7 @@ import (
 type ServerOptions struct {
 	Kind                   string
 	TokenPath              string
+	Authentication         *ServerAuthentication
 	Persistent             bool
 	OnStartup              func(client.ServerHello) error
 	RegisterHandlers       func(*http.ServeMux, RuntimeView)
@@ -19,6 +21,32 @@ type ServerOptions struct {
 	NormalizeStartRequest  func(*client.StartInstanceRequest, RuntimeView) error
 	NormalizeRunRequest    func(*client.RunRequest, RuntimeView) error
 }
+
+// ServerAuthentication is a validated transport authentication policy for a
+// ccvmd listener. Construct one with NewMutualTLSAuthentication.
+type ServerAuthentication struct {
+	internal *internal.ServerAuthentication
+}
+
+// NewMutualTLSAuthentication validates and wraps a TLS configuration that
+// requires a verified client certificate on every connection.
+func NewMutualTLSAuthentication(config *tls.Config) (*ServerAuthentication, error) {
+	authentication, err := internal.NewMutualTLSAuthentication(config)
+	if err != nil {
+		return nil, err
+	}
+	return &ServerAuthentication{internal: authentication}, nil
+}
+
+type ListenerSecurityError = internal.ListenerSecurityError
+type ListenerSecurityReason = internal.ListenerSecurityReason
+
+const (
+	ListenerSecurityInvalidAddress               = internal.ListenerSecurityInvalidAddress
+	ListenerSecurityRemoteAuthenticationRequired = internal.ListenerSecurityRemoteAuthenticationRequired
+	ListenerSecurityInvalidMutualTLS             = internal.ListenerSecurityInvalidMutualTLS
+	ListenerSecurityConflictingAuthentication    = internal.ListenerSecurityConflictingAuthentication
+)
 
 type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
@@ -32,8 +60,14 @@ func Main(args []string) {
 
 func RunServer(args []string, opts ServerOptions) (bool, error) {
 	return internal.RunServer(args, internal.ServerOptions{
-		Kind:       opts.Kind,
-		TokenPath:  opts.TokenPath,
+		Kind:      opts.Kind,
+		TokenPath: opts.TokenPath,
+		Authentication: func() *internal.ServerAuthentication {
+			if opts.Authentication == nil {
+				return nil
+			}
+			return opts.Authentication.internal
+		}(),
 		Persistent: opts.Persistent,
 		OnStartup:  opts.OnStartup,
 		NormalizeCreateRequest: func(req *client.CreateInstanceRequest, runtime internal.RuntimeView) error {

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -9,6 +9,7 @@ import (
 
 type ServerHello struct {
 	Addr      string `json:"addr,omitempty"`
+	Scheme    string `json:"scheme,omitempty"`
 	Kind      string `json:"kind,omitempty"`
 	TokenPath string `json:"token_path,omitempty"`
 	Error     string `json:"error,omitempty"`

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -80,6 +80,7 @@ type server struct {
 type ServerOptions struct {
 	Kind                   string
 	TokenPath              string
+	Authentication         *ServerAuthentication
 	Persistent             bool
 	OnStartup              func(client.ServerHello) error
 	RegisterHandlers       func(*http.ServeMux, RuntimeView)
@@ -363,10 +364,15 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 
 	addr := fs.String("addr", "localhost:0", "Address to listen on")
 	cacheDir := fs.String("cache-dir", "", "Cache directory")
+	tlsConfigPath := fs.String("tls-config", "", "Path to mutual TLS listener configuration")
 	worker := fs.Bool("worker", false, "Run as a single-process VM worker")
 
 	if err := fs.Parse(args); err != nil {
 		return false, fmt.Errorf("parse ccvm flags: %w", err)
+	}
+	authentication, err := resolveServerAuthentication(*addr, *tlsConfigPath, opts.Authentication)
+	if err != nil {
+		return false, err
 	}
 
 	rootCache, err := resolveCacheDir(*cacheDir)
@@ -397,9 +403,22 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("listen on %q: %w", *addr, err)
 	}
+	if listenerAddrRequiresAuthentication(l.Addr()) && authentication == nil {
+		_ = l.Close()
+		return false, &ListenerSecurityError{
+			Address: *addr,
+			Reason:  ListenerSecurityRemoteAuthenticationRequired,
+		}
+	}
+	scheme := "http"
+	if authentication != nil {
+		l = authentication.listener(l)
+		scheme = "https"
+	}
 
 	hello := client.ServerHello{
 		Addr:      l.Addr().String(),
+		Scheme:    scheme,
 		Kind:      opts.Kind,
 		TokenPath: opts.TokenPath,
 	}

--- a/internal/ccvmd/listener_security.go
+++ b/internal/ccvmd/listener_security.go
@@ -1,0 +1,296 @@
+package ccvmd
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ListenerSecurityReason string
+
+const (
+	ListenerSecurityInvalidAddress               ListenerSecurityReason = "invalid_address"
+	ListenerSecurityRemoteAuthenticationRequired ListenerSecurityReason = "remote_authentication_required"
+	ListenerSecurityInvalidMutualTLS             ListenerSecurityReason = "invalid_mutual_tls"
+	ListenerSecurityConflictingAuthentication    ListenerSecurityReason = "conflicting_authentication"
+)
+
+type ListenerSecurityError struct {
+	Address string
+	Reason  ListenerSecurityReason
+	Detail  string
+}
+
+func (e *ListenerSecurityError) Error() string {
+	if e == nil {
+		return "invalid listener security configuration"
+	}
+	switch e.Reason {
+	case ListenerSecurityInvalidAddress:
+		return fmt.Sprintf("invalid listener address %q: %s", e.Address, e.Detail)
+	case ListenerSecurityRemoteAuthenticationRequired:
+		return fmt.Sprintf("listener %q is remotely reachable and requires mutual TLS authentication", e.Address)
+	case ListenerSecurityInvalidMutualTLS:
+		return fmt.Sprintf("invalid mutual TLS configuration for listener %q: %s", e.Address, e.Detail)
+	case ListenerSecurityConflictingAuthentication:
+		return fmt.Sprintf("listener %q has both programmatic and file-based authentication", e.Address)
+	default:
+		return fmt.Sprintf("invalid listener security configuration for %q: %s", e.Address, e.Detail)
+	}
+}
+
+type ServerAuthentication struct {
+	tlsConfig *tls.Config
+}
+
+func NewMutualTLSAuthentication(config *tls.Config) (*ServerAuthentication, error) {
+	wrapped, err := validatedMutualTLSConfig(config)
+	if err != nil {
+		return nil, &ListenerSecurityError{
+			Reason: ListenerSecurityInvalidMutualTLS,
+			Detail: err.Error(),
+		}
+	}
+	return &ServerAuthentication{tlsConfig: wrapped}, nil
+}
+
+func (a *ServerAuthentication) listener(listener net.Listener) net.Listener {
+	return tls.NewListener(listener, a.tlsConfig.Clone())
+}
+
+func validatedMutualTLSConfig(config *tls.Config) (*tls.Config, error) {
+	if config == nil {
+		return nil, fmt.Errorf("TLS configuration is required")
+	}
+	source := config.Clone()
+	// A resumed TLS session can skip fresh client-certificate verification.
+	// Disable tickets so every new connection observes certificate and CA
+	// rotation through the validated configuration callback.
+	source.SessionTicketsDisabled = true
+	if err := validateMutualTLSPolicy(source, source.GetConfigForClient != nil); err != nil {
+		return nil, err
+	}
+	getConfigForClient := source.GetConfigForClient
+	if getConfigForClient == nil {
+		return source, nil
+	}
+
+	wrapped := source.Clone()
+	wrapped.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		selected, err := getConfigForClient(hello)
+		if err != nil {
+			return nil, err
+		}
+		if selected == nil {
+			return nil, fmt.Errorf("mutual TLS configuration callback returned nil")
+		}
+		selected = selected.Clone()
+		selected.SessionTicketsDisabled = true
+		if err := validateMutualTLSPolicy(selected, false); err != nil {
+			return nil, err
+		}
+		selected.GetConfigForClient = nil
+		return selected, nil
+	}
+	return wrapped, nil
+}
+
+func validateMutualTLSPolicy(config *tls.Config, callbackProvidesMaterial bool) error {
+	if config.MinVersion < tls.VersionTLS13 {
+		return fmt.Errorf("minimum TLS version must be TLS 1.3")
+	}
+	if config.ClientAuth != tls.RequireAndVerifyClientCert {
+		return fmt.Errorf("client authentication must require and verify a certificate")
+	}
+	if !callbackProvidesMaterial && len(config.Certificates) == 0 && config.GetCertificate == nil {
+		return fmt.Errorf("server certificate is required")
+	}
+	if !callbackProvidesMaterial && config.ClientCAs == nil {
+		return fmt.Errorf("client CA pool is required")
+	}
+	return nil
+}
+
+func resolveServerAuthentication(address, configPath string, configured *ServerAuthentication) (*ServerAuthentication, error) {
+	configPath = strings.TrimSpace(configPath)
+	if configured != nil && configPath != "" {
+		return nil, &ListenerSecurityError{
+			Address: address,
+			Reason:  ListenerSecurityConflictingAuthentication,
+		}
+	}
+	authentication := configured
+	if configPath != "" {
+		loaded, err := newFileMutualTLSAuthentication(configPath)
+		if err != nil {
+			var securityErr *ListenerSecurityError
+			if errors.As(err, &securityErr) {
+				securityErr.Address = address
+				return nil, securityErr
+			}
+			return nil, &ListenerSecurityError{
+				Address: address,
+				Reason:  ListenerSecurityInvalidMutualTLS,
+				Detail:  err.Error(),
+			}
+		}
+		authentication = loaded
+	}
+
+	required, err := listenerAddressRequiresAuthentication(address)
+	if err != nil {
+		return nil, err
+	}
+	if required && authentication == nil {
+		return nil, &ListenerSecurityError{
+			Address: address,
+			Reason:  ListenerSecurityRemoteAuthenticationRequired,
+		}
+	}
+	return authentication, nil
+}
+
+func listenerAddressRequiresAuthentication(address string) (bool, error) {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(address))
+	if err != nil {
+		return false, &ListenerSecurityError{
+			Address: address,
+			Reason:  ListenerSecurityInvalidAddress,
+			Detail:  err.Error(),
+		}
+	}
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if zone := strings.LastIndexByte(host, '%'); zone >= 0 {
+		host = host[:zone]
+	}
+	if host == "" {
+		return true, nil
+	}
+	if strings.EqualFold(host, "localhost") {
+		return false, nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// A hostname can resolve to different or mixed addresses over time. Only
+		// the reserved localhost name is classified as local without mTLS.
+		return true, nil
+	}
+	return !ip.IsLoopback(), nil
+}
+
+func listenerAddrRequiresAuthentication(address net.Addr) bool {
+	if address == nil {
+		return true
+	}
+	tcpAddress, ok := address.(*net.TCPAddr)
+	if !ok || tcpAddress.IP == nil {
+		return true
+	}
+	return !tcpAddress.IP.IsLoopback()
+}
+
+type mutualTLSFileConfig struct {
+	CertificateFile string `json:"certificate_file"`
+	PrivateKeyFile  string `json:"private_key_file"`
+	ClientCAFile    string `json:"client_ca_file"`
+}
+
+func newFileMutualTLSAuthentication(configPath string) (*ServerAuthentication, error) {
+	configPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve TLS configuration path: %w", err)
+	}
+	if err := validatePrivateConfigFile(configPath); err != nil {
+		return nil, err
+	}
+	files, err := readMutualTLSFileConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+	resolveRelativeTLSPaths(filepath.Dir(configPath), &files)
+	initial, err := loadMutualTLSFiles(files)
+	if err != nil {
+		return nil, err
+	}
+
+	config := initial.Clone()
+	config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		return loadMutualTLSFiles(files)
+	}
+	return NewMutualTLSAuthentication(config)
+}
+
+func readMutualTLSFileConfig(path string) (mutualTLSFileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return mutualTLSFileConfig{}, fmt.Errorf("read TLS configuration: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var config mutualTLSFileConfig
+	if err := decoder.Decode(&config); err != nil {
+		return mutualTLSFileConfig{}, fmt.Errorf("decode TLS configuration: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values")
+		}
+		return mutualTLSFileConfig{}, fmt.Errorf("decode TLS configuration: %w", err)
+	}
+	if strings.TrimSpace(config.CertificateFile) == "" {
+		return mutualTLSFileConfig{}, fmt.Errorf("certificate_file is required")
+	}
+	if strings.TrimSpace(config.PrivateKeyFile) == "" {
+		return mutualTLSFileConfig{}, fmt.Errorf("private_key_file is required")
+	}
+	if strings.TrimSpace(config.ClientCAFile) == "" {
+		return mutualTLSFileConfig{}, fmt.Errorf("client_ca_file is required")
+	}
+	return config, nil
+}
+
+func resolveRelativeTLSPaths(base string, config *mutualTLSFileConfig) {
+	config.CertificateFile = resolveRelativeTLSPath(base, config.CertificateFile)
+	config.PrivateKeyFile = resolveRelativeTLSPath(base, config.PrivateKeyFile)
+	config.ClientCAFile = resolveRelativeTLSPath(base, config.ClientCAFile)
+}
+
+func resolveRelativeTLSPath(base, path string) string {
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(base, path)
+}
+
+func loadMutualTLSFiles(config mutualTLSFileConfig) (*tls.Config, error) {
+	if err := validatePrivateKeyFile(config.PrivateKeyFile); err != nil {
+		return nil, err
+	}
+	certificate, err := tls.LoadX509KeyPair(config.CertificateFile, config.PrivateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load server certificate and private key: %w", err)
+	}
+	caPEM, err := os.ReadFile(config.ClientCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("read client CA bundle: %w", err)
+	}
+	clientCAs := x509.NewCertPool()
+	if !clientCAs.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("client CA bundle contains no certificates")
+	}
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{certificate},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+	}, nil
+}

--- a/internal/ccvmd/listener_security_test.go
+++ b/internal/ccvmd/listener_security_test.go
@@ -1,0 +1,268 @@
+package ccvmd
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestListenerAddressAuthenticationClassification(t *testing.T) {
+	tests := []struct {
+		address string
+		remote  bool
+	}{
+		{address: "localhost:0"},
+		{address: "127.0.0.1:8080"},
+		{address: "[::1]:8080"},
+		{address: "0.0.0.0:8080", remote: true},
+		{address: "[::]:8080", remote: true},
+		{address: "192.0.2.10:8080", remote: true},
+		{address: "node.tailnet.ts.net:8080", remote: true},
+	}
+	for _, test := range tests {
+		t.Run(test.address, func(t *testing.T) {
+			remote, err := listenerAddressRequiresAuthentication(test.address)
+			if err != nil {
+				t.Fatalf("classify listener: %v", err)
+			}
+			if remote != test.remote {
+				t.Fatalf("remote = %t, want %t", remote, test.remote)
+			}
+		})
+	}
+}
+
+func TestRemoteListenerRequiresTypedAuthentication(t *testing.T) {
+	_, err := resolveServerAuthentication("0.0.0.0:0", "", nil)
+	var securityErr *ListenerSecurityError
+	if !errors.As(err, &securityErr) {
+		t.Fatalf("error type = %T, want ListenerSecurityError", err)
+	}
+	if securityErr.Reason != ListenerSecurityRemoteAuthenticationRequired {
+		t.Fatalf("reason = %q, want %q", securityErr.Reason, ListenerSecurityRemoteAuthenticationRequired)
+	}
+
+	if _, err := resolveServerAuthentication("localhost:0", "", nil); err != nil {
+		t.Fatalf("local listener rejected: %v", err)
+	}
+}
+
+func TestMutualTLSAuthenticationRejectsWeakPolicy(t *testing.T) {
+	_, err := NewMutualTLSAuthentication(&tls.Config{MinVersion: tls.VersionTLS13})
+	var securityErr *ListenerSecurityError
+	if !errors.As(err, &securityErr) {
+		t.Fatalf("error type = %T, want ListenerSecurityError", err)
+	}
+	if securityErr.Reason != ListenerSecurityInvalidMutualTLS {
+		t.Fatalf("reason = %q, want %q", securityErr.Reason, ListenerSecurityInvalidMutualTLS)
+	}
+}
+
+func TestFileMutualTLSProtectsAllRoutesAndReloadsClientCA(t *testing.T) {
+	dir := t.TempDir()
+	serverCA := newTestCertificateAuthority(t, "server-ca")
+	clientCA1 := newTestCertificateAuthority(t, "client-ca-1")
+	clientCA2 := newTestCertificateAuthority(t, "client-ca-2")
+	serverCert, serverKey := serverCA.issue(t, "ccvmd", true)
+	clientCert1, clientKey1 := clientCA1.issue(t, "client-1", false)
+	clientCert2, clientKey2 := clientCA2.issue(t, "client-2", false)
+
+	writeTestFile(t, filepath.Join(dir, "server.crt"), serverCert, 0o644)
+	writeTestFile(t, filepath.Join(dir, "server.key"), serverKey, 0o600)
+	writeTestFile(t, filepath.Join(dir, "clients.pem"), clientCA1.certPEM, 0o644)
+	configData, err := json.Marshal(mutualTLSFileConfig{
+		CertificateFile: "server.crt",
+		PrivateKeyFile:  "server.key",
+		ClientCAFile:    "clients.pem",
+	})
+	if err != nil {
+		t.Fatalf("marshal TLS config: %v", err)
+	}
+	configPath := filepath.Join(dir, "tls.json")
+	writeTestFile(t, configPath, configData, 0o600)
+
+	authentication, err := newFileMutualTLSAuthentication(configPath)
+	if err != nil {
+		t.Fatalf("load mutual TLS authentication: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ErrorLog: log.New(io.Discard, "", 0),
+	}
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- server.Serve(authentication.listener(listener))
+	}()
+	t.Cleanup(func() {
+		_ = server.Shutdown(context.Background())
+		<-serveDone
+	})
+
+	serverRoots := x509.NewCertPool()
+	if !serverRoots.AppendCertsFromPEM(serverCA.certPEM) {
+		t.Fatal("append server CA")
+	}
+	client1 := newMutualTLSTestClient(t, serverRoots, clientCert1, clientKey1)
+	client2 := newMutualTLSTestClient(t, serverRoots, clientCert2, clientKey2)
+	unauthenticated := newMutualTLSTestClient(t, serverRoots, nil, nil)
+	baseURL := "https://" + listener.Addr().String()
+
+	for _, path := range []string{"/healthz", "/debug/virtiofs", "/vm/run", "/stream"} {
+		if status, err := requestTestRoute(client1, baseURL+path); err != nil || status != http.StatusNoContent {
+			t.Fatalf("authenticated route %s: status=%d err=%v", path, status, err)
+		}
+		if _, err := requestTestRoute(unauthenticated, baseURL+path); err == nil {
+			t.Fatalf("unauthenticated route %s completed TLS", path)
+		}
+	}
+
+	atomicReplaceTestFile(t, filepath.Join(dir, "clients.pem"), clientCA2.certPEM, 0o644)
+	if status, err := requestTestRoute(client2, baseURL+"/healthz"); err != nil || status != http.StatusNoContent {
+		t.Fatalf("rotated client CA was not used: status=%d err=%v", status, err)
+	}
+	if _, err := requestTestRoute(client1, baseURL+"/healthz"); err == nil {
+		t.Fatal("client signed by removed CA completed a new TLS connection")
+	}
+}
+
+type testCertificateAuthority struct {
+	certificate *x509.Certificate
+	privateKey  ed25519.PrivateKey
+	certPEM     []byte
+}
+
+func newTestCertificateAuthority(t *testing.T, name string) testCertificateAuthority {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          randomTestSerial(t),
+		Subject:               pkix.Name{CommonName: name},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+	return testCertificateAuthority{
+		certificate: certificate,
+		privateKey:  privateKey,
+		certPEM:     pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+func (ca testCertificateAuthority) issue(t *testing.T, name string, server bool) ([]byte, []byte) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: randomTestSerial(t),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	if server {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		template.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.certificate, publicKey, ca.privateKey)
+	if err != nil {
+		t.Fatalf("create leaf certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+func randomTestSerial(t *testing.T) *big.Int {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 120))
+	if err != nil {
+		t.Fatalf("generate certificate serial: %v", err)
+	}
+	return serial
+}
+
+func newMutualTLSTestClient(t *testing.T, roots *x509.CertPool, certPEM, keyPEM []byte) *http.Client {
+	t.Helper()
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		RootCAs:    roots,
+	}
+	if len(certPEM) != 0 {
+		certificate, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			t.Fatalf("load client key pair: %v", err)
+		}
+		config.Certificates = []tls.Certificate{certificate}
+	}
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig:   config,
+		DisableKeepAlives: true,
+	}}
+}
+
+func requestTestRoute(client *http.Client, target string) (int, error) {
+	response, err := client.Get(target)
+	if err != nil {
+		return 0, err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+	return response.StatusCode, nil
+}
+
+func writeTestFile(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func atomicReplaceTestFile(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	temporary := path + ".new"
+	writeTestFile(t, temporary, data, mode)
+	if err := os.Rename(temporary, path); err != nil {
+		t.Fatalf("replace %s: %v", path, err)
+	}
+}

--- a/internal/ccvmd/listener_security_unix.go
+++ b/internal/ccvmd/listener_security_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package ccvmd
+
+import (
+	"fmt"
+	"os"
+)
+
+func validatePrivateConfigFile(path string) error {
+	return validatePrivateTLSFile(path, "TLS configuration")
+}
+
+func validatePrivateKeyFile(path string) error {
+	return validatePrivateTLSFile(path, "TLS private key")
+}
+
+func validatePrivateTLSFile(path, kind string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", kind, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", kind)
+	}
+	if permissions := info.Mode().Perm(); permissions&0o077 != 0 {
+		return fmt.Errorf("%s mode is %04o, want owner-only permissions", kind, permissions)
+	}
+	return nil
+}

--- a/internal/ccvmd/listener_security_windows.go
+++ b/internal/ccvmd/listener_security_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package ccvmd
+
+import (
+	"fmt"
+	"os"
+)
+
+func validatePrivateConfigFile(path string) error {
+	return validatePrivateTLSFile(path, "TLS configuration")
+}
+
+func validatePrivateKeyFile(path string) error {
+	return validatePrivateTLSFile(path, "TLS private key")
+}
+
+func validatePrivateTLSFile(path, kind string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", kind, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", kind)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #56.

## What changed

- Classify wildcard, non-loopback, and non-`localhost` hostname binds as remote before startup.
- Require a typed, validated TLS 1.3 mutual-authentication policy for every remote listener.
- Wrap the listener itself so health, control, debug, streaming, custom, and WebSocket routes share the same authentication boundary.
- Add an owner-only `--tls-config` file for server certificate, private key, and client CA paths.
- Reload certificate/key/CA material on every new connection and disable TLS resumption so rotations reauthenticate.
- Expose structured listener-security reasons and the startup URL scheme.
- Document short-lived client certificates, atomic key/CA rotation, Tailscale's role, and unsupported proxy termination.

## Why

`--addr` could previously publish the full daemon API to an arbitrary network without an authentication contract. `WrapHandler` and `TokenPath` were not proof that all routes were protected.

## Impact

Local `localhost` and loopback startup remains unchanged. Remote and wildcard startup now fails closed unless mTLS is configured. Any client certificate chaining to the configured dedicated CA has full ccvmd API authority; finer capability authorization remains the responsibility of the higher vmsh group layer.

## Root cause

Authentication was optional middleware outside the listener model, so ccvmd could not distinguish a private local channel from an exposed unauthenticated control plane.

## Validation

- `go test ./...`
- `go test -race ./internal/ccvmd`
- repeated real TLS route-denial and client-CA rotation tests
- `go vet ./internal/ccvmd ./ccvmd ./client`
- Windows amd64 and arm64 compile checks for `internal/ccvmd`
