### PR TITLE
Isolate and bound Linux virtual networking

### DIFF
--- a/internal/vm/backend_builtin_bsd_linux_amd64.go
+++ b/internal/vm/backend_builtin_bsd_linux_amd64.go
@@ -137,7 +137,7 @@ func (b *runtimeBackend) startBSDManagedStream(ctx context.Context, req client.C
 	if def.BuildArtifact == nil {
 		return nil, fmt.Errorf("%s runtime root builder is not configured", displayName)
 	}
-	network, err := newLinuxPCINetworkRuntime(req.ID, managedBSDNetworkConfig(req.Network))
+	network, err := newLinuxPCINetworkRuntime(req.ID, managedBSDNetworkConfig(req.Network), b.networkSwitch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/backend_builtin_bsd_linux_arm64.go
+++ b/internal/vm/backend_builtin_bsd_linux_arm64.go
@@ -172,7 +172,7 @@ func (b *runtimeBackend) startBSDArm64ManagedStream(ctx context.Context, req cli
 	if def.BuildArtifact == nil {
 		return nil, fmt.Errorf("%s runtime root builder is not configured", displayName)
 	}
-	network, err := newLinuxARM64NetworkRuntime(req.ID, managedBSDNetworkConfig(req.Network))
+	network, err := newLinuxARM64NetworkRuntime(req.ID, managedBSDNetworkConfig(req.Network), b.networkSwitch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -35,10 +35,11 @@ type runtimeBackend struct {
 	kernel         *alpine.Manager
 	images         *oci.Store
 	guestInitCache string
+	networkSwitch  *linuxVirtualSwitch
 }
 
 func NewRuntimeBackend(kernel *alpine.Manager, images *oci.Store, guestInitCache string) Backend {
-	return &runtimeBackend{kernel: kernel, images: images, guestInitCache: guestInitCache}
+	return &runtimeBackend{kernel: kernel, images: images, guestInitCache: guestInitCache, networkSwitch: newLinuxVirtualSwitch()}
 }
 
 func (b *runtimeBackend) Start(ctx context.Context, req client.CreateInstanceRequest) (Instance, error) {
@@ -68,7 +69,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
-	network, err := newLinuxAMD64NetworkRuntime(req.ID, req.Network)
+	network, err := newLinuxSwitchNetworkRuntimeOn(b.networkSwitch, req.ID, req.Network, amd64vm.NetBase, amd64vm.NetSize, amd64vm.NetIRQ)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if err != nil {
 		return nil, err
 	}
-	network, err := newLinuxAMD64NetworkRuntime(req.ID, req.Network)
+	network, err := newLinuxAMD64NetworkRuntime(req.ID, req.Network, b.networkSwitch)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +362,7 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 	if err != nil {
 		return client.ExecResponse{}, fmt.Errorf("build guest init: %w", err)
 	}
-	network, err := newLinuxAMD64NetworkRuntime(req.ID, req.Network)
+	network, err := newLinuxAMD64NetworkRuntime(req.ID, req.Network, b.networkSwitch)
 	if err != nil {
 		return client.ExecResponse{}, err
 	}

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -69,7 +69,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
-	network, err := newLinuxSwitchNetworkRuntimeOn(b.networkSwitch, req.ID, req.Network, amd64vm.NetBase, amd64vm.NetSize, amd64vm.NetIRQ)
+	network, err := newLinuxAMD64NetworkRuntime(req.ID, req.Network, b.networkSwitch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/backend_linux_arm64.go
+++ b/internal/vm/backend_linux_arm64.go
@@ -31,10 +31,11 @@ type runtimeBackend struct {
 	kernel         *alpine.Manager
 	images         *oci.Store
 	guestInitCache string
+	networkSwitch  *linuxVirtualSwitch
 }
 
 func NewRuntimeBackend(kernel *alpine.Manager, images *oci.Store, guestInitCache string) Backend {
-	return &runtimeBackend{kernel: kernel, images: images, guestInitCache: guestInitCache}
+	return &runtimeBackend{kernel: kernel, images: images, guestInitCache: guestInitCache, networkSwitch: newLinuxVirtualSwitch()}
 }
 
 func (b *runtimeBackend) Start(ctx context.Context, req client.CreateInstanceRequest) (Instance, error) {

--- a/internal/vm/network_linux.go
+++ b/internal/vm/network_linux.go
@@ -4,9 +4,11 @@ package vm
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/amd64vm"
@@ -17,32 +19,51 @@ import (
 type linuxNetworkRuntime struct {
 	*networkRuntime
 	switchNet *linuxVirtualSwitch
+	rxQueue   chan []byte
+	done      chan struct{}
+	closeOnce sync.Once
+	worker    sync.WaitGroup
+	dropped   atomic.Uint64
 }
 
-func newLinuxAMD64NetworkRuntime(id string, cfg *client.NetworkConfig) (*linuxNetworkRuntime, error) {
+func newLinuxAMD64NetworkRuntime(id string, cfg *client.NetworkConfig, switches ...*linuxVirtualSwitch) (*linuxNetworkRuntime, error) {
 	if cfg == nil || !cfg.Enabled {
 		return nil, nil
 	}
-	return newLinuxSwitchNetworkRuntime(id, cfg, amd64vm.NetBase, amd64vm.NetSize, amd64vm.NetIRQ)
+	return newLinuxSwitchNetworkRuntimeOn(selectLinuxSwitch(switches), id, cfg, amd64vm.NetBase, amd64vm.NetSize, amd64vm.NetIRQ)
 }
 
-func newLinuxARM64NetworkRuntime(id string, cfg *client.NetworkConfig) (*linuxNetworkRuntime, error) {
+func newLinuxARM64NetworkRuntime(id string, cfg *client.NetworkConfig, switches ...*linuxVirtualSwitch) (*linuxNetworkRuntime, error) {
 	if cfg == nil || !cfg.Enabled {
 		return nil, nil
 	}
-	return newLinuxSwitchNetworkRuntime(id, cfg, arm64vm.NetBase, arm64vm.NetSize, arm64vm.NetIRQ)
+	return newLinuxSwitchNetworkRuntimeOn(selectLinuxSwitch(switches), id, cfg, arm64vm.NetBase, arm64vm.NetSize, arm64vm.NetIRQ)
 }
 
-func newLinuxPCINetworkRuntime(id string, cfg *client.NetworkConfig) (*linuxNetworkRuntime, error) {
+func newLinuxPCINetworkRuntime(id string, cfg *client.NetworkConfig, switches ...*linuxVirtualSwitch) (*linuxNetworkRuntime, error) {
 	if cfg == nil || !cfg.Enabled {
 		return nil, nil
 	}
-	return newLinuxSwitchNetworkRuntime(id, cfg, 0, 0x1000, 11)
+	return newLinuxSwitchNetworkRuntimeOn(selectLinuxSwitch(switches), id, cfg, 0, 0x1000, 11)
+}
+
+func selectLinuxSwitch(switches []*linuxVirtualSwitch) *linuxVirtualSwitch {
+	if len(switches) != 0 && switches[0] != nil {
+		return switches[0]
+	}
+	return defaultLinuxVirtualSwitch
 }
 
 func newLinuxSwitchNetworkRuntime(id string, cfg *client.NetworkConfig, base, size uint64, irq uint32) (*linuxNetworkRuntime, error) {
-	lease := defaultLinuxVirtualSwitch.Register(id)
-	runtime := &linuxNetworkRuntime{switchNet: defaultLinuxVirtualSwitch}
+	return newLinuxSwitchNetworkRuntimeOn(newLinuxVirtualSwitch(), id, cfg, base, size, irq)
+}
+
+func newLinuxSwitchNetworkRuntimeOn(switchNet *linuxVirtualSwitch, id string, cfg *client.NetworkConfig, base, size uint64, irq uint32) (*linuxNetworkRuntime, error) {
+	lease, err := switchNet.Register(id, cfg)
+	if err != nil {
+		return nil, err
+	}
+	runtime := &linuxNetworkRuntime{switchNet: switchNet, rxQueue: make(chan []byte, 256), done: make(chan struct{})}
 	common, err := newNetworkRuntime(networkDeviceConfig{
 		ID:     lease.id,
 		Config: cfg,
@@ -52,17 +73,19 @@ func newLinuxSwitchNetworkRuntime(id string, cfg *client.NetworkConfig, base, si
 		Size:   size,
 		IRQ:    irq,
 		TXHook: func(packet []byte) {
-			defaultLinuxVirtualSwitch.Forward(runtime, packet)
+			switchNet.Forward(runtime, packet)
 		},
 		Cleanup: func() {
-			defaultLinuxVirtualSwitch.Unregister(lease.id)
+			switchNet.Unregister(lease.id)
 		},
 	})
 	if err != nil {
 		return nil, err
 	}
 	runtime.networkRuntime = common
-	defaultLinuxVirtualSwitch.Attach(runtime)
+	switchNet.Attach(runtime)
+	runtime.worker.Add(1)
+	go runtime.runRX()
 	return runtime, nil
 }
 
@@ -74,6 +97,7 @@ func (n *linuxNetworkRuntime) Close() error {
 		n.switchNet.Unregister(n.id)
 		n.switchNet = nil
 	}
+	n.closeOnce.Do(func() { close(n.done); n.worker.Wait() })
 	if n.networkRuntime == nil {
 		return nil
 	}
@@ -113,14 +137,15 @@ type linuxNetworkLease struct {
 	mac net.HardwareAddr
 }
 
-var defaultLinuxVirtualSwitch = &linuxVirtualSwitch{
-	leases:    make(map[string]linuxNetworkLease),
-	endpoints: make(map[string]*linuxNetworkRuntime),
+func newLinuxVirtualSwitch() *linuxVirtualSwitch {
+	return &linuxVirtualSwitch{leases: make(map[string]linuxNetworkLease), endpoints: make(map[string]*linuxNetworkRuntime)}
 }
 
-func (s *linuxVirtualSwitch) Register(id string) linuxNetworkLease {
+var defaultLinuxVirtualSwitch = newLinuxVirtualSwitch()
+
+func (s *linuxVirtualSwitch) Register(id string, cfg ...*client.NetworkConfig) (linuxNetworkLease, error) {
 	if s == nil {
-		return linuxNetworkLease{id: id, ip: net.IPv4(10, 42, 0, 2), mac: net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0x00, 0x02}}
+		return linuxNetworkLease{}, fmt.Errorf("network switch is required")
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -128,6 +153,30 @@ func (s *linuxVirtualSwitch) Register(id string) linuxNetworkLease {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	var requested *client.NetworkConfig
+	if len(cfg) != 0 {
+		requested = cfg[0]
+	}
+	if requested != nil && (strings.TrimSpace(requested.GuestIPv4) != "" || strings.TrimSpace(requested.GuestMAC) != "") {
+		ip := net.ParseIP(strings.TrimSpace(requested.GuestIPv4)).To4()
+		mac, err := net.ParseMAC(strings.TrimSpace(requested.GuestMAC))
+		if ip == nil || err != nil || len(mac) != 6 {
+			return linuxNetworkLease{}, fmt.Errorf("explicit network identity requires valid guest_ipv4 and guest_mac")
+		}
+		for otherID, lease := range s.leases {
+			if otherID != id && (lease.ip.Equal(ip) || bytesEqualMAC(lease.mac, mac)) {
+				return linuxNetworkLease{}, fmt.Errorf("network identity conflicts with VM %q", otherID)
+			}
+		}
+		for otherID, endpoint := range s.endpoints {
+			if otherID != id && endpoint != nil && (endpoint.ip.Equal(ip) || bytesEqualMAC(endpoint.mac, mac)) {
+				return linuxNetworkLease{}, fmt.Errorf("network identity conflicts with VM %q", otherID)
+			}
+		}
+		lease := linuxNetworkLease{id: id, ip: append(net.IP(nil), ip...), mac: append(net.HardwareAddr(nil), mac...)}
+		s.leases[id] = lease
+		return lease, nil
+	}
 
 	used := map[byte]bool{1: true}
 	for _, lease := range s.leases {
@@ -157,7 +206,7 @@ func (s *linuxVirtualSwitch) Register(id string) linuxNetworkLease {
 		s.leases = make(map[string]linuxNetworkLease)
 	}
 	s.leases[id] = lease
-	return lease
+	return lease, nil
 }
 
 func (s *linuxVirtualSwitch) Attach(endpoint *linuxNetworkRuntime) {
@@ -271,13 +320,36 @@ func (s *linuxVirtualSwitch) forwardToAll(sourceID string, frame []byte) {
 }
 
 func (n *linuxNetworkRuntime) enqueueSwitchFrame(frame []byte) {
-	if n == nil || n.dev == nil {
+	if n == nil {
 		return
 	}
 	copied := append([]byte(nil), frame...)
-	go func() {
-		_ = n.dev.EnqueueRxPacketOwned(copied)
-	}()
+	select {
+	case n.rxQueue <- copied:
+	default:
+		n.dropped.Add(1)
+	}
+}
+
+func (n *linuxNetworkRuntime) runRX() {
+	defer n.worker.Done()
+	for {
+		select {
+		case frame := <-n.rxQueue:
+			if n.dev != nil {
+				_ = n.dev.EnqueueRxPacketOwned(frame)
+			}
+		case <-n.done:
+			return
+		}
+	}
+}
+
+func (n *linuxNetworkRuntime) DroppedFrames() uint64 {
+	if n == nil {
+		return 0
+	}
+	return n.dropped.Load()
 }
 
 func isLinuxBroadcastMAC(mac net.HardwareAddr) bool {

--- a/internal/vm/network_linux_test.go
+++ b/internal/vm/network_linux_test.go
@@ -3,6 +3,7 @@
 package vm
 
 import (
+	"bytes"
 	"testing"
 
 	"j5.nz/cc/client"
@@ -11,9 +12,9 @@ import (
 func TestLinuxVirtualSwitchAllocatesDistinctLeases(t *testing.T) {
 	defaultLinuxVirtualSwitch.Unregister("freebsd")
 	defaultLinuxVirtualSwitch.Unregister("openbsd")
-	leaseA := defaultLinuxVirtualSwitch.Register("freebsd")
+	leaseA := mustRegisterLinuxLease(t, defaultLinuxVirtualSwitch, "freebsd", nil)
 	t.Cleanup(func() { defaultLinuxVirtualSwitch.Unregister(leaseA.id) })
-	leaseB := defaultLinuxVirtualSwitch.Register("openbsd")
+	leaseB := mustRegisterLinuxLease(t, defaultLinuxVirtualSwitch, "openbsd", nil)
 	t.Cleanup(func() { defaultLinuxVirtualSwitch.Unregister(leaseB.id) })
 
 	if got := leaseA.ip.String(); got != "10.42.0.2" {
@@ -28,6 +29,45 @@ func TestLinuxVirtualSwitchAllocatesDistinctLeases(t *testing.T) {
 	if got := leaseB.mac.String(); got != "02:42:0a:2a:00:03" {
 		t.Fatalf("second lease MAC = %s, want 02:42:0a:2a:00:03", got)
 	}
+}
+
+func TestLinuxSwitchHonorsExplicitIdentityAndScopesConflicts(t *testing.T) {
+	cfg := &client.NetworkConfig{Enabled: true, GuestIPv4: "10.42.0.77", GuestMAC: "02:42:0a:2a:00:4d"}
+	firstDomain := newLinuxVirtualSwitch()
+	lease := mustRegisterLinuxLease(t, firstDomain, "one", cfg)
+	if lease.ip.String() != cfg.GuestIPv4 || lease.mac.String() != cfg.GuestMAC {
+		t.Fatalf("lease = %s/%s, want %s/%s", lease.ip, lease.mac, cfg.GuestIPv4, cfg.GuestMAC)
+	}
+	if _, err := firstDomain.Register("two", cfg); err == nil {
+		t.Fatal("duplicate explicit identity was accepted in one domain")
+	}
+	secondDomain := newLinuxVirtualSwitch()
+	other := mustRegisterLinuxLease(t, secondDomain, "two", cfg)
+	if !other.ip.Equal(lease.ip) || !bytes.Equal(other.mac, lease.mac) {
+		t.Fatalf("isolated domain identity = %s/%s", other.ip, other.mac)
+	}
+}
+
+func TestLinuxEndpointQueueIsBoundedFIFO(t *testing.T) {
+	runtime := &linuxNetworkRuntime{rxQueue: make(chan []byte, 2)}
+	runtime.enqueueSwitchFrame([]byte{1})
+	runtime.enqueueSwitchFrame([]byte{2})
+	runtime.enqueueSwitchFrame([]byte{3})
+	if runtime.DroppedFrames() != 1 {
+		t.Fatalf("dropped frames = %d, want 1", runtime.DroppedFrames())
+	}
+	if first, second := <-runtime.rxQueue, <-runtime.rxQueue; !bytes.Equal(first, []byte{1}) || !bytes.Equal(second, []byte{2}) {
+		t.Fatalf("queued frames = %v, %v", first, second)
+	}
+}
+
+func mustRegisterLinuxLease(t *testing.T, s *linuxVirtualSwitch, id string, cfg *client.NetworkConfig) linuxNetworkLease {
+	t.Helper()
+	lease, err := s.Register(id, cfg)
+	if err != nil {
+		t.Fatalf("register lease: %v", err)
+	}
+	return lease
 }
 
 func TestLinuxPCINetworkRuntimeAttachesToVirtualSwitch(t *testing.T) {


### PR DESCRIPTION
Fixes #98
Fixes #99
Fixes #100

## Summary
- create one Linux virtual switch per runtime backend/security domain instead of a process singleton
- preserve manager-selected explicit guest IP/MAC values and reject duplicate IP or MAC within a domain
- use one FIFO receive worker and a 256-frame bounded queue per endpoint instead of one goroutine per packet
- drop newest on overload and expose an atomic endpoint drop counter
- stop endpoint workers and unregister all switch state during teardown

Separate managers may use the same identities because their switches are isolated. Shared L2 is intentionally not implicit; a future explicit domain API can pass a shared switch deliberately.

## Validation
- `go test ./...` on Darwin/arm64
- `GOOS=linux GOARCH=amd64 go test -c ./internal/vm`
- `GOOS=linux GOARCH=arm64 go test -c ./internal/vm`
- Linux behavior tests for identity conflicts/domain isolation and bounded FIFO/drop accounting

Full packet-path validation requires a Linux KVM host with `/dev/kvm`; GitHub Linux CI executes the platform tests, while a hardware boot/traffic run can be added if CI exposes KVM.