### PR TITLE
Keep cache roots private by default

### DIFF
--- a/cmd/cc/main.go
+++ b/cmd/cc/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"j5.nz/cc/client"
+	"j5.nz/cc/internal/cachepath"
 	"j5.nz/cc/internal/fulltest"
 )
 
@@ -819,14 +820,14 @@ func writeDaemonState(path string, state daemonState) error {
 
 func resolveCacheDir(arg string) (string, error) {
 	if arg != "" {
-		return arg, os.MkdirAll(arg, 0o755)
+		return arg, cachepath.EnsurePrivateRoot(arg)
 	}
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user cache dir: %w", err)
 	}
 	dir := filepath.Join(userCacheDir, "ccx3")
-	return dir, os.MkdirAll(dir, 0o755)
+	return dir, cachepath.EnsurePrivateRoot(dir)
 }
 
 func printJSON(v any) error {

--- a/internal/cachepath/cachepath.go
+++ b/internal/cachepath/cachepath.go
@@ -1,0 +1,29 @@
+package cachepath
+
+import (
+	"fmt"
+	"os"
+)
+
+// EnsurePrivateRoot creates or repairs a cache root so only its owner can
+// traverse it. Files within the root may retain content-oriented modes because
+// the private root is the access-control boundary.
+func EnsurePrivateRoot(path string) error {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("cache root %q is a symbolic link", path)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("cache root %q is not a directory", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		return fmt.Errorf("make cache root %q private: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cachepath/cachepath_test.go
+++ b/internal/cachepath/cachepath_test.go
@@ -1,0 +1,42 @@
+package cachepath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsurePrivateRootCreatesAndRepairsDirectory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("create permissive cache: %v", err)
+	}
+	if err := EnsurePrivateRoot(root); err != nil {
+		t.Fatalf("ensure private cache: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(root)
+		if err != nil {
+			t.Fatalf("stat cache: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o700 {
+			t.Fatalf("cache mode = %o, want 700", got)
+		}
+	}
+}
+
+func TestEnsurePrivateRootRejectsSymlink(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	link := filepath.Join(parent, "cache")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := EnsurePrivateRoot(link); err == nil {
+		t.Fatal("symbolic-link cache root was accepted")
+	}
+}

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/net/websocket"
 	"j5.nz/cc/client"
+	"j5.nz/cc/internal/cachepath"
 	intcvmfs "j5.nz/cc/internal/cvmfs"
 	"j5.nz/cc/internal/hv/hvf"
 	"j5.nz/cc/internal/kernel/alpine"
@@ -1666,14 +1667,14 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 
 func resolveCacheDir(arg string) (string, error) {
 	if arg != "" {
-		return arg, os.MkdirAll(arg, 0o755)
+		return arg, cachepath.EnsurePrivateRoot(arg)
 	}
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user cache dir: %w", err)
 	}
 	dir := filepath.Join(userCacheDir, "ccx3")
-	return dir, os.MkdirAll(dir, 0o755)
+	return dir, cachepath.EnsurePrivateRoot(dir)
 }
 
 func registerPprofHandlers(mux *http.ServeMux) {


### PR DESCRIPTION
## Summary

- create CLI and daemon cache roots with owner-only traversal
- repair existing cache-root modes to 0700 on Unix-like systems
- reject symbolic-link and non-directory cache roots before trusted reuse

The root is the privacy boundary, so content-addressed files can retain their existing modes without being reachable by other local users.

## Validation

- `go test ./internal/cachepath ./internal/ccvmd ./cmd/cc`
- `go test ./...`

Fixes #58