### PR TITLE
Secure worker control TCP with mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,66 @@ print(nm.run("niimath", "-help"))
 
 See [pyneurodesk/README.md](pyneurodesk/README.md) for Python-specific usage.
 
+## Worker control transport
+
+Sidecar worker control uses an owner-only Unix socket where the platform
+supports it. TCP worker control never permits the old `tcp://` plaintext scheme,
+including on loopback. Use `tls://` with mutually authenticated TLS 1.3 when a
+TCP transport is required. Windows local sidecars create a one-worker ephemeral
+CA and scoped certificates automatically.
+
+A remotely started worker receives a worker-role configuration file:
+
+```json
+{
+  "role": "worker",
+  "certificate_file": "worker.crt",
+  "private_key_file": "worker.key",
+  "peer_ca_file": "coordinator-ca.pem",
+  "scope": "deployment-issued-worker-scope",
+  "handshake_timeout": "20s"
+}
+```
+
+The coordinator uses a separate file and private key:
+
+```json
+{
+  "role": "coordinator",
+  "certificate_file": "coordinator.crt",
+  "private_key_file": "coordinator.key",
+  "peer_ca_file": "worker-ca.pem",
+  "server_name": "worker.tailnet.ts.net",
+  "scope": "deployment-issued-worker-scope",
+  "handshake_timeout": "20s"
+}
+```
+
+Relative paths are resolved beside each owner-only configuration file. Private
+keys must also be owner-only on Unix. Choose `handshake_timeout` from the
+deployment's measured Tailscale latency and authentication path; cc does not
+substitute a universal remote timeout.
+
+Both leaf certificates must carry the matching URI identity
+`urn:cc:worker:<scope>:worker` or
+`urn:cc:worker:<scope>:coordinator`. The role, CA chain, server name, certificate
+lifetime, and scope are all verified before the worker sends its hello frame.
+Tailscale supplies reachability but does not replace these checks.
+
+Start the worker with its existing address setting and the security file:
+
+```sh
+CCX3_WORKER_CONTROL_SOCKET=tls://100.64.0.20:9443 \
+  ccvm -worker -worker-tls-config /secure/worker.json
+```
+
+The server reloads its certificate, key, peer CA, and policy file for each new
+connection. Rotate them with atomic replacement while retaining the same scope;
+changing scope requires a new worker. TLS session resumption is disabled so a
+new connection always reauthenticates. Existing worker connections keep their
+authenticated scope until they close. There is no insecure migration flag or
+plaintext deprecation window before v1.
+
 ## Repository Layout
 
 - `cmd/cc`: user-facing CLI

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -364,6 +364,7 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 	addr := fs.String("addr", "localhost:0", "Address to listen on")
 	cacheDir := fs.String("cache-dir", "", "Cache directory")
 	worker := fs.Bool("worker", false, "Run as a single-process VM worker")
+	workerTLSConfigPath := fs.String("worker-tls-config", "", "Path to worker-control mutual TLS configuration")
 
 	if err := fs.Parse(args); err != nil {
 		return false, fmt.Errorf("parse ccvm flags: %w", err)
@@ -389,7 +390,7 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 
 	if *worker {
 		if socketPath := strings.TrimSpace(os.Getenv("CCX3_WORKER_CONTROL_SOCKET")); socketPath != "" {
-			return runWorkerControlSocket(socketPath, srvState, opts)
+			return runWorkerControlSocket(socketPath, *workerTLSConfigPath, srvState, opts)
 		}
 	}
 
@@ -446,10 +447,17 @@ func writeStartupError(w interface{ Write([]byte) (int, error) }, err error) err
 	})
 }
 
-func runWorkerControlSocket(socketPath string, srvState *server, opts ServerOptions) (bool, error) {
-	listenNetwork, listenAddress, cleanup, err := workerControlListenEndpoint(socketPath)
+func runWorkerControlSocket(socketPath, tlsConfigPath string, srvState *server, opts ServerOptions) (bool, error) {
+	listenNetwork, listenAddress, secure, cleanup, err := workerControlListenEndpoint(socketPath, tlsConfigPath)
 	if err != nil {
 		return false, err
+	}
+	var security *vm.WorkerTransportSecurity
+	if secure {
+		security, err = vm.LoadWorkerServerSecurity(tlsConfigPath)
+		if err != nil {
+			return false, err
+		}
 	}
 	defer cleanup()
 	l, err := net.Listen(listenNetwork, listenAddress)
@@ -457,18 +465,38 @@ func runWorkerControlSocket(socketPath string, srvState *server, opts ServerOpti
 		return false, fmt.Errorf("listen worker control socket: %w", err)
 	}
 	defer l.Close()
-	if err := json.NewEncoder(os.Stdout).Encode(client.ServerHello{Kind: "worker", Addr: workerControlDialEndpoint(listenNetwork, l.Addr().String())}); err != nil {
+	endpoint := workerControlDialEndpoint(listenNetwork, l.Addr().String(), secure)
+	if err := json.NewEncoder(os.Stdout).Encode(client.ServerHello{Kind: "worker", Addr: endpoint}); err != nil {
 		return false, fmt.Errorf("write worker startup banner: %w", err)
 	}
-	conn, err := l.Accept()
-	if err != nil {
-		return true, fmt.Errorf("accept worker control connection: %w", err)
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return true, fmt.Errorf("accept worker control connection: %w", err)
+		}
+		if secure {
+			authenticated, handshakeErr := vm.HandshakeWorkerServer(context.Background(), conn, endpoint, security)
+			if handshakeErr != nil {
+				_ = conn.Close()
+				continue
+			}
+			conn = authenticated
+		}
+		workerID := "local-sidecar"
+		if security != nil {
+			workerID = security.Scope
+		}
+		err = serveAuthenticatedWorkerControl(conn, workerID, srvState, opts)
+		_ = conn.Close()
+		return true, err
 	}
-	defer conn.Close()
+}
+
+func serveAuthenticatedWorkerControl(conn net.Conn, workerID string, srvState *server, opts ServerOptions) error {
 	codec := vm.NewWorkerCodec(conn)
 	hello, err := vm.NewWorkerFrame(0, vm.WorkerServiceControl, vm.WorkerFrameHello, vm.WorkerHello{
 		Version:  vm.WorkerProtocolVersion,
-		WorkerID: "local-sidecar",
+		WorkerID: workerID,
 		Backend:  "worker",
 		Capabilities: vm.VMHostCapabilities{
 			Backend:       "worker",
@@ -479,28 +507,54 @@ func runWorkerControlSocket(socketPath string, srvState *server, opts ServerOpti
 		},
 	})
 	if err != nil {
-		return true, err
+		return err
 	}
 	if err := codec.Send(hello); err != nil {
-		return true, fmt.Errorf("send worker hello: %w", err)
+		return fmt.Errorf("send worker hello: %w", err)
 	}
-	return true, serveWorkerControl(codec, srvState, opts)
+	return serveWorkerControl(codec, srvState, opts)
 }
 
-func workerControlListenEndpoint(address string) (network string, listenAddress string, cleanup func(), err error) {
+func workerControlListenEndpoint(address, tlsConfigPath string) (network string, listenAddress string, secure bool, cleanup func(), err error) {
 	cleanup = func() {}
 	if strings.HasPrefix(address, "tcp://") {
-		return "tcp", strings.TrimPrefix(address, "tcp://"), cleanup, nil
+		return "", "", false, cleanup, &vm.WorkerSecurityError{
+			Endpoint: address,
+			Reason:   vm.WorkerSecurityPlaintextTCPRejected,
+		}
+	}
+	if strings.HasPrefix(address, vm.WorkerTLSScheme) {
+		if strings.TrimSpace(tlsConfigPath) == "" {
+			return "", "", false, cleanup, &vm.WorkerSecurityError{
+				Endpoint: address,
+				Reason:   vm.WorkerSecurityTLSConfigRequired,
+			}
+		}
+		listenAddress = strings.TrimPrefix(address, vm.WorkerTLSScheme)
+		if _, _, err := net.SplitHostPort(listenAddress); err != nil {
+			return "", "", false, cleanup, fmt.Errorf("parse worker TLS endpoint: %w", err)
+		}
+		return "tcp", listenAddress, true, cleanup, nil
+	}
+	if strings.TrimSpace(tlsConfigPath) != "" {
+		return "", "", false, cleanup, &vm.WorkerSecurityError{
+			Endpoint: address,
+			Reason:   vm.WorkerSecurityInvalidTLSConfig,
+			Detail:   "TLS configuration cannot be used with a Unix socket",
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(address), 0o700); err != nil {
-		return "", "", cleanup, fmt.Errorf("prepare worker control socket dir: %w", err)
+		return "", "", false, cleanup, fmt.Errorf("prepare worker control socket dir: %w", err)
 	}
 	_ = os.Remove(address)
-	return "unix", address, func() { _ = os.Remove(address) }, nil
+	return "unix", address, false, func() { _ = os.Remove(address) }, nil
 }
 
-func workerControlDialEndpoint(network string, address string) string {
+func workerControlDialEndpoint(network string, address string, secure bool) string {
 	if network == "tcp" {
+		if secure {
+			return vm.WorkerTLSScheme + address
+		}
 		return "tcp://" + address
 	}
 	return address

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -3,6 +3,7 @@ package ccvmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,34 @@ import (
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/vm"
 )
+
+func TestWorkerControlTransportRequiresTLSForTCP(t *testing.T) {
+	_, _, _, _, err := workerControlListenEndpoint("tcp://127.0.0.1:0", "")
+	var securityErr *vm.WorkerSecurityError
+	if !errors.As(err, &securityErr) {
+		t.Fatalf("plaintext TCP error type = %T", err)
+	}
+	if securityErr.Reason != vm.WorkerSecurityPlaintextTCPRejected {
+		t.Fatalf("plaintext TCP reason = %q", securityErr.Reason)
+	}
+
+	_, _, _, _, err = workerControlListenEndpoint("tls://127.0.0.1:0", "")
+	if !errors.As(err, &securityErr) {
+		t.Fatalf("missing TLS config error type = %T", err)
+	}
+	if securityErr.Reason != vm.WorkerSecurityTLSConfigRequired {
+		t.Fatalf("missing TLS config reason = %q", securityErr.Reason)
+	}
+
+	network, address, secure, cleanup, err := workerControlListenEndpoint(t.TempDir()+"/control.sock", "")
+	if err != nil {
+		t.Fatalf("Unix endpoint: %v", err)
+	}
+	defer cleanup()
+	if network != "unix" || address == "" || secure {
+		t.Fatalf("Unix endpoint = network:%q address:%q secure:%t", network, address, secure)
+	}
+}
 
 func TestMuxHealthStatusWatchdogAndShutdown(t *testing.T) {
 	shutdownCalled := make(chan struct{}, 1)

--- a/internal/vm/sidecar/client.go
+++ b/internal/vm/sidecar/client.go
@@ -30,22 +30,39 @@ type workerFrameResult struct {
 }
 
 func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
-	var conn net.Conn
-	var err error
-	network, address := workerDialTarget(socketPath)
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		conn, err = net.Dial(network, address)
-		if err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("dial sidecar worker control socket: %w", err)
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(10 * time.Millisecond):
+	return dialWorker(ctx, socketPath, nil)
+}
+
+func DialWorkerTLS(ctx context.Context, endpoint, configPath string) (*Client, error) {
+	security, err := LoadWorkerClientSecurity(configPath)
+	if err != nil {
+		return nil, err
+	}
+	return dialWorker(ctx, endpoint, security)
+}
+
+func dialWorker(ctx context.Context, socketPath string, security *WorkerTransportSecurity) (*Client, error) {
+	target, err := workerDialTarget(socketPath)
+	if err != nil {
+		return nil, err
+	}
+	if target.secure && security == nil {
+		return nil, &WorkerSecurityError{Endpoint: socketPath, Reason: WorkerSecurityTLSConfigRequired}
+	}
+	if !target.secure && security != nil {
+		return nil, &WorkerSecurityError{Endpoint: socketPath, Reason: WorkerSecurityInvalidTLSConfig, Detail: "TLS configuration was provided for a Unix socket"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	conn, err := (&net.Dialer{}).DialContext(ctx, target.network, target.address)
+	if err != nil {
+		return nil, fmt.Errorf("dial sidecar worker control socket: %w", err)
+	}
+	if target.secure {
+		conn, err = handshakeWorkerClient(ctx, conn, socketPath, security)
+		if err != nil {
+			return nil, err
 		}
 	}
 	worker := &Client{conn: conn, codec: NewWorkerCodec(conn), pending: map[uint64]chan workerFrameResult{}}
@@ -58,15 +75,48 @@ func DialWorker(ctx context.Context, socketPath string) (*Client, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("sidecar worker sent %q before hello", frame.Type)
 	}
+	var hello WorkerHello
+	if err := frame.DecodePayload(&hello); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("decode sidecar worker hello: %w", err)
+	}
+	if hello.Version != WorkerProtocolVersion {
+		_ = conn.Close()
+		return nil, fmt.Errorf("sidecar worker protocol version %d is not supported", hello.Version)
+	}
+	if target.secure && hello.WorkerID != security.Scope {
+		_ = conn.Close()
+		return nil, &WorkerSecurityError{
+			Endpoint: socketPath,
+			Reason:   WorkerSecurityPeerScopeMismatch,
+			Detail:   "worker hello identity does not match the authenticated certificate scope",
+		}
+	}
 	go worker.receiveLoop()
 	return worker, nil
 }
 
-func workerDialTarget(address string) (string, string) {
+type workerDialEndpoint struct {
+	network string
+	address string
+	secure  bool
+}
+
+func workerDialTarget(address string) (workerDialEndpoint, error) {
 	if strings.HasPrefix(address, "tcp://") {
-		return "tcp", strings.TrimPrefix(address, "tcp://")
+		return workerDialEndpoint{}, &WorkerSecurityError{
+			Endpoint: address,
+			Reason:   WorkerSecurityPlaintextTCPRejected,
+		}
 	}
-	return "unix", address
+	if strings.HasPrefix(address, WorkerTLSScheme) {
+		target := strings.TrimPrefix(address, WorkerTLSScheme)
+		if _, _, err := net.SplitHostPort(target); err != nil {
+			return workerDialEndpoint{}, fmt.Errorf("parse worker TLS endpoint: %w", err)
+		}
+		return workerDialEndpoint{network: "tcp", address: target, secure: true}, nil
+	}
+	return workerDialEndpoint{network: "unix", address: address}, nil
 }
 
 func (c *Client) Close() error {

--- a/internal/vm/sidecar/client_test.go
+++ b/internal/vm/sidecar/client_test.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -11,19 +12,35 @@ import (
 )
 
 func TestWorkerDialTarget(t *testing.T) {
-	network, address := workerDialTarget("tcp://127.0.0.1:1234")
-	if network != "tcp" || address != "127.0.0.1:1234" {
-		t.Fatalf("tcp target = %q %q", network, address)
+	_, err := workerDialTarget("tcp://127.0.0.1:1234")
+	var securityErr *WorkerSecurityError
+	if !errors.As(err, &securityErr) {
+		t.Fatalf("plaintext TCP error type = %T", err)
 	}
-	network, address = workerDialTarget("/tmp/worker.sock")
-	if network != "unix" || address != "/tmp/worker.sock" {
-		t.Fatalf("unix target = %q %q", network, address)
+	if securityErr.Reason != WorkerSecurityPlaintextTCPRejected {
+		t.Fatalf("plaintext TCP reason = %q", securityErr.Reason)
+	}
+	target, err := workerDialTarget("tls://127.0.0.1:1234")
+	if err != nil {
+		t.Fatalf("TLS target: %v", err)
+	}
+	if target.network != "tcp" || target.address != "127.0.0.1:1234" || !target.secure {
+		t.Fatalf("TLS target = %+v", target)
+	}
+	target, err = workerDialTarget("/tmp/worker.sock")
+	if err != nil {
+		t.Fatalf("Unix target: %v", err)
+	}
+	if target.network != "unix" || target.address != "/tmp/worker.sock" || target.secure {
+		t.Fatalf("Unix target = %+v", target)
 	}
 }
 
 func TestDialWorkerReadsHello(t *testing.T) {
-	addr, done := serveWorkerFrame(t, WorkerFrame{Type: WorkerFrameHello})
-	worker, err := DialWorker(context.Background(), "tcp://"+addr)
+	endpoint, clientConfig, done := serveWorkerFrame(t, func(scope string) WorkerFrame {
+		return mustWorkerFrame(0, WorkerFrameHello, WorkerHello{Version: WorkerProtocolVersion, WorkerID: scope})
+	})
+	worker, err := DialWorkerTLS(context.Background(), endpoint, clientConfig)
 	if err != nil {
 		t.Fatalf("DialWorker: %v", err)
 	}
@@ -37,8 +54,10 @@ func TestDialWorkerReadsHello(t *testing.T) {
 }
 
 func TestDialWorkerRejectsNonHello(t *testing.T) {
-	addr, done := serveWorkerFrame(t, WorkerFrame{Type: WorkerFrameError})
-	worker, err := DialWorker(context.Background(), "tcp://"+addr)
+	endpoint, clientConfig, done := serveWorkerFrame(t, func(string) WorkerFrame {
+		return WorkerFrame{Type: WorkerFrameError}
+	})
+	worker, err := DialWorkerTLS(context.Background(), endpoint, clientConfig)
 	if worker != nil {
 		_ = worker.Close()
 	}
@@ -51,59 +70,38 @@ func TestDialWorkerRejectsNonHello(t *testing.T) {
 }
 
 func TestWorkerClientMultiplexesControlWhileExecStreams(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer ln.Close()
-
-	serverErr := make(chan error, 1)
 	releaseExec := make(chan struct{})
 	execReceived := make(chan struct{})
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			serverErr <- err
-			return
-		}
-		codec := NewWorkerCodec(conn)
-		defer codec.Close()
-		if err := codec.Send(WorkerFrame{Type: WorkerFrameHello}); err != nil {
-			serverErr <- err
-			return
+	endpoint, clientConfig, serverErr := serveWorkerTLS(t, func(codec *WorkerCodec, scope string) error {
+		if err := codec.Send(mustWorkerFrame(0, WorkerFrameHello, WorkerHello{Version: WorkerProtocolVersion, WorkerID: scope})); err != nil {
+			return err
 		}
 		execFrame, err := codec.Receive()
 		if err != nil {
-			serverErr <- err
-			return
+			return err
 		}
 		if execFrame.Type != WorkerFrameExec {
-			serverErr <- fmt.Errorf("first frame type = %q", execFrame.Type)
-			return
+			return fmt.Errorf("first frame type = %q", execFrame.Type)
 		}
 		close(execReceived)
 		addShareFrame, err := codec.Receive()
 		if err != nil {
-			serverErr <- err
-			return
+			return err
 		}
 		if addShareFrame.Type != WorkerFrameAddShare {
-			serverErr <- fmt.Errorf("second frame type = %q", addShareFrame.Type)
-			return
+			return fmt.Errorf("second frame type = %q", addShareFrame.Type)
 		}
 		if err := codec.Send(mustWorkerFrame(addShareFrame.ID, WorkerFrameDone, map[string]string{"status": "mounted"})); err != nil {
-			serverErr <- err
-			return
+			return err
 		}
 		<-releaseExec
 		if err := codec.Send(mustWorkerFrame(execFrame.ID, WorkerFrameDone, map[string]string{"status": "done"})); err != nil {
-			serverErr <- err
-			return
+			return err
 		}
-		serverErr <- nil
-	}()
+		return nil
+	})
 
-	worker, err := DialWorker(context.Background(), "tcp://"+ln.Addr().String())
+	worker, err := DialWorkerTLS(context.Background(), endpoint, clientConfig)
 	if err != nil {
 		t.Fatalf("DialWorker: %v", err)
 	}
@@ -158,8 +156,24 @@ func mustWorkerFrame(id uint64, frameType string, payload any) WorkerFrame {
 	return frame
 }
 
-func serveWorkerFrame(t *testing.T, frame WorkerFrame) (string, <-chan error) {
+func serveWorkerFrame(t *testing.T, frame func(scope string) WorkerFrame) (string, string, <-chan error) {
 	t.Helper()
+	return serveWorkerTLS(t, func(codec *WorkerCodec, scope string) error {
+		return codec.Send(frame(scope))
+	})
+}
+
+func serveWorkerTLS(t *testing.T, serve func(*WorkerCodec, string) error) (string, string, <-chan error) {
+	t.Helper()
+	credentials, err := NewEphemeralWorkerSecurity(t.TempDir())
+	if err != nil {
+		t.Fatalf("create worker credentials: %v", err)
+	}
+	t.Cleanup(credentials.Close)
+	security, err := LoadWorkerServerSecurity(credentials.ServerConfigPath)
+	if err != nil {
+		t.Fatalf("load worker server security: %v", err)
+	}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -172,13 +186,20 @@ func serveWorkerFrame(t *testing.T, frame WorkerFrame) (string, <-chan error) {
 			done <- err
 			return
 		}
-		codec := NewWorkerCodec(conn)
-		if err := codec.Send(frame); err != nil {
-			_ = codec.Close()
+		endpoint := WorkerTLSScheme + ln.Addr().String()
+		authenticated, err := HandshakeWorkerServer(context.Background(), conn, endpoint, security)
+		if err != nil {
+			_ = conn.Close()
 			done <- err
 			return
 		}
-		done <- codec.Close()
+		codec := NewWorkerCodec(authenticated)
+		err = serve(codec, security.Scope)
+		closeErr := codec.Close()
+		if err == nil {
+			err = closeErr
+		}
+		done <- err
 	}()
-	return ln.Addr().String(), done
+	return WorkerTLSScheme + ln.Addr().String(), credentials.ClientConfigPath, done
 }

--- a/internal/vm/sidecar/launch.go
+++ b/internal/vm/sidecar/launch.go
@@ -7,14 +7,18 @@ import (
 )
 
 type LaunchOptions struct {
-	DisableEnv string
-	ControlEnv string
-	ModeEnv    string
+	DisableEnv    string
+	ControlEnv    string
+	ModeEnv       string
+	TLSConfigPath string
 }
 
 func LaunchCommand(exe, cacheDir, controlSocket string, env []string, opts LaunchOptions) *exec.Cmd {
 	args := launchArgs(opts.ModeEnv)
 	args = append(args, "-worker", "-cache-dir", cacheDir)
+	if tlsConfigPath := strings.TrimSpace(opts.TLSConfigPath); tlsConfigPath != "" {
+		args = append(args, "-worker-tls-config", tlsConfigPath)
+	}
 	cmd := exec.Command(exe, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), opts.DisableEnv+"=1", opts.ControlEnv+"="+controlSocket)

--- a/internal/vm/sidecar/security.go
+++ b/internal/vm/sidecar/security.go
@@ -1,0 +1,511 @@
+package sidecar
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const WorkerTLSScheme = "tls://"
+
+type WorkerSecurityReason string
+
+const (
+	WorkerSecurityPlaintextTCPRejected WorkerSecurityReason = "plaintext_tcp_rejected"
+	WorkerSecurityTLSConfigRequired    WorkerSecurityReason = "tls_config_required"
+	WorkerSecurityInvalidTLSConfig     WorkerSecurityReason = "invalid_tls_config"
+	WorkerSecurityPeerScopeMismatch    WorkerSecurityReason = "peer_scope_mismatch"
+	WorkerSecurityHandshakeFailed      WorkerSecurityReason = "handshake_failed"
+)
+
+type WorkerSecurityError struct {
+	Endpoint string
+	Reason   WorkerSecurityReason
+	Detail   string
+}
+
+func (e *WorkerSecurityError) Error() string {
+	if e == nil {
+		return "invalid worker transport security"
+	}
+	switch e.Reason {
+	case WorkerSecurityPlaintextTCPRejected:
+		return fmt.Sprintf("worker endpoint %q uses unsupported plaintext TCP", e.Endpoint)
+	case WorkerSecurityTLSConfigRequired:
+		return fmt.Sprintf("worker endpoint %q requires mutual TLS configuration", e.Endpoint)
+	case WorkerSecurityInvalidTLSConfig:
+		return fmt.Sprintf("invalid worker mutual TLS configuration for %q: %s", e.Endpoint, e.Detail)
+	case WorkerSecurityPeerScopeMismatch:
+		return fmt.Sprintf("worker peer scope mismatch for %q: %s", e.Endpoint, e.Detail)
+	case WorkerSecurityHandshakeFailed:
+		return fmt.Sprintf("worker mutual TLS handshake failed for %q: %s", e.Endpoint, e.Detail)
+	default:
+		return fmt.Sprintf("worker transport security failed for %q: %s", e.Endpoint, e.Detail)
+	}
+}
+
+type workerTLSRole string
+
+const (
+	workerTLSRoleWorker      workerTLSRole = "worker"
+	workerTLSRoleCoordinator workerTLSRole = "coordinator"
+)
+
+type workerTLSFileConfig struct {
+	Role             workerTLSRole `json:"role"`
+	CertificateFile  string        `json:"certificate_file"`
+	PrivateKeyFile   string        `json:"private_key_file"`
+	PeerCAFile       string        `json:"peer_ca_file"`
+	ServerName       string        `json:"server_name,omitempty"`
+	Scope            string        `json:"scope"`
+	HandshakeTimeout string        `json:"handshake_timeout"`
+}
+
+type WorkerTransportSecurity struct {
+	TLSConfig        *tls.Config
+	Scope            string
+	HandshakeTimeout time.Duration
+	reload           func() (*WorkerTransportSecurity, error)
+}
+
+func LoadWorkerServerSecurity(path string) (*WorkerTransportSecurity, error) {
+	initial, absolutePath, err := loadWorkerTLSFile(path, workerTLSRoleWorker)
+	if err != nil {
+		return nil, workerTLSConfigError(path, err)
+	}
+	initial.reload = func() (*WorkerTransportSecurity, error) {
+		current, _, err := loadWorkerTLSFile(absolutePath, workerTLSRoleWorker)
+		if err != nil {
+			return nil, workerTLSConfigError(absolutePath, err)
+		}
+		if current.Scope != initial.Scope {
+			return nil, &WorkerSecurityError{
+				Endpoint: absolutePath,
+				Reason:   WorkerSecurityInvalidTLSConfig,
+				Detail:   fmt.Sprintf("worker scope changed from %q to %q; restart is required", initial.Scope, current.Scope),
+			}
+		}
+		return current, nil
+	}
+	return initial, nil
+}
+
+func LoadWorkerClientSecurity(path string) (*WorkerTransportSecurity, error) {
+	security, _, err := loadWorkerTLSFile(path, workerTLSRoleCoordinator)
+	if err != nil {
+		return nil, workerTLSConfigError(path, err)
+	}
+	return security, nil
+}
+
+func workerTLSConfigError(endpoint string, err error) error {
+	var securityErr *WorkerSecurityError
+	if errors.As(err, &securityErr) {
+		securityErr.Endpoint = endpoint
+		return securityErr
+	}
+	return &WorkerSecurityError{
+		Endpoint: endpoint,
+		Reason:   WorkerSecurityInvalidTLSConfig,
+		Detail:   err.Error(),
+	}
+}
+
+func loadWorkerTLSFile(path string, role workerTLSRole) (*WorkerTransportSecurity, string, error) {
+	absolutePath, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve configuration path: %w", err)
+	}
+	if err := validateWorkerPrivateFile(absolutePath, "worker TLS configuration"); err != nil {
+		return nil, "", err
+	}
+	data, err := os.ReadFile(absolutePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("read configuration: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var fileConfig workerTLSFileConfig
+	if err := decoder.Decode(&fileConfig); err != nil {
+		return nil, "", fmt.Errorf("decode configuration: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values")
+		}
+		return nil, "", fmt.Errorf("decode configuration: %w", err)
+	}
+	if fileConfig.Role != role {
+		return nil, "", fmt.Errorf("configuration role is %q, want %q", fileConfig.Role, role)
+	}
+	if err := validateWorkerScope(fileConfig.Scope); err != nil {
+		return nil, "", err
+	}
+	timeout, err := time.ParseDuration(strings.TrimSpace(fileConfig.HandshakeTimeout))
+	if err != nil || timeout <= 0 {
+		return nil, "", fmt.Errorf("handshake_timeout must be a positive duration")
+	}
+	base := filepath.Dir(absolutePath)
+	certificateFile, err := requiredWorkerTLSPath(base, "certificate_file", fileConfig.CertificateFile)
+	if err != nil {
+		return nil, "", err
+	}
+	privateKeyFile, err := requiredWorkerTLSPath(base, "private_key_file", fileConfig.PrivateKeyFile)
+	if err != nil {
+		return nil, "", err
+	}
+	peerCAFile, err := requiredWorkerTLSPath(base, "peer_ca_file", fileConfig.PeerCAFile)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := validateWorkerPrivateFile(privateKeyFile, "worker TLS private key"); err != nil {
+		return nil, "", err
+	}
+	certificate, err := tls.LoadX509KeyPair(certificateFile, privateKeyFile)
+	if err != nil {
+		return nil, "", fmt.Errorf("load certificate and private key: %w", err)
+	}
+	caPEM, err := os.ReadFile(peerCAFile)
+	if err != nil {
+		return nil, "", fmt.Errorf("read peer CA: %w", err)
+	}
+	peerCAs := x509.NewCertPool()
+	if !peerCAs.AppendCertsFromPEM(caPEM) {
+		return nil, "", fmt.Errorf("peer CA file contains no certificates")
+	}
+
+	config := &tls.Config{
+		MinVersion:             tls.VersionTLS13,
+		Certificates:           []tls.Certificate{certificate},
+		SessionTicketsDisabled: true,
+	}
+	peerRole := workerTLSRoleCoordinator
+	if role == workerTLSRoleCoordinator {
+		peerRole = workerTLSRoleWorker
+		serverName := strings.TrimSpace(fileConfig.ServerName)
+		if serverName == "" {
+			return nil, "", fmt.Errorf("server_name is required for coordinator configuration")
+		}
+		config.RootCAs = peerCAs
+		config.ServerName = serverName
+	} else {
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+		config.ClientCAs = peerCAs
+	}
+	config.VerifyConnection = verifyWorkerPeerScope(fileConfig.Scope, peerRole)
+	return &WorkerTransportSecurity{
+		TLSConfig:        config,
+		Scope:            fileConfig.Scope,
+		HandshakeTimeout: timeout,
+	}, absolutePath, nil
+}
+
+func requiredWorkerTLSPath(base, field, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Join(base, path), nil
+}
+
+func validateWorkerScope(scope string) error {
+	if len(scope) < 16 || len(scope) > 128 {
+		return fmt.Errorf("scope must contain 16 to 128 URL-safe characters")
+	}
+	for _, char := range scope {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '-' || char == '_' {
+			continue
+		}
+		return fmt.Errorf("scope must contain only URL-safe characters")
+	}
+	return nil
+}
+
+func workerScopeURI(scope string, role workerTLSRole) *url.URL {
+	return &url.URL{Scheme: "urn", Opaque: "cc:worker:" + scope + ":" + string(role)}
+}
+
+func verifyWorkerPeerScope(scope string, role workerTLSRole) func(tls.ConnectionState) error {
+	expected := workerScopeURI(scope, role).String()
+	return func(state tls.ConnectionState) error {
+		if len(state.VerifiedChains) == 0 || len(state.VerifiedChains[0]) == 0 {
+			return &WorkerSecurityError{Reason: WorkerSecurityPeerScopeMismatch, Detail: "peer certificate was not verified"}
+		}
+		for _, identity := range state.VerifiedChains[0][0].URIs {
+			if identity.String() == expected {
+				return nil
+			}
+		}
+		return &WorkerSecurityError{Reason: WorkerSecurityPeerScopeMismatch, Detail: "peer certificate does not contain the required worker scope"}
+	}
+}
+
+func HandshakeWorkerServer(ctx context.Context, conn net.Conn, endpoint string, security *WorkerTransportSecurity) (*tls.Conn, error) {
+	if security == nil || security.TLSConfig == nil {
+		return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityTLSConfigRequired}
+	}
+	if security.reload != nil {
+		current, err := security.reload()
+		if err != nil {
+			var securityErr *WorkerSecurityError
+			if errors.As(err, &securityErr) {
+				securityErr.Endpoint = endpoint
+				return nil, securityErr
+			}
+			return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityInvalidTLSConfig, Detail: err.Error()}
+		}
+		security = current
+	}
+	if security.HandshakeTimeout <= 0 {
+		return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityInvalidTLSConfig, Detail: "handshake timeout must be positive"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	handshakeCtx, cancel := context.WithTimeout(ctx, security.HandshakeTimeout)
+	defer cancel()
+	tlsConn := tls.Server(conn, security.TLSConfig.Clone())
+	if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		_ = tlsConn.Close()
+		var securityErr *WorkerSecurityError
+		if errors.As(err, &securityErr) {
+			securityErr.Endpoint = endpoint
+			return nil, securityErr
+		}
+		return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityHandshakeFailed, Detail: err.Error()}
+	}
+	return tlsConn, nil
+}
+
+func handshakeWorkerClient(ctx context.Context, conn net.Conn, endpoint string, security *WorkerTransportSecurity) (*tls.Conn, error) {
+	if security == nil || security.TLSConfig == nil {
+		return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityTLSConfigRequired}
+	}
+	if security.HandshakeTimeout <= 0 {
+		return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityInvalidTLSConfig, Detail: "handshake timeout must be positive"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	handshakeCtx, cancel := context.WithTimeout(ctx, security.HandshakeTimeout)
+	defer cancel()
+	tlsConn := tls.Client(conn, security.TLSConfig.Clone())
+	if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		_ = tlsConn.Close()
+		var securityErr *WorkerSecurityError
+		if errors.As(err, &securityErr) {
+			securityErr.Endpoint = endpoint
+			return nil, securityErr
+		}
+		return nil, &WorkerSecurityError{Endpoint: endpoint, Reason: WorkerSecurityHandshakeFailed, Detail: err.Error()}
+	}
+	return tlsConn, nil
+}
+
+type EphemeralWorkerSecurity struct {
+	ServerConfigPath string
+	ClientConfigPath string
+	Scope            string
+	cleanup          func()
+}
+
+func (s *EphemeralWorkerSecurity) Close() {
+	if s != nil && s.cleanup != nil {
+		s.cleanup()
+	}
+}
+
+func NewEphemeralWorkerSecurity(cacheDir string) (*EphemeralWorkerSecurity, error) {
+	root := filepath.Join(cacheDir, "_worker-auth")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("create worker authentication root: %w", err)
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return nil, fmt.Errorf("secure worker authentication root: %w", err)
+	}
+	dir, err := os.MkdirTemp(root, "session-")
+	if err != nil {
+		return nil, fmt.Errorf("create worker authentication directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	fail := func(err error) (*EphemeralWorkerSecurity, error) {
+		cleanup()
+		return nil, err
+	}
+
+	scope, err := randomWorkerScope()
+	if err != nil {
+		return fail(err)
+	}
+	ca, caKey, caPEM, err := createWorkerCA()
+	if err != nil {
+		return fail(err)
+	}
+	workerCert, workerKey, err := createWorkerLeaf(ca, caKey, scope, workerTLSRoleWorker)
+	if err != nil {
+		return fail(err)
+	}
+	coordinatorCert, coordinatorKey, err := createWorkerLeaf(ca, caKey, scope, workerTLSRoleCoordinator)
+	if err != nil {
+		return fail(err)
+	}
+	files := map[string][]byte{
+		"ca.pem":          caPEM,
+		"worker.crt":      workerCert,
+		"worker.key":      workerKey,
+		"coordinator.crt": coordinatorCert,
+		"coordinator.key": coordinatorKey,
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			return fail(fmt.Errorf("write ephemeral worker credential: %w", err))
+		}
+	}
+	serverConfig := workerTLSFileConfig{
+		Role:             workerTLSRoleWorker,
+		CertificateFile:  "worker.crt",
+		PrivateKeyFile:   "worker.key",
+		PeerCAFile:       "ca.pem",
+		Scope:            scope,
+		HandshakeTimeout: "5s",
+	}
+	clientConfig := workerTLSFileConfig{
+		Role:             workerTLSRoleCoordinator,
+		CertificateFile:  "coordinator.crt",
+		PrivateKeyFile:   "coordinator.key",
+		PeerCAFile:       "ca.pem",
+		ServerName:       "127.0.0.1",
+		Scope:            scope,
+		HandshakeTimeout: "5s",
+	}
+	serverConfigPath := filepath.Join(dir, "worker.json")
+	clientConfigPath := filepath.Join(dir, "coordinator.json")
+	if err := writeWorkerTLSFile(serverConfigPath, serverConfig); err != nil {
+		return fail(err)
+	}
+	if err := writeWorkerTLSFile(clientConfigPath, clientConfig); err != nil {
+		return fail(err)
+	}
+	return &EphemeralWorkerSecurity{
+		ServerConfigPath: serverConfigPath,
+		ClientConfigPath: clientConfigPath,
+		Scope:            scope,
+		cleanup:          cleanup,
+	}, nil
+}
+
+func writeWorkerTLSFile(path string, config workerTLSFileConfig) error {
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write worker TLS configuration: %w", err)
+	}
+	return nil
+}
+
+func randomWorkerScope() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate worker scope: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func createWorkerCA() (*x509.Certificate, ed25519.PrivateKey, []byte, error) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	now := time.Now()
+	serial, err := randomWorkerSerial()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "cc ephemeral worker CA"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return certificate, privateKey, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}
+
+func createWorkerLeaf(ca *x509.Certificate, caKey ed25519.PrivateKey, scope string, role workerTLSRole) ([]byte, []byte, error) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	serial, err := randomWorkerSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "cc worker " + string(role)},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		URIs:         []*url.URL{workerScopeURI(scope, role)},
+	}
+	if role == workerTLSRoleWorker {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		template.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, publicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), nil
+}
+
+func randomWorkerSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 120)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("generate certificate serial: %w", err)
+	}
+	return serial, nil
+}

--- a/internal/vm/sidecar/security_test.go
+++ b/internal/vm/sidecar/security_test.go
@@ -1,0 +1,220 @@
+package sidecar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWorkerMutualTLSRejectsPlaintextBeforeHello(t *testing.T) {
+	credentials, err := NewEphemeralWorkerSecurity(t.TempDir())
+	if err != nil {
+		t.Fatalf("create worker credentials: %v", err)
+	}
+	defer credentials.Close()
+	serverSecurity, err := LoadWorkerServerSecurity(credentials.ServerConfigPath)
+	if err != nil {
+		t.Fatalf("load server security: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+	endpoint := WorkerTLSScheme + listener.Addr().String()
+
+	handshakes := make(chan error, 2)
+	go func() {
+		for attempt := 0; attempt < 2; attempt++ {
+			conn, err := listener.Accept()
+			if err != nil {
+				handshakes <- err
+				continue
+			}
+			authenticated, err := HandshakeWorkerServer(context.Background(), conn, endpoint, serverSecurity)
+			if err != nil {
+				_ = conn.Close()
+				handshakes <- err
+				continue
+			}
+			codec := NewWorkerCodec(authenticated)
+			err = codec.Send(mustWorkerFrame(0, WorkerFrameHello, WorkerHello{
+				Version:  WorkerProtocolVersion,
+				WorkerID: serverSecurity.Scope,
+			}))
+			_ = codec.Close()
+			handshakes <- err
+		}
+	}()
+
+	plaintext, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial plaintext: %v", err)
+	}
+	if _, err := plaintext.Write([]byte(`{"service":"control","type":"hello"}` + "\n")); err != nil {
+		t.Fatalf("write plaintext frame: %v", err)
+	}
+	if err := plaintext.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set plaintext deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	if n, err := plaintext.Read(buf); err == nil || n != 0 {
+		t.Fatalf("plaintext peer read %d bytes before authentication, err=%v", n, err)
+	}
+	_ = plaintext.Close()
+	var securityErr *WorkerSecurityError
+	if err := <-handshakes; !errors.As(err, &securityErr) || securityErr.Reason != WorkerSecurityHandshakeFailed {
+		t.Fatalf("plaintext handshake error = %T %v", err, err)
+	}
+
+	worker, err := DialWorkerTLS(context.Background(), endpoint, credentials.ClientConfigPath)
+	if err != nil {
+		t.Fatalf("dial authenticated worker: %v", err)
+	}
+	_ = worker.Close()
+	if err := <-handshakes; err != nil {
+		t.Fatalf("authenticated handshake: %v", err)
+	}
+}
+
+func TestWorkerMutualTLSEnforcesCertificateScope(t *testing.T) {
+	credentials, err := NewEphemeralWorkerSecurity(t.TempDir())
+	if err != nil {
+		t.Fatalf("create worker credentials: %v", err)
+	}
+	defer credentials.Close()
+	serverSecurity, err := LoadWorkerServerSecurity(credentials.ServerConfigPath)
+	if err != nil {
+		t.Fatalf("load server security: %v", err)
+	}
+	clientConfig := readWorkerTLSConfigForTest(t, credentials.ClientConfigPath)
+	clientConfig.Scope = "different_worker_scope"
+	writeWorkerTLSConfigForTest(t, credentials.ClientConfigPath, clientConfig)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+	endpoint := WorkerTLSScheme + listener.Addr().String()
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		_, err = HandshakeWorkerServer(context.Background(), conn, endpoint, serverSecurity)
+		_ = conn.Close()
+		serverDone <- err
+	}()
+
+	_, err = DialWorkerTLS(context.Background(), endpoint, credentials.ClientConfigPath)
+	var securityErr *WorkerSecurityError
+	if !errors.As(err, &securityErr) {
+		t.Fatalf("scope error type = %T, want WorkerSecurityError", err)
+	}
+	if securityErr.Reason != WorkerSecurityPeerScopeMismatch {
+		t.Fatalf("scope error reason = %q", securityErr.Reason)
+	}
+	<-serverDone
+}
+
+func TestWorkerServerReloadsRotatedCredentialsWithinScope(t *testing.T) {
+	credentials, err := NewEphemeralWorkerSecurity(t.TempDir())
+	if err != nil {
+		t.Fatalf("create worker credentials: %v", err)
+	}
+	defer credentials.Close()
+	serverSecurity, err := LoadWorkerServerSecurity(credentials.ServerConfigPath)
+	if err != nil {
+		t.Fatalf("load server security: %v", err)
+	}
+	dir := filepath.Dir(credentials.ServerConfigPath)
+	rotateWorkerCredentialsForTest(t, dir, credentials.Scope)
+	clientSecurity, err := LoadWorkerClientSecurity(credentials.ClientConfigPath)
+	if err != nil {
+		t.Fatalf("load rotated client security: %v", err)
+	}
+
+	left, right := net.Pipe()
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := HandshakeWorkerServer(context.Background(), left, "pipe", serverSecurity)
+		if err == nil {
+			_ = conn.Close()
+		}
+		serverDone <- err
+	}()
+	clientConn, err := handshakeWorkerClient(context.Background(), right, "pipe", clientSecurity)
+	if err != nil {
+		t.Fatalf("handshake with rotated credentials: %v", err)
+	}
+	_ = clientConn.Close()
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server handshake with rotated credentials: %v", err)
+	}
+}
+
+func rotateWorkerCredentialsForTest(t *testing.T, dir, scope string) {
+	t.Helper()
+	ca, caKey, caPEM, err := createWorkerCA()
+	if err != nil {
+		t.Fatalf("create rotated CA: %v", err)
+	}
+	workerCert, workerKey, err := createWorkerLeaf(ca, caKey, scope, workerTLSRoleWorker)
+	if err != nil {
+		t.Fatalf("create rotated worker certificate: %v", err)
+	}
+	coordinatorCert, coordinatorKey, err := createWorkerLeaf(ca, caKey, scope, workerTLSRoleCoordinator)
+	if err != nil {
+		t.Fatalf("create rotated coordinator certificate: %v", err)
+	}
+	for name, data := range map[string][]byte{
+		"ca.pem":          caPEM,
+		"worker.crt":      workerCert,
+		"worker.key":      workerKey,
+		"coordinator.crt": coordinatorCert,
+		"coordinator.key": coordinatorKey,
+	} {
+		atomicReplaceWorkerFileForTest(t, filepath.Join(dir, name), data)
+	}
+}
+
+func atomicReplaceWorkerFileForTest(t *testing.T, path string, data []byte) {
+	t.Helper()
+	temporary := path + ".new"
+	if err := os.WriteFile(temporary, data, 0o600); err != nil {
+		t.Fatalf("write rotated credential: %v", err)
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		t.Fatalf("replace rotated credential: %v", err)
+	}
+}
+
+func readWorkerTLSConfigForTest(t *testing.T, path string) workerTLSFileConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read worker TLS config: %v", err)
+	}
+	var config workerTLSFileConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("decode worker TLS config: %v", err)
+	}
+	return config
+}
+
+func writeWorkerTLSConfigForTest(t *testing.T, path string, config workerTLSFileConfig) {
+	t.Helper()
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatalf("encode worker TLS config: %v", err)
+	}
+	atomicReplaceWorkerFileForTest(t, path, append(data, '\n'))
+}

--- a/internal/vm/sidecar/security_unix.go
+++ b/internal/vm/sidecar/security_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package sidecar
+
+import (
+	"fmt"
+	"os"
+)
+
+func validateWorkerPrivateFile(path, kind string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", kind, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", kind)
+	}
+	if permissions := info.Mode().Perm(); permissions&0o077 != 0 {
+		return fmt.Errorf("%s mode is %04o, want owner-only permissions", kind, permissions)
+	}
+	return nil
+}

--- a/internal/vm/sidecar/security_windows.go
+++ b/internal/vm/sidecar/security_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package sidecar
+
+import (
+	"fmt"
+	"os"
+)
+
+func validateWorkerPrivateFile(path, kind string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", kind, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", kind)
+	}
+	return nil
+}

--- a/internal/vm/sidecar_host.go
+++ b/internal/vm/sidecar_host.go
@@ -362,14 +362,21 @@ func (h *sidecarVMHost) launch(ctx context.Context, env []string) (*sidecarpkg.D
 	if err != nil {
 		return nil, err
 	}
-	controlSocket, err := h.sidecarControlSocketPath()
+	control, err := h.sidecarControlEndpoint()
 	if err != nil {
 		return nil, err
 	}
-	cmd := sidecarpkg.LaunchCommand(exe, h.cacheDir, controlSocket, env, sidecarpkg.LaunchOptions{
-		DisableEnv: sidecarDisableEnv,
-		ControlEnv: sidecarControlEnv,
-		ModeEnv:    sidecarModeEnv,
+	keepControl := false
+	defer func() {
+		if !keepControl {
+			control.Close()
+		}
+	}()
+	cmd := sidecarpkg.LaunchCommand(exe, h.cacheDir, control.address, env, sidecarpkg.LaunchOptions{
+		DisableEnv:    sidecarDisableEnv,
+		ControlEnv:    sidecarControlEnv,
+		ModeEnv:       sidecarModeEnv,
+		TLSConfigPath: control.serverTLSConfig,
 	})
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -395,25 +402,56 @@ func (h *sidecarVMHost) launch(ctx context.Context, env []string) (*sidecarpkg.D
 		started = false
 		return nil, err
 	}
-	worker, err := sidecarpkg.DialWorker(ctx, hello.Addr)
+	var worker *sidecarpkg.Client
+	if control.clientTLSConfig == "" {
+		worker, err = sidecarpkg.DialWorker(ctx, hello.Addr)
+	} else {
+		worker, err = sidecarpkg.DialWorkerTLS(ctx, hello.Addr, control.clientTLSConfig)
+	}
 	if err != nil {
 		started = false
 		return nil, err
 	}
-	return sidecarpkg.NewDaemon(cmd, worker, stdout, []func(){sidecarControlCleanup(controlSocket)}), nil
+	keepControl = true
+	return sidecarpkg.NewDaemon(cmd, worker, stdout, []func(){control.Close}), nil
 }
 
-func (h *sidecarVMHost) sidecarControlSocketPath() (string, error) {
+type sidecarControlEndpoint struct {
+	address         string
+	serverTLSConfig string
+	clientTLSConfig string
+	cleanup         func()
+}
+
+func (e sidecarControlEndpoint) Close() {
+	if e.cleanup != nil {
+		e.cleanup()
+	}
+}
+
+func (h *sidecarVMHost) sidecarControlEndpoint() (sidecarControlEndpoint, error) {
 	if runtime.GOOS == "windows" {
-		return "tcp://127.0.0.1:0", nil
+		security, err := sidecarpkg.NewEphemeralWorkerSecurity(h.cacheDir)
+		if err != nil {
+			return sidecarControlEndpoint{}, err
+		}
+		return sidecarControlEndpoint{
+			address:         sidecarpkg.WorkerTLSScheme + "127.0.0.1:0",
+			serverTLSConfig: security.ServerConfigPath,
+			clientTLSConfig: security.ClientConfigPath,
+			cleanup:         security.Close,
+		}, nil
 	}
 	socketDir := filepath.Join(h.cacheDir, "_worker-sockets")
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
-		return "", err
+		return sidecarControlEndpoint{}, err
 	}
 	socketPath := filepath.Join(socketDir, fmt.Sprintf("control-%d-%d.sock", os.Getpid(), time.Now().UnixNano()))
 	_ = os.Remove(socketPath)
-	return socketPath, nil
+	return sidecarControlEndpoint{
+		address: socketPath,
+		cleanup: sidecarControlCleanup(socketPath),
+	}, nil
 }
 
 func prepareSidecarUnixListener(cacheDir, prefix string) (string, net.Listener, func(), error) {

--- a/internal/vm/worker_protocol_alias.go
+++ b/internal/vm/worker_protocol_alias.go
@@ -3,6 +3,7 @@ package vm
 import sidecarproto "j5.nz/cc/internal/vm/sidecar"
 
 const WorkerProtocolVersion = sidecarproto.WorkerProtocolVersion
+const WorkerTLSScheme = sidecarproto.WorkerTLSScheme
 
 const (
 	WorkerServiceControl   = sidecarproto.WorkerServiceControl
@@ -50,6 +51,19 @@ type WorkerCancelRequest = sidecarproto.WorkerCancelRequest
 type WorkerError = sidecarproto.WorkerError
 type WorkerFrame = sidecarproto.WorkerFrame
 type WorkerCodec = sidecarproto.WorkerCodec
+type WorkerSecurityError = sidecarproto.WorkerSecurityError
+type WorkerSecurityReason = sidecarproto.WorkerSecurityReason
+type WorkerTransportSecurity = sidecarproto.WorkerTransportSecurity
+
+const (
+	WorkerSecurityPlaintextTCPRejected = sidecarproto.WorkerSecurityPlaintextTCPRejected
+	WorkerSecurityTLSConfigRequired    = sidecarproto.WorkerSecurityTLSConfigRequired
+	WorkerSecurityInvalidTLSConfig     = sidecarproto.WorkerSecurityInvalidTLSConfig
+	WorkerSecurityPeerScopeMismatch    = sidecarproto.WorkerSecurityPeerScopeMismatch
+	WorkerSecurityHandshakeFailed      = sidecarproto.WorkerSecurityHandshakeFailed
+)
 
 var NewWorkerFrame = sidecarproto.NewWorkerFrame
 var NewWorkerCodec = sidecarproto.NewWorkerCodec
+var LoadWorkerServerSecurity = sidecarproto.LoadWorkerServerSecurity
+var HandshakeWorkerServer = sidecarproto.HandshakeWorkerServer


### PR DESCRIPTION
Closes #60.

## What changed

- Reject the legacy `tcp://` worker-control transport, including on loopback.
- Add `tls://` worker control with TLS 1.3 mutual authentication before any worker hello or control frame is sent.
- Give worker and coordinator certificates separate URI-scoped identities and verify the authenticated scope against the worker hello.
- Load security-sensitive settings from separate owner-only worker/coordinator files, with an explicit deployment-chosen handshake timeout.
- Reload server credentials, peer CA, and policy before each new handshake; disable session resumption so new connections reauthenticate after rotation.
- Generate one-worker, short-lived ephemeral credentials for local Windows sidecars. Unix-socket sidecars remain unchanged.
- Return structured security reasons for plaintext transport, missing/invalid TLS configuration, scope mismatch, and handshake failure.
- Document provisioning, scope, rotation, timeout, migration, and connection-lifetime behavior.

## Security contract

The worker authenticates the coordinator certificate before sending its hello. The coordinator authenticates the worker certificate and server name, then requires the hello identity to match the certificate scope. Certificates use role-specific identities:

- `urn:cc:worker:<scope>:worker`
- `urn:cc:worker:<scope>:coordinator`

There is no plaintext compatibility flag or deprecation window before v1. Existing authenticated connections remain valid until they close; rotation affects new connections, and a scope change requires a worker restart.

## Validation

- `go test ./...`
- focused sidecar and ccvmd tests
- focused race tests repeated 10–20 times
- `go vet ./internal/vm/sidecar ./internal/ccvmd ./internal/vm`
- Linux amd64/arm64 compile checks for the changed packages
- Windows amd64/arm64 compile checks for the changed packages
- hardware-backed Darwin arm64 VM runtime tests

## Hardware still needed before merge

The repository CI matrix should exercise the short suite on Linux amd64/arm64, macOS amd64/arm64, and Windows amd64/arm64. A Windows amd64 or arm64 runner is specifically required to execute the new local sidecar startup path; this checkout could only cross-compile that path.
