### PR TITLE
Expose VM-scoped service admission to daemon integrations

### DIFF
--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -24,6 +24,7 @@ type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
 	RunStreamIn(context.Context, string, client.RunRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
 	ShutdownInstance(context.Context, string) error
+	AllowServiceProxyPort(context.Context, string, int) error
 }
 
 func Main(args []string) {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -93,6 +93,7 @@ type RuntimeView interface {
 	InstanceStatuses() []client.InstanceState
 	RunStreamIn(context.Context, string, client.RunRequest, <-chan client.ExecInput, func(client.ExecEvent) error) error
 	ShutdownInstance(context.Context, string) error
+	AllowServiceProxyPort(context.Context, string, int) error
 }
 
 func (s *server) InstanceStatuses() []client.InstanceState {
@@ -116,6 +117,13 @@ func (s *server) ShutdownInstance(ctx context.Context, id string) error {
 		return fmt.Errorf("runtime is not available")
 	}
 	return s.vms.ShutdownInstance(ctx, id)
+}
+
+func (s *server) AllowServiceProxyPort(ctx context.Context, id string, port int) error {
+	if s == nil || s.vms == nil {
+		return fmt.Errorf("runtime is not available")
+	}
+	return s.vms.AllowServiceProxyPortTo(ctx, id, port)
 }
 
 type watchdogController struct {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -6,11 +6,22 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/virtio"
 )
+
+func TestInstanceStatusPreservesSubsecondStartIdentity(t *testing.T) {
+	manager := NewManager()
+	manager.running = make(map[string]*Machine)
+	manager.running[DefaultInstanceID] = &Machine{startedAt: time.Date(2026, 7, 14, 1, 2, 3, 456789, time.UTC)}
+	state := manager.Status()
+	if state.StartedAt != "2026-07-14T01:02:03.000456789Z" {
+		t.Fatalf("started_at = %q, want nanosecond-stable VM identity", state.StartedAt)
+	}
+}
 
 func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	ctx := context.Background()

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -719,7 +719,7 @@ func (m *Manager) statusLocked(id string) client.InstanceState {
 		BalloonMB:  machine.balloonMB,
 		CPUs:       machine.cpus,
 		NestedVirt: machine.nestedVirt,
-		StartedAt:  machine.startedAt.Format(time.RFC3339),
+		StartedAt:  machine.startedAt.Format(time.RFC3339Nano),
 	}
 	if provider, ok := machine.instance.(networkIPv4Provider); ok {
 		state.NetworkIPv4 = provider.NetworkIPv4()


### PR DESCRIPTION
Supports tinyrange/vmsh#89.

## What changed

- Expose the existing per-instance service-proxy admission operation through `ccvmd.RuntimeView`.
- Preserve nanosecond precision in `InstanceState.started_at` so a VM replacement cannot inherit a same-second trust generation.
- Add a behavior test for the stable start identity.

## Why

vmsh trusted-context gateways use a unique loopback port per grant and ask cc to admit that port only to the selected running VM. The guest cannot choose or spoof the VM identity used for admission.

## Validation

- `go test ./...`
- `go test ./internal/vm ./internal/ccvmd ./ccvmd`
- `git diff --check`

`go vet ./...` still reports pre-existing unkeyed-literal and no-copy warnings outside this patch.
