### PR TITLE
Make worker operations concurrent and cancellable

### DIFF
--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -517,6 +517,86 @@ type workerActiveExec struct {
 	closed bool
 }
 
+type workerOperationRegistry struct {
+	mu      sync.Mutex
+	active  map[uint64]context.CancelFunc
+	vmTails map[string]chan struct{}
+}
+
+func newWorkerOperationRegistry() *workerOperationRegistry {
+	return &workerOperationRegistry{
+		active:  make(map[uint64]context.CancelFunc),
+		vmTails: make(map[string]chan struct{}),
+	}
+}
+
+func (r *workerOperationRegistry) start(frameID uint64, vmID string, run func(context.Context)) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var previous <-chan struct{}
+	var done chan struct{}
+	r.mu.Lock()
+	r.active[frameID] = cancel
+	if vmID != "" {
+		previous = r.vmTails[vmID]
+		done = make(chan struct{})
+		r.vmTails[vmID] = done
+	}
+	r.mu.Unlock()
+
+	go func() {
+		defer cancel()
+		defer func() {
+			r.mu.Lock()
+			delete(r.active, frameID)
+			if done != nil {
+				close(done)
+				if r.vmTails[vmID] == done {
+					delete(r.vmTails, vmID)
+				}
+			}
+			r.mu.Unlock()
+		}()
+		if previous != nil {
+			select {
+			case <-previous:
+			case <-ctx.Done():
+				return
+			}
+		}
+		run(ctx)
+	}()
+}
+
+func (r *workerOperationRegistry) cancel(frameID uint64) bool {
+	r.mu.Lock()
+	cancel := r.active[frameID]
+	r.mu.Unlock()
+	if cancel == nil {
+		return false
+	}
+	cancel()
+	return true
+}
+
+func (r *workerOperationRegistry) close() {
+	r.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(r.active))
+	for _, cancel := range r.active {
+		cancels = append(cancels, cancel)
+	}
+	r.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+func workerVMKey(id string) string {
+	if id == "" {
+		return vm.DefaultInstanceID
+	}
+	return id
+}
+
 func (e *workerActiveExec) closeInputs() {
 	if e == nil || e.inputs == nil {
 		return
@@ -579,6 +659,8 @@ func (e *workerActiveExec) forwardInputs() {
 func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOptions) error {
 	var activeMu sync.Mutex
 	activeExecs := make(map[uint64]*workerActiveExec)
+	operations := newWorkerOperationRegistry()
+	defer operations.close()
 
 	for {
 		frame, err := codec.Receive()
@@ -601,14 +683,16 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 					continue
 				}
 			}
-			state, err := srvState.vms.StartStream(context.Background(), req, func(event client.BootEvent) error {
-				return sendWorkerPayload(codec, frame.ID, vm.WorkerFrameEvent, event)
+			operations.start(frame.ID, workerVMKey(req.ID), func(ctx context.Context) {
+				state, err := srvState.vms.StartStream(ctx, req, func(event client.BootEvent) error {
+					return sendWorkerPayload(codec, frame.ID, vm.WorkerFrameEvent, event)
+				})
+				if err != nil {
+					_ = sendWorkerError(codec, frame.ID, err)
+					return
+				}
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStartResponse{State: state})
 			})
-			if err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
-				continue
-			}
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStartResponse{State: state})
 		case vm.WorkerFrameStartBlank:
 			var req client.StartInstanceRequest
 			if err := frame.DecodePayload(&req); err != nil {
@@ -621,58 +705,72 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 					continue
 				}
 			}
-			state, err := srvState.vms.StartBlankStream(context.Background(), req, func(event client.BootEvent) error {
-				return sendWorkerPayload(codec, frame.ID, vm.WorkerFrameEvent, event)
+			operations.start(frame.ID, workerVMKey(req.ID), func(ctx context.Context) {
+				state, err := srvState.vms.StartBlankStream(ctx, req, func(event client.BootEvent) error {
+					return sendWorkerPayload(codec, frame.ID, vm.WorkerFrameEvent, event)
+				})
+				if err != nil {
+					_ = sendWorkerError(codec, frame.ID, err)
+					return
+				}
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStartResponse{State: state})
 			})
-			if err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
-				continue
-			}
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStartResponse{State: state})
 		case vm.WorkerFrameStatus:
 			var req vm.WorkerStatusRequest
 			_ = frame.DecodePayload(&req)
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: srvState.vms.StatusOf(req.ID)})
+			operations.start(frame.ID, "", func(context.Context) {
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: srvState.vms.StatusOf(req.ID)})
+			})
 		case vm.WorkerFrameStop:
 			var req vm.WorkerStopRequest
 			_ = frame.DecodePayload(&req)
-			if err := srvState.vms.ShutdownInstance(context.Background(), req.ID); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
-				continue
-			}
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: srvState.vms.StatusOf(req.ID)})
+			operations.start(frame.ID, workerVMKey(req.ID), func(ctx context.Context) {
+				if err := srvState.vms.ShutdownInstance(ctx, req.ID); err != nil {
+					_ = sendWorkerError(codec, frame.ID, err)
+					return
+				}
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: srvState.vms.StatusOf(req.ID)})
+			})
 		case vm.WorkerFrameWait:
 			var req vm.WorkerWaitRequest
 			_ = frame.DecodePayload(&req)
-			go serveWorkerWait(codec, srvState, frame.ID, req.ID)
+			operations.start(frame.ID, "", func(ctx context.Context) {
+				serveWorkerWait(ctx, codec, srvState, frame.ID, req.ID)
+			})
 		case vm.WorkerFrameFlush:
 			var req vm.WorkerFlushRequest
 			_ = frame.DecodePayload(&req)
-			if err := srvState.vms.FlushInstance(context.Background(), req.ID); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
-				continue
-			}
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "flushed"})
+			operations.start(frame.ID, workerVMKey(req.ID), func(ctx context.Context) {
+				if err := srvState.vms.FlushInstance(ctx, req.ID); err != nil {
+					_ = sendWorkerError(codec, frame.ID, err)
+					return
+				}
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "flushed"})
+			})
 		case vm.WorkerFrameAddShare:
 			var req vm.WorkerAddShareRequest
 			if err := frame.DecodePayload(&req); err != nil {
 				_ = sendWorkerError(codec, frame.ID, err)
 				continue
 			}
-			if err := srvState.vms.AddShareTo(context.Background(), req.ID, req.Share); err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
-				continue
-			}
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "mounted"})
+			operations.start(frame.ID, workerVMKey(req.ID), func(ctx context.Context) {
+				if err := srvState.vms.AddShareTo(ctx, req.ID, req.Share); err != nil {
+					_ = sendWorkerError(codec, frame.ID, err)
+					return
+				}
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, map[string]string{"status": "mounted"})
+			})
 		case vm.WorkerFrameConsole:
 			var req vm.WorkerConsoleRequest
 			_ = frame.DecodePayload(&req)
-			history, err := srvState.vms.ConsoleHistory(context.Background(), req.ID)
-			if err != nil {
-				_ = sendWorkerError(codec, frame.ID, err)
-				continue
-			}
-			_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerConsoleResponse{History: history})
+			operations.start(frame.ID, "", func(ctx context.Context) {
+				history, err := srvState.vms.ConsoleHistory(ctx, req.ID)
+				if err != nil {
+					_ = sendWorkerError(codec, frame.ID, err)
+					return
+				}
+				_ = sendWorkerPayload(codec, frame.ID, vm.WorkerFrameDone, vm.WorkerConsoleResponse{History: history})
+			})
 		case vm.WorkerFrameExec:
 			if err := serveWorkerExec(codec, srvState, frame, &activeMu, activeExecs); err != nil {
 				_ = sendWorkerError(codec, frame.ID, err)
@@ -697,6 +795,7 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 				_ = sendWorkerError(codec, frame.ID, fmt.Errorf("worker exec input queue is full"))
 			}
 		case vm.WorkerFrameCancel:
+			operations.cancel(frame.ID)
 			activeMu.Lock()
 			exec := activeExecs[frame.ID]
 			activeMu.Unlock()
@@ -710,7 +809,7 @@ func serveWorkerControl(codec *vm.WorkerCodec, srvState *server, opts ServerOpti
 	}
 }
 
-func serveWorkerWait(codec *vm.WorkerCodec, srvState *server, frameID uint64, id string) {
+func serveWorkerWait(ctx context.Context, codec *vm.WorkerCodec, srvState *server, frameID uint64, id string) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -719,7 +818,11 @@ func serveWorkerWait(codec *vm.WorkerCodec, srvState *server, frameID uint64, id
 			_ = sendWorkerPayload(codec, frameID, vm.WorkerFrameDone, vm.WorkerStatusResponse{State: state})
 			return
 		}
-		<-ticker.C
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/internal/ccvmd/worker_operations_test.go
+++ b/internal/ccvmd/worker_operations_test.go
@@ -1,0 +1,48 @@
+package ccvmd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWorkerOperationsRemainResponsiveAndSerializeOneVM(t *testing.T) {
+	operations := newWorkerOperationRegistry()
+	defer operations.close()
+
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	operations.start(1, "alpha", func(ctx context.Context) {
+		close(firstStarted)
+		<-ctx.Done()
+		close(firstCanceled)
+	})
+	awaitWorkerOperation(t, firstStarted, "first operation start")
+
+	secondStarted := make(chan struct{})
+	operations.start(2, "alpha", func(context.Context) { close(secondStarted) })
+	unrelatedStarted := make(chan struct{})
+	operations.start(3, "", func(context.Context) { close(unrelatedStarted) })
+
+	awaitWorkerOperation(t, unrelatedStarted, "unrelated operation while start is blocked")
+	select {
+	case <-secondStarted:
+		t.Fatal("conflicting operation started before the first operation completed")
+	default:
+	}
+
+	if !operations.cancel(1) {
+		t.Fatal("active operation was not cancellable")
+	}
+	awaitWorkerOperation(t, firstCanceled, "cancellation reaching operation context")
+	awaitWorkerOperation(t, secondStarted, "queued same-VM operation after cancellation")
+}
+
+func awaitWorkerOperation(t *testing.T, ch <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}


### PR DESCRIPTION
Fixes #67

## Summary
- dispatch worker lifecycle and read operations without blocking the frame reader
- give each request a cancellable context and route cancel frames to lifecycle work as well as execs
- preserve FIFO ordering only for conflicting mutations of the same VM
- keep status, console, wait, and unrelated VM operations responsive

Cancellation produces the normal terminal backend error if the caller is still listening; a caller that canceled may safely discard it. Requests queued behind a same-VM mutation are removed without running when canceled.

## Validation
- `go test -race ./internal/ccvmd`
- `go test ./...` (one unrelated service-proxy guest test timed out; its exact retry passed)
- `go test ./internal/vm -run "^TestRuntimeIsolatedRunningGuestCanReachDynamicallyAllowedServiceProxyPort$" -count=1`

No special hardware is required.