### PR TITLE
Keep daemon token cleanup caller-owned

### DIFF
--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -9,7 +9,8 @@ import (
 )
 
 type ServerOptions struct {
-	Kind                   string
+	Kind string
+	// TokenPath is caller-owned. RunServer advertises it but does not remove it.
 	TokenPath              string
 	Persistent             bool
 	OnStartup              func(client.ServerHello) error

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -78,7 +78,10 @@ type server struct {
 }
 
 type ServerOptions struct {
-	Kind                   string
+	Kind string
+	// TokenPath is advertised to clients but remains owned by the caller that
+	// created it. RunServer never unlinks it: only the publisher can safely
+	// coordinate token generation and discovery-state rotation.
 	TokenPath              string
 	Persistent             bool
 	OnStartup              func(client.ServerHello) error
@@ -355,10 +358,6 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 	if err := macos.EnsureExecutableIsSigned(); err != nil {
 		return false, fmt.Errorf("prepare ccvm executable: %w", err)
 	}
-	if strings.TrimSpace(opts.TokenPath) != "" {
-		defer os.Remove(opts.TokenPath)
-	}
-
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 	addr := fs.String("addr", "localhost:0", "Address to listen on")


### PR DESCRIPTION
## Summary

- stop ccvmd from unlinking a token path supplied by its caller
- document that ccvmd advertises the credential while publication, rotation, and cleanup remain caller-owned
- eliminate the old-daemon/new-token pathname race entirely instead of narrowing its timing window

Crash-stale generation credentials remain recoverable for caller-side garbage collection.

## Validation

- `go test ./internal/ccvmd ./ccvmd`
- `go test ./...`

Fixes #63