### PR TITLE
Retain VM exit status and crash diagnostics

### DIFF
--- a/client/protocol.go
+++ b/client/protocol.go
@@ -391,6 +391,8 @@ type InstanceState struct {
 	StartedAt   string `json:"started_at,omitempty"`
 	NetworkIPv4 string `json:"network_ipv4,omitempty"`
 	Error       string `json:"error,omitempty"`
+	ExitedAt    string `json:"exited_at,omitempty"`
+	ExitReason  string `json:"exit_reason,omitempty"`
 }
 
 type ConsoleHistoryResponse struct {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2,10 +2,12 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/imagefs"
@@ -115,6 +117,38 @@ func TestManagerBlankStartRemembersImageForRunIn(t *testing.T) {
 	if got := host.runInCalls(); len(got) != 1 || got[0].runningImage != "ubuntu" || got[0].req.Image != "ubuntu" {
 		t.Fatalf("run-in calls = %+v", got)
 	}
+}
+
+func TestManagerRetainsCrashStatusUntilNextGeneration(t *testing.T) {
+	host := newFakeHost(VMHostCapabilities{MaxVMs: 2})
+	crashed := newFakeInstance()
+	crashed.waitErr = errors.New("hypervisor exited")
+	host.queueInstance(crashed)
+	manager := testManager(host)
+	if _, err := manager.Start(context.Background(), client.CreateInstanceRequest{ID: "alpha", Image: "alpine", MemoryMB: 256, CPUs: 1}); err != nil {
+		t.Fatalf("start crashing instance: %v", err)
+	}
+	_ = crashed.Close()
+	deadline := time.Now().Add(time.Second)
+	var state client.InstanceState
+	for time.Now().Before(deadline) {
+		state = manager.StatusOf("alpha")
+		if state.Status == "crashed" {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if state.Status != "crashed" || state.ExitReason != "hypervisor exited" || state.ExitedAt == "" || state.StartedAt == "" {
+		t.Fatalf("crash state = %+v", state)
+	}
+	host.queueInstance(newFakeInstance())
+	if _, err := manager.Start(context.Background(), client.CreateInstanceRequest{ID: "alpha", Image: "alpine", MemoryMB: 256, CPUs: 1}); err != nil {
+		t.Fatalf("start replacement instance: %v", err)
+	}
+	if state := manager.StatusOf("alpha"); state.Status != "running" || state.ExitReason != "" || state.ExitedAt != "" {
+		t.Fatalf("replacement state = %+v", state)
+	}
+	_ = manager.ShutdownAll(context.Background())
 }
 
 func TestManagerBlankSnapshotStartKeepsSharesInStartRequest(t *testing.T) {
@@ -539,6 +573,7 @@ type fakeInstance struct {
 	stats          []virtio.FSStats
 	ipv4           string
 	execStream     func(client.ExecRequest, func(client.ExecEvent) error) error
+	waitErr        error
 }
 
 func newFakeInstance() *fakeInstance {
@@ -582,7 +617,7 @@ func (i *fakeInstance) ExecStream(_ context.Context, req client.ExecRequest, _ <
 
 func (i *fakeInstance) Wait() error {
 	<-i.done
-	return nil
+	return i.waitErr
 }
 
 func (i *fakeInstance) Close() error {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -20,6 +20,7 @@ import (
 )
 
 const DefaultInstanceID = "default"
+const maxExitTombstones = 64
 
 type Backend = vmhost.Backend
 
@@ -67,6 +68,7 @@ type Manager struct {
 	running       map[string]*Machine
 	starting      map[string]struct{}
 	networkLeases map[string]managerNetworkLease
+	exited        map[string]client.InstanceState
 }
 
 type Machine struct {
@@ -230,6 +232,7 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
+	delete(m.exited, id)
 	m.starting[id] = struct{}{}
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
@@ -314,6 +317,7 @@ func (m *Manager) StartBlankInstanceStream(
 		m.mu.Unlock()
 		return client.InstanceState{}, err
 	}
+	delete(m.exited, id)
 	m.starting[id] = struct{}{}
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
@@ -676,12 +680,24 @@ func (m *Manager) VirtioFSStats(id string) []virtio.FSStats {
 func (m *Manager) Statuses() []client.InstanceState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m.running) == 0 {
+	if len(m.running) == 0 && len(m.starting) == 0 && len(m.exited) == 0 {
 		return nil
 	}
-	ids := make([]string, 0, len(m.running))
+	ids := make([]string, 0, len(m.running)+len(m.starting)+len(m.exited))
 	for id := range m.running {
 		ids = append(ids, id)
+	}
+	for id := range m.starting {
+		if m.running[id] == nil {
+			ids = append(ids, id)
+		}
+	}
+	for id := range m.exited {
+		if m.running[id] == nil {
+			if _, starting := m.starting[id]; !starting {
+				ids = append(ids, id)
+			}
+		}
 	}
 	sort.Strings(ids)
 	out := make([]client.InstanceState, 0, len(ids))
@@ -705,6 +721,9 @@ func (m *Manager) statusLocked(id string) client.InstanceState {
 			if _, ok := m.starting[id]; ok {
 				return client.InstanceState{ID: id, Status: "starting"}
 			}
+		}
+		if state, ok := m.exited[id]; ok {
+			return state
 		}
 		return client.InstanceState{ID: id, Status: "stopped"}
 	}
@@ -739,6 +758,29 @@ func (m *Manager) watch(machine *Machine) {
 	delete(m.networkLeases, machine.id)
 	machine.lastErr = err
 	machine.exitedAt = time.Now().UTC()
+	if m.exited == nil {
+		m.exited = make(map[string]client.InstanceState)
+	}
+	state := client.InstanceState{ID: machine.id, Status: "stopped", Image: machine.image, InitSystem: machine.initSystem, Kernel: machine.kernel, MemoryMB: machine.memoryMB, BalloonMB: machine.balloonMB, CPUs: machine.cpus, NestedVirt: machine.nestedVirt, StartedAt: machine.startedAt.Format(time.RFC3339), ExitedAt: machine.exitedAt.Format(time.RFC3339)}
+	if err != nil {
+		state.Status = "crashed"
+		state.Error = err.Error()
+		state.ExitReason = err.Error()
+	} else {
+		state.ExitReason = "clean shutdown"
+	}
+	m.exited[machine.id] = state
+	for len(m.exited) > maxExitTombstones {
+		var oldestID string
+		var oldest time.Time
+		for id, candidate := range m.exited {
+			at, _ := time.Parse(time.RFC3339, candidate.ExitedAt)
+			if oldestID == "" || at.Before(oldest) {
+				oldestID, oldest = id, at
+			}
+		}
+		delete(m.exited, oldestID)
+	}
 }
 
 func (m *Manager) checkCapacityLocked() error {


### PR DESCRIPTION
Fixes #94

## Summary
- retain structured terminal instance state after a backend exits
- distinguish clean `stopped` generations from `crashed` generations
- report start time, exit time, and terminal reason/error
- include tombstones in instance status listings
- bound history to the documented 64-instance backend envelope and discard an old tombstone before the same ID starts again

## Validation
- `go test ./internal/vm`
- `go test ./...`
- behavior coverage for crash retention and same-ID generation replacement

No special hardware is required.