### PR TITLE
Validate VM resources and reserve host capacity

### DIFF
--- a/client/protocol.go
+++ b/client/protocol.go
@@ -340,6 +340,10 @@ type CapabilitiesResponse struct {
 	SupportsNestedVirt     bool     `json:"supports_nested_virtualization"`
 	RequiresPrivilegedCCX3 bool     `json:"requires_privileged_ccx3"`
 	Notes                  []string `json:"notes,omitempty"`
+	MemoryCapacityMB       uint64   `json:"memory_capacity_mb,omitempty"`
+	MemoryReservedMB       uint64   `json:"memory_reserved_mb,omitempty"`
+	CPUCapacity            int      `json:"cpu_capacity,omitempty"`
+	CPUReserved            int      `json:"cpu_reserved,omitempty"`
 }
 
 type CreateInstanceRequest struct {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -117,6 +117,53 @@ func TestManagerBlankStartRemembersImageForRunIn(t *testing.T) {
 	}
 }
 
+func TestManagerRejectsInvalidResourcesBeforeHostAllocation(t *testing.T) {
+	host := newFakeHost(VMHostCapabilities{MaxVMs: 4})
+	manager := testManager(host)
+	_, err := manager.Start(context.Background(), client.CreateInstanceRequest{Image: "alpine", MemoryMB: ^uint64(0), CPUs: 1})
+	if err == nil {
+		t.Fatal("overflowing memory request was accepted")
+	}
+	if len(host.starts) != 0 {
+		t.Fatalf("host starts = %+v", host.starts)
+	}
+	_, err = manager.Start(context.Background(), client.CreateInstanceRequest{Image: "alpine", MemoryMB: 512, BalloonMB: 513, CPUs: 1})
+	if err == nil {
+		t.Fatal("balloon larger than guest memory was accepted")
+	}
+	if len(host.starts) != 0 {
+		t.Fatalf("host starts after balloon rejection = %+v", host.starts)
+	}
+}
+
+func TestManagerAdmissionIncludesInflightStarts(t *testing.T) {
+	base := newFakeHost(VMHostCapabilities{MaxVMs: 4})
+	base.queueInstance(newFakeInstance())
+	host := &blockingStartHost{fakeHost: base, entered: make(chan struct{}), release: make(chan struct{})}
+	manager := testManager(host)
+	manager.maxMemoryMB = 512
+	manager.maxCPUs = 2
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Start(context.Background(), client.CreateInstanceRequest{ID: "one", Image: "alpine", MemoryMB: 512, CPUs: 2})
+		firstDone <- err
+	}()
+	<-host.entered
+	if _, err := manager.Start(context.Background(), client.CreateInstanceRequest{ID: "two", Image: "alpine", MemoryMB: 512, CPUs: 1}); err == nil {
+		t.Fatal("concurrent start exceeded reserved budget")
+	}
+	if len(base.starts) != 0 {
+		t.Fatalf("host starts before release = %d, want 0", len(base.starts))
+	}
+	close(host.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	if len(base.starts) != 1 {
+		t.Fatalf("host starts after release = %d, want 1", len(base.starts))
+	}
+}
+
 func TestManagerBlankSnapshotStartKeepsSharesInStartRequest(t *testing.T) {
 	ctx := context.Background()
 	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2, SupportsL2: true})
@@ -377,6 +424,22 @@ type fakeHost struct {
 	hostCapabilitiesN int
 }
 
+type blockingStartHost struct {
+	*fakeHost
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (h *blockingStartHost) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	close(h.entered)
+	select {
+	case <-h.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return h.fakeHost.StartStream(ctx, req, onEvent)
+}
+
 type fakeRunInCall struct {
 	inst         Instance
 	runningImage string
@@ -633,6 +696,8 @@ func (i *fakeInstance) VirtioFSStats() []virtio.FSStats {
 
 func testManager(host VMHost) *Manager {
 	manager := NewManagerWithHost(host)
+	manager.maxMemoryMB = 1 << 40
+	manager.maxCPUs = 1 << 20
 	manager.supports = func() error { return nil }
 	manager.capabilities = func() client.CapabilitiesResponse {
 		caps := host.HostCapabilities(context.Background())

--- a/internal/vm/resources_darwin.go
+++ b/internal/vm/resources_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package vm
+
+import "golang.org/x/sys/unix"
+
+func hostMemoryMB() uint64 {
+	bytes, err := unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+	return bytes >> 20
+}

--- a/internal/vm/resources_linux.go
+++ b/internal/vm/resources_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package vm
+
+import "golang.org/x/sys/unix"
+
+func hostMemoryMB() uint64 {
+	var info unix.Sysinfo_t
+	if unix.Sysinfo(&info) != nil {
+		return 0
+	}
+	return uint64(info.Totalram) * uint64(info.Unit) >> 20
+}

--- a/internal/vm/resources_other.go
+++ b/internal/vm/resources_other.go
@@ -1,0 +1,5 @@
+//go:build !linux && !darwin && !windows
+
+package vm
+
+func hostMemoryMB() uint64 { return 0 }

--- a/internal/vm/resources_windows.go
+++ b/internal/vm/resources_windows.go
@@ -8,11 +8,25 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+type memoryStatusEx struct {
+	length               uint32
+	memoryLoad           uint32
+	totalPhys            uint64
+	availPhys            uint64
+	totalPageFile        uint64
+	availPageFile        uint64
+	totalVirtual         uint64
+	availVirtual         uint64
+	availExtendedVirtual uint64
+}
+
 func hostMemoryMB() uint64 {
-	var status windows.MemStatusEx
-	status.Length = uint32(unsafe.Sizeof(status))
-	if windows.GlobalMemoryStatusEx(&status) != nil {
+	var status memoryStatusEx
+	status.length = uint32(unsafe.Sizeof(status))
+	proc := windows.NewLazySystemDLL("kernel32.dll").NewProc("GlobalMemoryStatusEx")
+	ok, _, _ := proc.Call(uintptr(unsafe.Pointer(&status)))
+	if ok == 0 {
 		return 0
 	}
-	return status.TotalPhys >> 20
+	return status.totalPhys >> 20
 }

--- a/internal/vm/resources_windows.go
+++ b/internal/vm/resources_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package vm
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func hostMemoryMB() uint64 {
+	var status windows.MemStatusEx
+	status.Length = uint32(unsafe.Sizeof(status))
+	if windows.GlobalMemoryStatusEx(&status) != nil {
+		return 0
+	}
+	return status.TotalPhys >> 20
+}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -67,6 +67,14 @@ type Manager struct {
 	running       map[string]*Machine
 	starting      map[string]struct{}
 	networkLeases map[string]managerNetworkLease
+	reservations  map[string]resourceReservation
+	maxMemoryMB   uint64
+	maxCPUs       int
+}
+
+type resourceReservation struct {
+	memoryMB uint64
+	cpus     int
 }
 
 type Machine struct {
@@ -97,10 +105,8 @@ func NewManager() *Manager {
 }
 
 func NewManagerWithBackend(backend Backend) *Manager {
-	m := &Manager{supports: Supports, capabilities: HostCapabilities}
-	m.host = vmhost.NewInProcess(backend, func() client.CapabilitiesResponse {
-		return m.Capabilities()
-	})
+	m := newManagerBudgets(&Manager{supports: Supports, capabilities: HostCapabilities})
+	m.host = vmhost.NewInProcess(backend, HostCapabilities)
 	return m
 }
 
@@ -108,7 +114,13 @@ func NewManagerWithHost(host VMHost) *Manager {
 	if host == nil {
 		host = vmhost.NewInProcess(vmhost.UnsupportedBackend{}, HostCapabilities)
 	}
-	return &Manager{host: host, supports: Supports, capabilities: HostCapabilities}
+	return newManagerBudgets(&Manager{host: host, supports: Supports, capabilities: HostCapabilities})
+}
+
+func newManagerBudgets(m *Manager) *Manager {
+	m.maxMemoryMB = hostMemoryMB()
+	m.maxCPUs = runtime.NumCPU()
+	return m
 }
 
 func NewManagerWithHosts(hosts ...VMHost) *Manager {
@@ -205,6 +217,9 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	if req.Image == "" {
 		return client.InstanceState{}, fmt.Errorf("image is required")
 	}
+	if err := normalizeResources(&req.MemoryMB, &req.BalloonMB, &req.CPUs); err != nil {
+		return client.InstanceState{}, err
+	}
 	if err := m.supports(); err != nil {
 		return client.InstanceState{}, err
 	}
@@ -226,11 +241,15 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		m.mu.Unlock()
 		return state, fmt.Errorf("VM %q is already starting", id)
 	}
-	if err := m.checkCapacityLocked(); err != nil {
+	if err := m.checkCapacityLocked(req.MemoryMB, req.CPUs); err != nil {
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
 	m.starting[id] = struct{}{}
+	if m.reservations == nil {
+		m.reservations = make(map[string]resourceReservation)
+	}
+	m.reservations[id] = resourceReservation{memoryMB: req.MemoryMB, cpus: req.CPUs}
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
@@ -260,6 +279,7 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		m.running = make(map[string]*Machine)
 	}
 	delete(m.starting, id)
+	delete(m.reservations, id)
 	m.running[id] = machine
 	m.mu.Unlock()
 
@@ -289,6 +309,9 @@ func (m *Manager) StartBlankInstanceStream(
 ) (client.InstanceState, error) {
 	id = instanceID(id)
 	req.ID = id
+	if err := normalizeResources(&req.MemoryMB, &req.BalloonMB, &req.CPUs); err != nil {
+		return client.InstanceState{}, err
+	}
 	if err := m.supports(); err != nil {
 		return client.InstanceState{}, err
 	}
@@ -310,11 +333,15 @@ func (m *Manager) StartBlankInstanceStream(
 		m.mu.Unlock()
 		return state, fmt.Errorf("VM %q is already starting", id)
 	}
-	if err := m.checkCapacityLocked(); err != nil {
+	if err := m.checkCapacityLocked(req.MemoryMB, req.CPUs); err != nil {
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
 	m.starting[id] = struct{}{}
+	if m.reservations == nil {
+		m.reservations = make(map[string]resourceReservation)
+	}
+	m.reservations[id] = resourceReservation{memoryMB: req.MemoryMB, cpus: req.CPUs}
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
@@ -359,6 +386,7 @@ func (m *Manager) StartBlankInstanceStream(
 		m.running = make(map[string]*Machine)
 	}
 	delete(m.starting, id)
+	delete(m.reservations, id)
 	m.running[id] = machine
 	m.mu.Unlock()
 
@@ -692,10 +720,22 @@ func (m *Manager) Statuses() []client.InstanceState {
 }
 
 func (m *Manager) Capabilities() client.CapabilitiesResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.capabilitiesLocked()
+}
+
+func (m *Manager) capabilitiesLocked() client.CapabilitiesResponse {
+	var caps client.CapabilitiesResponse
 	if m.capabilities == nil {
-		return HostCapabilities()
+		caps = HostCapabilities()
+	} else {
+		caps = m.capabilities()
 	}
-	return m.capabilities()
+	memory, cpus := m.resourceUsageLocked()
+	caps.MemoryCapacityMB, caps.MemoryReservedMB = m.maxMemoryMB, memory
+	caps.CPUCapacity, caps.CPUReserved = m.maxCPUs, cpus
+	return caps
 }
 
 func (m *Manager) statusLocked(id string) client.InstanceState {
@@ -741,10 +781,51 @@ func (m *Manager) watch(machine *Machine) {
 	machine.exitedAt = time.Now().UTC()
 }
 
-func (m *Manager) checkCapacityLocked() error {
+func (m *Manager) checkCapacityLocked(memoryMB uint64, cpus int) error {
 	caps := m.host.HostCapabilities(context.Background())
 	if caps.MaxVMs > 0 && len(m.running)+len(m.starting) >= caps.MaxVMs {
 		return fmt.Errorf("maximum running VM instances reached: %d", caps.MaxVMs)
+	}
+	usedMemory, usedCPUs := m.resourceUsageLocked()
+	if m.maxMemoryMB > 0 && (memoryMB > m.maxMemoryMB || usedMemory > m.maxMemoryMB-memoryMB) {
+		return fmt.Errorf("VM memory admission rejected: requested=%d MiB reserved=%d MiB capacity=%d MiB", memoryMB, usedMemory, m.maxMemoryMB)
+	}
+	if m.maxCPUs > 0 && (cpus > m.maxCPUs || usedCPUs > m.maxCPUs-cpus) {
+		return fmt.Errorf("VM CPU admission rejected: requested=%d reserved=%d capacity=%d", cpus, usedCPUs, m.maxCPUs)
+	}
+	return nil
+}
+
+func (m *Manager) resourceUsageLocked() (uint64, int) {
+	var memory uint64
+	var cpus int
+	for _, machine := range m.running {
+		memory += machine.memoryMB
+		cpus += machine.cpus
+	}
+	for _, reservation := range m.reservations {
+		memory += reservation.memoryMB
+		cpus += reservation.cpus
+	}
+	return memory, cpus
+}
+
+func normalizeResources(memoryMB, balloonMB *uint64, cpus *int) error {
+	if *memoryMB == 0 {
+		*memoryMB = 512
+	}
+	if *cpus == 0 {
+		*cpus = 1
+	}
+	if *cpus < 0 {
+		return fmt.Errorf("cpus must be positive")
+	}
+	maxAllocationMB := uint64(^uint(0)>>1) >> 20
+	if *memoryMB > maxAllocationMB {
+		return fmt.Errorf("memory_mb %d overflows host allocation size", *memoryMB)
+	}
+	if *balloonMB > *memoryMB {
+		return fmt.Errorf("balloon_mb %d exceeds memory_mb %d", *balloonMB, *memoryMB)
 	}
 	return nil
 }
@@ -753,6 +834,7 @@ func (m *Manager) clearStarting(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.starting, id)
+	delete(m.reservations, id)
 }
 
 func (m *Manager) ensureNetworkLeaseLocked(id, image string, cfg *client.NetworkConfig) *client.NetworkConfig {


### PR DESCRIPTION
Fixes #96
Fixes #97

## Summary
- normalize zero requests to 512 MiB and one vCPU, and reject negative CPUs, allocation-size overflow, and balloon targets above guest memory before host work
- derive aggregate budgets from physical host RAM and logical CPU count on Linux, Darwin, and Windows
- reserve memory/vCPUs atomically for in-flight starts and release reservations on every failure/success transition
- reject concurrent starts that exceed memory, CPU, or backend instance budgets
- expose capacity and current reserved totals through structured capability fields

Memory is charged at configured guest size; ballooning does not create extra capacity. Starting and running instances are charged, stopping instances remain charged until their backend exits, and failed starts release immediately.

## Validation
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/vm`
- `GOOS=darwin GOARCH=arm64 go test -c ./internal/vm`
- behavior coverage for pre-allocation rejection and concurrent in-flight admission

No special hardware is required.