### PR TITLE
Add Linux KVM arm64 startup snapshots

### DIFF
--- a/internal/arm64vm/boot.go
+++ b/internal/arm64vm/boot.go
@@ -34,6 +34,9 @@ func BootCommandLine(dmesg bool, serialConsole bool) string {
 		"panic=-1",
 		"rdinit=/init",
 	}
+	if !dmesg {
+		args = append(args, "quiet")
+	}
 	if serialConsole {
 		args = append([]string{"console=ttyS0,115200n8"}, args...)
 	}

--- a/internal/hv/kvm/abi_linux_arm64.go
+++ b/internal/hv/kvm/abi_linux_arm64.go
@@ -101,3 +101,7 @@ type kvmOneReg struct {
 	id   uint64
 	addr uint64
 }
+
+type kvmRegList struct {
+	n uint64
+}

--- a/internal/hv/kvm/bindings_linux_arm64.go
+++ b/internal/hv/kvm/bindings_linux_arm64.go
@@ -16,11 +16,13 @@ const (
 	kvmRun                 = 0xae80
 	kvmGetOneReg           = 0x4010aeab
 	kvmSetOneReg           = 0x4010aeac
+	kvmGetRegList          = 0xc008aeb0
 	kvmArmVCPUInit         = 0x4020aeae
 	kvmArmPrefTarget       = 0x8020aeaf
 	kvmIRQLine             = 0x4008ae61
 	kvmCreateDevice        = 0xc00caee0
 	kvmSetDeviceAttr       = 0x4018aee1
+	kvmGetDeviceAttr       = 0x4018aee2
 	kvmEnableCap           = 0x4068aea3
 )
 
@@ -31,9 +33,13 @@ const (
 	kvmDevTypeArmVgicV2 = 5
 	kvmDevTypeArmVgicV3 = 7
 
-	kvmDevArmVgicGrpAddr   = 0
-	kvmDevArmVgicGrpNrIrqs = 3
-	kvmDevArmVgicGrpCtrl   = 4
+	kvmDevArmVgicGrpAddr       = 0
+	kvmDevArmVgicGrpDistRegs   = 1
+	kvmDevArmVgicGrpCPURegs    = 2
+	kvmDevArmVgicGrpNrIrqs     = 3
+	kvmDevArmVgicGrpCtrl       = 4
+	kvmDevArmVgicGrpRedistRegs = 5
+	kvmDevArmVgicGrpCPUSysRegs = 6
 
 	kvmDevArmVgicCtrlInit = 0
 
@@ -127,6 +133,28 @@ func createDevice(fd int, dev *kvmCreateDeviceArgs) error {
 func setDeviceAttr(fd int, attr *kvmDeviceAttr) error {
 	_, err := ioctlWithRetry(uintptr(fd), uint64(kvmSetDeviceAttr), uintptr(unsafe.Pointer(attr)))
 	return err
+}
+
+func getDeviceAttr(fd int, attr *kvmDeviceAttr) error {
+	_, err := ioctlWithRetry(uintptr(fd), uint64(kvmGetDeviceAttr), uintptr(unsafe.Pointer(attr)))
+	return err
+}
+
+func getRegList(vcpuFd int) ([]uint64, error) {
+	header := kvmRegList{}
+	_, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetRegList), uintptr(unsafe.Pointer(&header)))
+	if err != nil && err != unix.E2BIG {
+		return nil, err
+	}
+	if header.n == 0 {
+		return nil, nil
+	}
+	buf := make([]uint64, header.n+1)
+	buf[0] = header.n
+	if _, err := ioctlWithRetry(uintptr(vcpuFd), uint64(kvmGetRegList), uintptr(unsafe.Pointer(&buf[0]))); err != nil {
+		return nil, err
+	}
+	return buf[1:], nil
 }
 
 func irqLevel(vmFd int, irqLine uint32, level bool) error {

--- a/internal/hv/kvm/exec_linux_arm64.go
+++ b/internal/hv/kvm/exec_linux_arm64.go
@@ -4,10 +4,14 @@ package kvm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"sync"
+
+	"golang.org/x/sys/unix"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/arm64vm"
@@ -187,17 +191,51 @@ func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, mem
 }
 
 func runManagedExecVM(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript) error {
+	return runManagedExecVMWithSnapshot(ctx, vm, uart, fsdevs, vsock, rng, serialOut, nil)
+}
+
+func runManagedExecVMWithSnapshot(ctx context.Context, vm *VM, uart *serial.UART8250, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, serialOut *vmruntime.SerialTranscript, snapshot *snapshotTrigger) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	vm.SetVCPUTID(unix.Gettid())
+	defer vm.SetVCPUTID(0)
+	cancelDone := make(chan struct{})
+	defer close(cancelDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			vm.RequestImmediateExit()
+		case <-cancelDone:
+		}
+	}()
+
 	var exit Exit
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := vm.Run(&exit); err != nil {
+		if err := vm.RunInterruptible(&exit); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
 			return fmt.Errorf("run step %d: %w", step, err)
 		}
 		switch exit.Reason {
 		case ExitMMIO:
-			if err := handleBootMMIO(vm, uart, fsdevs, vsock, rng, exit.MMIO); err != nil {
+			handled, err := snapshot.handleMMIO(vm, exit.MMIO)
+			if err != nil {
+				return err
+			}
+			if !handled {
+				err = handleBootMMIO(vm, uart, fsdevs, vsock, rng, exit.MMIO)
+			}
+			if err != nil {
+				return err
+			}
+			if err := snapshot.captureIfPending(vm, fsdevs, vsock, rng); err != nil {
 				return err
 			}
 		case ExitShutdown:

--- a/internal/hv/kvm/session_linux_arm64.go
+++ b/internal/hv/kvm/session_linux_arm64.go
@@ -10,12 +10,14 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/arm64vm"
 	"j5.nz/cc/internal/fdt"
 	managedagent "j5.nz/cc/internal/managed/agent"
 	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/timing"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
 )
@@ -36,6 +38,7 @@ type ManagedSession struct {
 }
 
 func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	stageStart := time.Now()
 	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
 		return nil, err
 	}
@@ -66,14 +69,19 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 			nodes = append(nodes, fsdev.DeviceTreeNode())
 		}
 	}
+	timing.Since(ctx, "startup.kvm.host_devices", stageStart)
 
+	stageStart = time.Now()
 	vm, err := NewVM()
+	timing.Since(ctx, "startup.kvm.vm_create", stageStart)
 	if err != nil {
 		_ = listener.Close()
 		vsock.Close()
 		return nil, err
 	}
+	stageStart = time.Now()
 	mem, err := vm.MapAnonymousMemory(arm64vm.MemorySizeBytes(memoryMB), arm64vm.MemoryBase)
+	timing.Since(ctx, "startup.kvm.memory_map", stageStart)
 	if err != nil {
 		closeVMWithFS(vm, fsdevs)
 		_ = listener.Close()
@@ -81,6 +89,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		return nil, fmt.Errorf("map guest memory: %w", err)
 	}
 
+	stageStart = time.Now()
 	serialOut := vmruntime.NewSerialTranscript()
 	var serialWriter io.Writer = serialOut
 	var bootWriter *vmruntime.BootEventWriter
@@ -97,13 +106,19 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 	}
 	vsock.Attach(vm, vm)
 	rng.Attach(vm, vm)
+	timing.Since(ctx, "startup.kvm.device_attach", stageStart)
 
+	stageStart = time.Now()
 	plan, err := arm64vm.PrepareBoot(mem, kernel, initrd, arm64vm.BootConfig{
 		MemoryMB:   memoryMB,
 		GICVersion: arm64vm.GICVersionV2,
 		Dmesg:      dmesg,
 		ExtraNodes: nodes,
+		RecordTime: func(name string, duration time.Duration) {
+			timing.Record(ctx, "startup.kvm.boot_prepare."+name, duration)
+		},
 	})
+	timing.Since(ctx, "startup.kvm.boot_prepare", stageStart)
 	if err != nil {
 		closeVMWithFS(vm, fsdevs)
 		_ = listener.Close()
@@ -123,6 +138,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		return nil, err
 	}
 
+	stageStart = time.Now()
 	runCtx, cancel := context.WithCancel(context.Background())
 	done := newSessionDone()
 	go func() {
@@ -161,7 +177,9 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		}
 		return nil, transcriptError(ctx.Err(), serialOut.String(), controlTranscript.String())
 	}
+	timing.Since(ctx, "startup.kvm.vcpu_to_control", stageStart)
 
+	stageStart = time.Now()
 	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
 		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
 	}); err != nil {
@@ -174,6 +192,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		}
 		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
 	}
+	timing.Since(ctx, "startup.kvm.control_to_ready", stageStart)
 	if vmruntime.HasFatalBootText(controlTranscript.String()) {
 		cancel()
 		_ = control.Close()

--- a/internal/hv/kvm/session_linux_arm64.go
+++ b/internal/hv/kvm/session_linux_arm64.go
@@ -37,7 +37,19 @@ type ManagedSession struct {
 	dmesg      bool
 }
 
+type ManagedSessionOptions struct {
+	SnapshotDir     string
+	RestoreSnapshot string
+}
+
 func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithOptions(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, ManagedSessionOptions{}, onEvent)
+}
+
+func StartManagedSessionWithOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if snapshotPath := strings.TrimSpace(opts.RestoreSnapshot); snapshotPath != "" {
+		return StartManagedSessionFromSnapshot(ctx, snapshotPath, memoryMB, dmesg, fsdevs, onEvent)
+	}
 	stageStart := time.Now()
 	if err := emitManagedBootStatus(onEvent, "starting VM"); err != nil {
 		return nil, err
@@ -64,6 +76,10 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 	}()
 
 	nodes := []fdt.Node{vsock.DeviceTreeNode(), rng.DeviceTreeNode()}
+	snapshot := newSnapshotTrigger(opts.SnapshotDir, nil)
+	if snapshot != nil {
+		nodes = append(nodes, arm64vm.SnapshotDeviceNode())
+	}
 	for _, fsdev := range fsdevs {
 		if fsdev != nil {
 			nodes = append(nodes, fsdev.DeviceTreeNode())
@@ -88,6 +104,9 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		vsock.Close()
 		return nil, fmt.Errorf("map guest memory: %w", err)
 	}
+	if snapshot != nil {
+		snapshot.mem = mem
+	}
 
 	stageStart = time.Now()
 	serialOut := vmruntime.NewSerialTranscript()
@@ -97,6 +116,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = io.MultiWriter(serialOut, bootWriter)
 	}
+	serialWriter = snapshot.wrapSerialWriter(serialWriter)
 	uart := serial.NewUART8250(arm64vm.DefaultUARTBase, arm64vm.DefaultUARTRegShift, serialWriter)
 	uart.AttachIRQ(vm, arm64vm.UARTSPI)
 	for _, fsdev := range fsdevs {
@@ -142,7 +162,7 @@ func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memo
 	runCtx, cancel := context.WithCancel(context.Background())
 	done := newSessionDone()
 	go func() {
-		err := runManagedExecVM(runCtx, vm, uart, fsdevs, vsock, rng, serialOut)
+		err := runManagedExecVMWithSnapshot(runCtx, vm, uart, fsdevs, vsock, rng, serialOut, snapshot)
 		closeVMWithFS(vm, fsdevs)
 		done.finish(err)
 	}()

--- a/internal/hv/kvm/snapshot_linux_arm64.go
+++ b/internal/hv/kvm/snapshot_linux_arm64.go
@@ -1,0 +1,587 @@
+//go:build linux && arm64
+
+package kvm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/arm64vm"
+	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/timing"
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+const (
+	snapshotTriggerMagic        = 0x43535833534e4150
+	snapshotTriggerSerialMarker = "__CCX3_SNAPSHOT__"
+	arm64KVMSnapshotFormat      = "ccx3-kvm-arm64-snapshot-v0"
+)
+
+type arm64KVMSnapshotManifest struct {
+	Format       string                      `json:"format"`
+	CapturedAt   string                      `json:"captured_at"`
+	TriggerBase  uint64                      `json:"trigger_base"`
+	TriggerValue uint64                      `json:"trigger_value"`
+	MemoryBase   uint64                      `json:"memory_base"`
+	MemorySize   uint64                      `json:"memory_size"`
+	MemoryFile   string                      `json:"memory_file"`
+	VCPU         map[string][]byte           `json:"vcpu"`
+	VGICType     uint32                      `json:"vgic_type"`
+	VGIC         []arm64KVMVGICRegister      `json:"vgic"`
+	Devices      map[string]virtio.MMIOState `json:"devices,omitempty"`
+}
+
+type arm64KVMVGICRegister struct {
+	Group uint32 `json:"group"`
+	Attr  uint64 `json:"attr"`
+	Value uint64 `json:"value"`
+	Size  uint8  `json:"size"`
+}
+
+type snapshotTrigger struct {
+	base uint64
+	size uint64
+	dir  string
+	mem  []byte
+
+	mu      sync.Mutex
+	pending bool
+	value   uint64
+	once    sync.Once
+	err     error
+}
+
+func newSnapshotTrigger(dir string, mem []byte) *snapshotTrigger {
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	return &snapshotTrigger{base: arm64vm.SnapshotBase, size: arm64vm.SnapshotSize, dir: strings.TrimSpace(dir), mem: mem}
+}
+
+func (s *snapshotTrigger) contains(addr uint64, size int) bool {
+	return s != nil && size > 0 && addr >= s.base && addr+uint64(size) <= s.base+s.size
+}
+
+func (s *snapshotTrigger) handleMMIO(vm *VM, mmio MMIOExit) (bool, error) {
+	if !s.contains(mmio.Addr, int(mmio.Len)) {
+		return false, nil
+	}
+	if mmio.Write {
+		if s.dir != "" {
+			s.markWrite(mmioValue(mmio))
+		}
+	} else {
+		vm.CompleteMMIORead(snapshotTriggerMagic, mmio.Len)
+	}
+	return true, nil
+}
+
+func (s *snapshotTrigger) markWrite(value uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.pending, s.value = true, value
+	s.mu.Unlock()
+}
+
+func (s *snapshotTrigger) takePending() (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.pending {
+		return 0, false
+	}
+	s.pending = false
+	return s.value, true
+}
+
+func (s *snapshotTrigger) wrapSerialWriter(w io.Writer) io.Writer {
+	if s == nil {
+		return w
+	}
+	return &snapshotSerialWriter{dst: w, trigger: s}
+}
+
+type snapshotSerialWriter struct {
+	dst     io.Writer
+	trigger *snapshotTrigger
+	recent  string
+}
+
+func (w *snapshotSerialWriter) Write(data []byte) (int, error) {
+	w.recent += string(data)
+	if len(w.recent) > len(snapshotTriggerSerialMarker)*2 {
+		w.recent = w.recent[len(w.recent)-len(snapshotTriggerSerialMarker)*2:]
+	}
+	if strings.Contains(w.recent, snapshotTriggerSerialMarker) {
+		w.trigger.markWrite(snapshotTriggerMagic)
+		w.recent = ""
+	}
+	if w.dst == nil {
+		return len(data), nil
+	}
+	return w.dst.Write(data)
+}
+
+func (s *snapshotTrigger) captureIfPending(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG) error {
+	if s == nil {
+		return nil
+	}
+	value, ok := s.takePending()
+	if !ok {
+		return nil
+	}
+	s.once.Do(func() { s.err = s.capture(vm, fsdevs, vsock, rng, value) })
+	if s.err != nil {
+		return fmt.Errorf("capture KVM arm64 snapshot: %w", s.err)
+	}
+	return nil
+}
+
+func (s *snapshotTrigger) capture(vm *VM, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG, value uint64) error {
+	outDir := filepath.Join(s.dir, "snapshot-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+	if err := writeArm64SparseFile(filepath.Join(outDir, "memory.bin"), s.mem); err != nil {
+		return fmt.Errorf("write memory: %w", err)
+	}
+	vcpu, err := snapshotArm64KVMVCPU(vm)
+	if err != nil {
+		return err
+	}
+	vgic, err := snapshotArm64KVMVGIC(vm)
+	if err != nil {
+		return err
+	}
+	manifest := arm64KVMSnapshotManifest{
+		Format: arm64KVMSnapshotFormat, CapturedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		TriggerBase: s.base, TriggerValue: value, MemoryBase: arm64vm.MemoryBase,
+		MemorySize: uint64(len(s.mem)), MemoryFile: "memory.bin", VCPU: vcpu,
+		VGICType: vm.vgicType, VGIC: vgic, Devices: snapshotArm64KVMDeviceStates(fsdevs, vsock, rng),
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, "manifest.json"), data, 0o644)
+}
+
+func snapshotArm64KVMVCPU(vm *VM) (map[string][]byte, error) {
+	ids, err := getRegList(vm.vcpufd)
+	if err != nil {
+		return nil, fmt.Errorf("list vCPU registers: %w", err)
+	}
+	out := make(map[string][]byte, len(ids))
+	for _, id := range ids {
+		size, err := arm64KVMRegisterSize(id)
+		if err != nil {
+			return nil, err
+		}
+		value := make([]byte, size)
+		if err := getOneReg(vm.vcpufd, id, unsafe.Pointer(&value[0])); err != nil {
+			return nil, fmt.Errorf("read vCPU register %#x: %w", id, err)
+		}
+		out[strconv.FormatUint(id, 16)] = value
+	}
+	return out, nil
+}
+
+func restoreArm64KVMVCPU(vm *VM, state map[string][]byte) error {
+	ids := make([]uint64, 0, len(state))
+	for key := range state {
+		id, err := strconv.ParseUint(key, 16, 64)
+		if err != nil {
+			return fmt.Errorf("invalid vCPU register %q", key)
+		}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		value := state[strconv.FormatUint(id, 16)]
+		if len(value) == 0 {
+			return fmt.Errorf("vCPU register %#x is empty", id)
+		}
+		if err := setOneReg(vm.vcpufd, id, unsafe.Pointer(&value[0])); err != nil {
+			return fmt.Errorf("restore vCPU register %#x: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func arm64KVMRegisterSize(id uint64) (int, error) {
+	shift := (id & 0x00f0000000000000) >> 52
+	if shift > 8 {
+		return 0, fmt.Errorf("unsupported KVM register size in %#x", id)
+	}
+	return 1 << shift, nil
+}
+
+func snapshotArm64KVMVGIC(vm *VM) ([]arm64KVMVGICRegister, error) {
+	if vm.vgicfd < 0 {
+		return nil, fmt.Errorf("VGIC is unavailable")
+	}
+	var out []arm64KVMVGICRegister
+	probe32 := func(group uint32, attr uint64) error {
+		var value uint32
+		err := getDeviceAttr(vm.vgicfd, &kvmDeviceAttr{Group: group, Attr: attr, Addr: uint64(uintptr(unsafe.Pointer(&value)))})
+		if errors.Is(err, unix.ENXIO) || errors.Is(err, unix.EINVAL) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		out = append(out, arm64KVMVGICRegister{Group: group, Attr: attr, Value: uint64(value), Size: 4})
+		return nil
+	}
+	// Probe only state-bearing migration registers. Reading or writing arbitrary
+	// GIC MMIO offsets can acknowledge, deactivate, or synthesize interrupts.
+	distRanges := [][2]uint64{{0x0, 0xc}, {0x80, 0xc0}, {0x100, 0x120}, {0x200, 0x220}, {0x300, 0x320}, {0x400, 0x500}, {0x800, 0x900}, {0xc00, 0xc40}, {0xe00, 0xe20}}
+	for _, span := range distRanges {
+		for off := span[0]; off < span[1]; off += 4 {
+			if err := probe32(kvmDevArmVgicGrpDistRegs, off); err != nil {
+				return nil, fmt.Errorf("read VGIC distributor %#x: %w", off, err)
+			}
+		}
+	}
+	if vm.vgicType == kvmDevTypeArmVgicV2 {
+		for _, off := range []uint64{0x0, 0x4, 0x8, 0xd0, 0xd4, 0xd8, 0xdc} {
+			if err := probe32(kvmDevArmVgicGrpCPURegs, off); err != nil {
+				return nil, fmt.Errorf("read VGIC CPU %#x: %w", off, err)
+			}
+		}
+	} else {
+		redistRanges := [][2]uint64{{0x0, 0xc}, {0x14, 0x18}, {0x70, 0x80}, {0x10080, 0x10084}, {0x10100, 0x10104}, {0x10200, 0x10204}, {0x10300, 0x10304}, {0x10400, 0x10420}, {0x10c00, 0x10c08}, {0x10e00, 0x10e04}}
+		for _, span := range redistRanges {
+			for off := span[0]; off < span[1]; off += 4 {
+				if err := probe32(kvmDevArmVgicGrpRedistRegs, off); err != nil {
+					return nil, fmt.Errorf("read VGIC redistributor %#x: %w", off, err)
+				}
+			}
+		}
+		for _, instr := range []uint64{
+			arm64SysRegInstruction(3, 0, 4, 6, 0),
+			arm64SysRegInstruction(3, 0, 12, 8, 3),
+			arm64SysRegInstruction(3, 0, 12, 8, 4),
+			arm64SysRegInstruction(3, 0, 12, 8, 5),
+			arm64SysRegInstruction(3, 0, 12, 8, 6),
+			arm64SysRegInstruction(3, 0, 12, 8, 7),
+			arm64SysRegInstruction(3, 0, 12, 9, 0),
+			arm64SysRegInstruction(3, 0, 12, 9, 1),
+			arm64SysRegInstruction(3, 0, 12, 9, 2),
+			arm64SysRegInstruction(3, 0, 12, 9, 3),
+			arm64SysRegInstruction(3, 0, 12, 12, 3),
+			arm64SysRegInstruction(3, 0, 12, 12, 4),
+			arm64SysRegInstruction(3, 0, 12, 12, 5),
+			arm64SysRegInstruction(3, 0, 12, 12, 6),
+			arm64SysRegInstruction(3, 0, 12, 12, 7),
+		} {
+			var value uint64
+			attr := kvmDeviceAttr{Group: kvmDevArmVgicGrpCPUSysRegs, Attr: instr, Addr: uint64(uintptr(unsafe.Pointer(&value)))}
+			err := getDeviceAttr(vm.vgicfd, &attr)
+			if errors.Is(err, unix.ENXIO) || errors.Is(err, unix.EINVAL) {
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("read VGIC CPU sysreg %#x: %w", instr, err)
+			}
+			out = append(out, arm64KVMVGICRegister{Group: attr.Group, Attr: attr.Attr, Value: value, Size: 8})
+		}
+	}
+	return out, nil
+}
+
+func arm64SysRegInstruction(op0, op1, crn, crm, op2 uint64) uint64 {
+	return (op0 << 14) | (op1 << 11) | (crn << 7) | (crm << 3) | op2
+}
+
+func restoreArm64KVMVGIC(vm *VM, typ uint32, state []arm64KVMVGICRegister) error {
+	if typ != vm.vgicType {
+		return fmt.Errorf("snapshot VGIC type %d does not match host type %d", typ, vm.vgicType)
+	}
+	ordered := append([]arm64KVMVGICRegister(nil), state...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		// Restore IIDR first and distributor CTLR last, as required by the KVM migration ABI.
+		rank := func(v arm64KVMVGICRegister) int {
+			if (v.Group == kvmDevArmVgicGrpDistRegs && v.Attr == 0x8) || (v.Group == kvmDevArmVgicGrpRedistRegs && v.Attr == 0x4) {
+				return 0
+			}
+			if (v.Group == kvmDevArmVgicGrpDistRegs || v.Group == kvmDevArmVgicGrpCPURegs || v.Group == kvmDevArmVgicGrpRedistRegs) && v.Attr == 0 {
+				return 2
+			}
+			return 1
+		}
+		return rank(ordered[i]) < rank(ordered[j])
+	})
+	for _, reg := range ordered {
+		value := reg.Value
+		addr := unsafe.Pointer(&value)
+		if reg.Size == 4 {
+			value = uint64(uint32(value))
+		} else if reg.Size != 8 {
+			return fmt.Errorf("unsupported VGIC register size %d", reg.Size)
+		}
+		attr := kvmDeviceAttr{Group: reg.Group, Attr: reg.Attr, Addr: uint64(uintptr(addr))}
+		if err := setDeviceAttr(vm.vgicfd, &attr); err != nil && !errors.Is(err, unix.ENXIO) {
+			return fmt.Errorf("restore VGIC group %d attr %#x: %w", reg.Group, reg.Attr, err)
+		}
+	}
+	return nil
+}
+
+func snapshotArm64KVMDeviceStates(fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG) map[string]virtio.MMIOState {
+	out := map[string]virtio.MMIOState{}
+	if rng != nil {
+		out["rng"] = rng.SnapshotState()
+	}
+	if vsock != nil {
+		out["vsock"] = vsock.SnapshotState()
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			out[fmt.Sprintf("fs:%x", fsdev.Base)] = fsdev.SnapshotState()
+		}
+	}
+	return out
+}
+
+func restoreArm64KVMDeviceStates(states map[string]virtio.MMIOState, fsdevs []*virtio.FS, vsock *virtio.Vsock, rng *virtio.RNG) error {
+	if state, ok := states["rng"]; ok && rng != nil {
+		if err := rng.RestoreState(state); err != nil {
+			return err
+		}
+	}
+	if state, ok := states["vsock"]; ok && vsock != nil {
+		if err := vsock.RestoreState(state); err != nil {
+			return err
+		}
+	}
+	for _, fsdev := range fsdevs {
+		if fsdev == nil {
+			continue
+		}
+		key := fmt.Sprintf("fs:%x", fsdev.Base)
+		state, ok := states[key]
+		if !ok {
+			return fmt.Errorf("snapshot missing state for fs device %#x", fsdev.Base)
+		}
+		if err := fsdev.RestoreState(state); err != nil {
+			return fmt.Errorf("restore fs device %#x: %w", fsdev.Base, err)
+		}
+	}
+	return nil
+}
+
+func writeArm64SparseFile(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for off := 0; off < len(data); off += 4096 {
+		end := off + 4096
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[off:end]
+		zero := true
+		for _, b := range chunk {
+			if b != 0 {
+				zero = false
+				break
+			}
+		}
+		if !zero {
+			if _, err := f.WriteAt(chunk, int64(off)); err != nil {
+				return err
+			}
+		}
+	}
+	return f.Truncate(int64(len(data)))
+}
+
+func loadArm64KVMSnapshot(path string) (arm64KVMSnapshotManifest, string, error) {
+	path = strings.TrimSpace(path)
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		path = filepath.Join(path, "manifest.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return arm64KVMSnapshotManifest{}, "", err
+	}
+	var manifest arm64KVMSnapshotManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return manifest, "", err
+	}
+	if manifest.Format != arm64KVMSnapshotFormat {
+		return manifest, "", fmt.Errorf("unsupported KVM arm64 snapshot format %q", manifest.Format)
+	}
+	memPath := manifest.MemoryFile
+	if !filepath.IsAbs(memPath) {
+		memPath = filepath.Join(filepath.Dir(path), memPath)
+	}
+	info, err := os.Stat(memPath)
+	if err != nil {
+		return manifest, "", err
+	}
+	if uint64(info.Size()) != manifest.MemorySize {
+		return manifest, "", fmt.Errorf("snapshot memory size %d, want %d", info.Size(), manifest.MemorySize)
+	}
+	return manifest, memPath, nil
+}
+
+func mmapArm64SnapshotMemory(path string, size uint64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return unix.Mmap(int(f.Fd()), 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE)
+}
+
+func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	stageStart := time.Now()
+	if err := emitManagedBootStatus(onEvent, "restoring VM snapshot"); err != nil {
+		return nil, err
+	}
+	manifest, memPath, err := loadArm64KVMSnapshot(snapshotPath)
+	if err != nil {
+		return nil, err
+	}
+	timing.Since(ctx, "startup.kvm.restore.load_snapshot", stageStart)
+	if memoryMB == 0 {
+		memoryMB = manifest.MemorySize >> 20
+	}
+	if arm64vm.MemorySizeBytes(memoryMB) != manifest.MemorySize {
+		return nil, fmt.Errorf("snapshot memory does not match requested memory")
+	}
+	backend := virtio.NewSimpleVsockBackend()
+	listener, err := backend.Listen(vmruntime.ControlPort)
+	if err != nil {
+		return nil, err
+	}
+	vsock := virtio.NewVsock(arm64vm.VsockBase, arm64vm.VsockSize, arm64vm.VsockIRQ, vmruntime.GuestCID, backend)
+	rng := virtio.NewRNG(arm64vm.RNGBase, arm64vm.RNGSize, arm64vm.RNGIRQ)
+	connCh := make(chan virtio.VsockConn, 1)
+	acceptErrCh := make(chan error, 1)
+	controlTranscript := vmruntime.NewSerialTranscript()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		connCh <- conn
+		_, _ = io.Copy(controlTranscript, conn)
+	}()
+	stageStart = time.Now()
+	vm, err := NewVM()
+	if err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+	mem, err := mmapArm64SnapshotMemory(memPath, manifest.MemorySize)
+	if err == nil {
+		err = vm.MapMemory(mem, arm64vm.MemoryBase)
+		if err != nil {
+			_ = unix.Munmap(mem)
+		}
+	}
+	if err != nil {
+		_ = vm.Close()
+		_ = listener.Close()
+		return nil, err
+	}
+	timing.Since(ctx, "startup.kvm.restore.vm_memory", stageStart)
+	stageStart = time.Now()
+	serialOut := vmruntime.NewSerialTranscript()
+	var serialWriter io.Writer = serialOut
+	var bootWriter *vmruntime.BootEventWriter
+	if onEvent != nil {
+		bootWriter = vmruntime.NewBootEventWriter(onEvent)
+		serialWriter = io.MultiWriter(serialOut, bootWriter)
+	}
+	uart := serial.NewUART8250(arm64vm.DefaultUARTBase, arm64vm.DefaultUARTRegShift, serialWriter)
+	uart.AttachIRQ(vm, arm64vm.UARTSPI)
+	for _, fsdev := range fsdevs {
+		if fsdev != nil {
+			fsdev.Attach(vm, vm)
+		}
+	}
+	vsock.Attach(vm, vm)
+	rng.Attach(vm, vm)
+	if err := restoreArm64KVMDeviceStates(manifest.Devices, fsdevs, vsock, rng); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		_ = listener.Close()
+		return nil, err
+	}
+	timing.Since(ctx, "startup.kvm.restore.devices", stageStart)
+	stageStart = time.Now()
+	if err := restoreArm64KVMVGIC(vm, manifest.VGICType, manifest.VGIC); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		_ = listener.Close()
+		return nil, err
+	}
+	if err := restoreArm64KVMVCPU(vm, manifest.VCPU); err != nil {
+		closeVMWithFS(vm, fsdevs)
+		_ = listener.Close()
+		return nil, err
+	}
+	timing.Since(ctx, "startup.kvm.restore.machine_state", stageStart)
+	stageStart = time.Now()
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := newSessionDone()
+	go func() {
+		resumeTrigger := &snapshotTrigger{base: arm64vm.SnapshotBase, size: arm64vm.SnapshotSize}
+		err := runManagedExecVMWithSnapshot(runCtx, vm, uart, fsdevs, vsock, rng, serialOut, resumeTrigger)
+		closeVMWithFS(vm, fsdevs)
+		done.finish(err)
+	}()
+	var control virtio.VsockConn
+	select {
+	case err := <-acceptErrCh:
+		cancel()
+		return nil, err
+	case control = <-connCh:
+	case <-done.done():
+		cancel()
+		return nil, done.result()
+	case <-ctx.Done():
+		cancel()
+		return nil, ctx.Err()
+	}
+	timing.Since(ctx, "startup.kvm.restore.vcpu_to_control", stageStart)
+	stageStart = time.Now()
+	if _, err := controlTranscript.WaitFor(ctx, 0, func(text string) bool {
+		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
+	}); err != nil {
+		cancel()
+		return nil, err
+	}
+	timing.Since(ctx, "startup.kvm.restore.control_to_ready", stageStart)
+	if vmruntime.HasFatalBootText(controlTranscript.String()) {
+		cancel()
+		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
+		cancel()
+		return nil, err
+	}
+	return &ManagedSession{cancel: cancel, done: done, control: control, listener: listener, vsock: vsock, bootWriter: bootWriter, transcript: controlTranscript, serialOut: serialOut, cleanup: func() { _ = vm.CancelRun() }, dmesg: dmesg}, nil
+}

--- a/internal/hv/kvm/vgic_linux_arm64.go
+++ b/internal/hv/kvm/vgic_linux_arm64.go
@@ -14,15 +14,16 @@ import (
 
 var errVGICUnsupported = errors.New("kvm: vgic device unsupported")
 
-func initVGIC(vmfd int) (int, error) {
+func initVGIC(vmfd int) (int, uint32, error) {
 	fd, err := initVGICv3(vmfd)
 	if err == nil {
-		return fd, nil
+		return fd, kvmDevTypeArmVgicV3, nil
 	}
 	if !errors.Is(err, errVGICUnsupported) {
-		return 0, err
+		return 0, 0, err
 	}
-	return initVGICv2(vmfd)
+	fd, err = initVGICv2(vmfd)
+	return fd, kvmDevTypeArmVgicV2, err
 }
 
 func finalizeVGIC(vgicfd int) error {

--- a/internal/hv/kvm/vm_linux_arm64.go
+++ b/internal/hv/kvm/vm_linux_arm64.go
@@ -51,6 +51,7 @@ type VM struct {
 	vmfd        int
 	vcpufd      int
 	vgicfd      int
+	vgicType    uint32
 	run         []byte
 	mem         []byte
 	extraMem    [][]byte
@@ -68,7 +69,7 @@ func NewVM() (*VM, error) {
 		_ = k.Close()
 		return nil, fmt.Errorf("create vm: %w", err)
 	}
-	vgicfd, err := initVGIC(vmfd)
+	vgicfd, vgicType, err := initVGIC(vmfd)
 	if err != nil {
 		_ = k.CloseVM(vmfd)
 		_ = k.Close()
@@ -111,7 +112,7 @@ func NewVM() (*VM, error) {
 		_ = k.Close()
 		return nil, fmt.Errorf("mmap kvm_run: %w", err)
 	}
-	return &VM{kvm: k, vmfd: vmfd, vcpufd: vcpufd, vgicfd: vgicfd, run: run}, nil
+	return &VM{kvm: k, vmfd: vmfd, vcpufd: vcpufd, vgicfd: vgicfd, vgicType: vgicType, run: run}, nil
 }
 
 func (v *VM) Close() error {
@@ -167,6 +168,22 @@ func (v *VM) MapAnonymousMemory(size uint64, guestPhysAddr uint64) ([]byte, erro
 	v.mem = mem
 	v.memRegion = region
 	return mem, nil
+}
+
+func (v *VM) MapMemory(mem []byte, guestPhysAddr uint64) error {
+	if len(mem) == 0 {
+		return fmt.Errorf("guest memory is empty")
+	}
+	region := kvmUserspaceMemoryRegion{
+		Slot: 0, GuestPhysAddr: guestPhysAddr, MemorySize: uint64(len(mem)),
+		UserspaceAddr: uint64(uintptr(unsafe.Pointer(&mem[0]))),
+	}
+	if err := setUserMemoryRegion(v.vmfd, &region); err != nil {
+		return fmt.Errorf("set user memory region: %w", err)
+	}
+	v.mem = mem
+	v.memRegion = region
+	return nil
 }
 
 func (v *VM) MapAnonymousMemorySlot(slot uint32, size uint64, guestPhysAddr uint64) ([]byte, error) {

--- a/internal/vm/backend_linux_arm64.go
+++ b/internal/vm/backend_linux_arm64.go
@@ -18,6 +18,7 @@ import (
 	"j5.nz/cc/internal/kernel/alpine"
 	managedguest "j5.nz/cc/internal/managed/guest"
 	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/timing"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vm/execplan"
 	kvmhost "j5.nz/cc/internal/vm/host/kvm"
@@ -46,6 +47,8 @@ func (b *runtimeBackend) StartBlank(ctx context.Context, req client.StartInstanc
 }
 
 func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+	totalStart := time.Now()
+	defer func() { timing.Since(ctx, "startup.total_ready", totalStart) }()
 	if inst, ok, err := b.startBuiltinGuestStream(ctx, req, onEvent); ok || err != nil {
 		return inst, err
 	}
@@ -55,32 +58,44 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if req.CPUs > 1 {
 		return nil, fmt.Errorf("linux arm64 runtime currently supports only 1 CPU")
 	}
+	stageStart := time.Now()
 	kernel, err := b.kernel.ReadKernel()
+	timing.Since(ctx, "startup.kernel_read", stageStart)
 	if err != nil {
 		return nil, err
 	}
+	stageStart = time.Now()
 	image, err := b.images.Open(req.Image)
+	timing.Since(ctx, "startup.image_open", stageStart)
 	if err != nil {
 		return nil, err
 	}
 	image = withLinuxRuntimeMountDirs(image)
+	stageStart = time.Now()
 	modules, err := b.kernel.PlanModuleLoad(linuxRuntimeConfigVars(image, req.KernelModules...), linuxRuntimeModuleMap())
+	timing.Since(ctx, "startup.module_plan", stageStart)
 	if err != nil {
 		return nil, err
 	}
+	stageStart = time.Now()
 	qemuX8664, err := PrepareAMD64Emulator(ctx, image, b.kernel.ExtractPackageFile)
+	timing.Since(ctx, "startup.emulator_prepare", stageStart)
 	if err != nil {
 		return nil, err
 	}
+	stageStart = time.Now()
 	fsdevs, rootFS, err := arm64vm.BuildFSDevices(vmruntime.RunRequest{
 		Image:             image,
 		AMD64EmulatorPath: qemuX8664,
 		Shares:            mounts.ConvertShareMounts(req.Shares),
 	}, nil)
+	timing.Since(ctx, "startup.fs_devices", stageStart)
 	if err != nil {
 		return nil, err
 	}
+	stageStart = time.Now()
 	initBin, err := guestinit.Build(ctx, b.guestInitCache)
+	timing.Since(ctx, "startup.guest_init", stageStart)
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
 	}
@@ -95,11 +110,15 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	}
 	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
 	initCfg.WorkDir = workDir
+	stageStart = time.Now()
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
+	timing.Since(ctx, "startup.initramfs", stageStart)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
 	}
+	stageStart = time.Now()
 	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, onEvent)
+	timing.Since(ctx, "startup.kvm_to_ready", stageStart)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/backend_linux_arm64.go
+++ b/internal/vm/backend_linux_arm64.go
@@ -110,6 +110,9 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	}
 	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
 	initCfg.WorkDir = workDir
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = arm64vm.SnapshotBase
+	}
 	stageStart = time.Now()
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	timing.Since(ctx, "startup.initramfs", stageStart)
@@ -117,7 +120,9 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		return nil, fmt.Errorf("build initramfs: %w", err)
 	}
 	stageStart = time.Now()
-	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, onEvent)
+	session, err := kvm.StartManagedSessionWithOptions(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, kvm.ManagedSessionOptions{
+		SnapshotDir: strings.TrimSpace(req.SnapshotDir), RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
+	}, onEvent)
 	timing.Since(ctx, "startup.kvm_to_ready", stageStart)
 	if err != nil {
 		return nil, err
@@ -147,17 +152,19 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	if strings.TrimSpace(req.Image) != "" {
 		return b.StartStream(ctx, client.CreateInstanceRequest{
-			ID:             req.ID,
-			Image:          req.Image,
-			InitSystem:     req.InitSystem,
-			Kernel:         req.Kernel,
-			Network:        req.Network,
-			KernelModules:  append([]string(nil), req.KernelModules...),
-			MemoryMB:       req.MemoryMB,
-			CPUs:           req.CPUs,
-			NestedVirt:     req.NestedVirt,
-			Dmesg:          req.Dmesg,
-			TimeoutSeconds: req.TimeoutSeconds,
+			ID:              req.ID,
+			Image:           req.Image,
+			InitSystem:      req.InitSystem,
+			Kernel:          req.Kernel,
+			Network:         req.Network,
+			KernelModules:   append([]string(nil), req.KernelModules...),
+			MemoryMB:        req.MemoryMB,
+			CPUs:            req.CPUs,
+			NestedVirt:      req.NestedVirt,
+			Dmesg:           req.Dmesg,
+			TimeoutSeconds:  req.TimeoutSeconds,
+			SnapshotDir:     req.SnapshotDir,
+			RestoreSnapshot: req.RestoreSnapshot,
 		}, onEvent)
 	}
 	if b == nil || b.kernel == nil || b.images == nil {
@@ -206,11 +213,16 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	initCfg.Env = vmruntime.WithDefaultEnv(nil)
 	initCfg.WorkDir = "/"
+	if strings.TrimSpace(req.SnapshotDir) != "" {
+		initCfg.SnapshotMMIOBase = arm64vm.SnapshotBase
+	}
 	initrd, err := vmruntime.BuildInitramfs(initBin, modules, initCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build initramfs: %w", err)
 	}
-	session, err := kvm.StartManagedSession(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, onEvent)
+	session, err := kvm.StartManagedSessionWithOptions(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, kvm.ManagedSessionOptions{
+		SnapshotDir: strings.TrimSpace(req.SnapshotDir), RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
+	}, onEvent)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -443,8 +443,8 @@ func TestRuntimePersistentLinuxStreamsStdin(t *testing.T) {
 }
 
 func TestRuntimeRestoresPersistentLinuxFromStartupSnapshot(t *testing.T) {
-	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
-		t.Skip("linux/amd64 startup snapshots are implemented by the KVM amd64 backend")
+	if runtime.GOOS != "linux" || (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64") {
+		t.Skip("KVM startup snapshots are implemented on Linux amd64 and arm64")
 	}
 	env := newRuntimeBootEnv(t)
 	snapshotRoot := t.TempDir()

--- a/internal/vm/startup_benchmark_linux_arm64_test.go
+++ b/internal/vm/startup_benchmark_linux_arm64_test.go
@@ -1,0 +1,95 @@
+//go:build linux && arm64
+
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"j5.nz/cc/client"
+	"j5.nz/cc/internal/kernel/alpine"
+	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/timing"
+)
+
+const arm64StartupBenchmarkEnv = "CC_KVM_ARM64_STARTUP_BENCHMARK"
+
+type arm64StartupSample struct {
+	ReadyNanos        int64                    `json:"ready_nanos"`
+	FirstCommandNanos int64                    `json:"first_command_nanos"`
+	Phases            map[string]time.Duration `json:"phases"`
+}
+
+type arm64StartupReport struct {
+	GOARCH                  string               `json:"goarch"`
+	MemoryMB                uint64               `json:"memory_mb"`
+	Samples                 []arm64StartupSample `json:"samples"`
+	MedianReadyNanos        int64                `json:"median_ready_nanos"`
+	MedianFirstCommandNanos int64                `json:"median_first_command_nanos"`
+}
+
+func TestKVMARM64StartupBenchmark(t *testing.T) {
+	if os.Getenv(arm64StartupBenchmarkEnv) != "1" {
+		t.Skipf("set %s=1 on a Linux/arm64 KVM host", arm64StartupBenchmarkEnv)
+	}
+	if err := Supports(); err != nil {
+		t.Fatalf("KVM unavailable: %v", err)
+	}
+
+	prepareCtx, prepareCancel := context.WithTimeout(context.Background(), runtimePrepareTimeout())
+	defer prepareCancel()
+	cacheRoot := runtimeBootCacheRoot(t)
+	kernelManager := alpine.NewManager(filepath.Join(cacheRoot, "kernel"))
+	if err := kernelManager.EnsureWithProgress(prepareCtx, nil); err != nil {
+		t.Fatalf("prepare kernel: %v", err)
+	}
+	backend := NewRuntimeBackend(kernelManager, oci.NewStore(filepath.Join(t.TempDir(), "images")), filepath.Join(cacheRoot, "guestinit"))
+
+	const samples = 5
+	report := arm64StartupReport{GOARCH: "arm64", MemoryMB: 768, Samples: make([]arm64StartupSample, 0, samples)}
+	readyValues := make([]int64, 0, samples)
+	commandValues := make([]int64, 0, samples)
+	for i := 0; i < samples; i++ {
+		recorder := timing.NewRecorder()
+		ctx, cancel := context.WithTimeout(timing.WithRecorder(context.Background(), recorder), runtimeBootTimeout())
+		readyStart := time.Now()
+		inst, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{MemoryMB: report.MemoryMB, CPUs: 1}, nil)
+		readyDuration := time.Since(readyStart)
+		if err != nil {
+			cancel()
+			t.Fatalf("sample %d boot: %v", i, err)
+		}
+		commandStart := time.Now()
+		_, commandErr := inst.Exec(ctx, client.ExecRequest{Command: []string{"true"}})
+		commandDuration := time.Since(commandStart)
+		closeErr := inst.Close()
+		cancel()
+		if commandErr != nil {
+			t.Fatalf("sample %d first command: %v", i, commandErr)
+		}
+		if closeErr != nil {
+			t.Fatalf("sample %d close: %v", i, closeErr)
+		}
+		phases := make(map[string]time.Duration)
+		for _, snapshot := range recorder.Snapshots() {
+			phases[snapshot.Name] = snapshot.Duration
+		}
+		report.Samples = append(report.Samples, arm64StartupSample{ReadyNanos: readyDuration.Nanoseconds(), FirstCommandNanos: commandDuration.Nanoseconds(), Phases: phases})
+		readyValues = append(readyValues, readyDuration.Nanoseconds())
+		commandValues = append(commandValues, commandDuration.Nanoseconds())
+	}
+	sort.Slice(readyValues, func(i, j int) bool { return readyValues[i] < readyValues[j] })
+	sort.Slice(commandValues, func(i, j int) bool { return commandValues[i] < commandValues[j] })
+	report.MedianReadyNanos = readyValues[len(readyValues)/2]
+	report.MedianFirstCommandNanos = commandValues[len(commandValues)/2]
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(encoded))
+}

--- a/internal/vm/startup_benchmark_linux_arm64_test.go
+++ b/internal/vm/startup_benchmark_linux_arm64_test.go
@@ -71,7 +71,7 @@ func TestKVMARM64StartupBenchmark(t *testing.T) {
 			cancel()
 			t.Fatalf("sample %d did not return a managed Linux session", i)
 		}
-		_, commandErr := linuxInst.managedInstance.session.Exec(ctx, client.ExecRequest{Kind: "sync"})
+		commandErr := linuxInst.managedInstance.session.Flush(ctx)
 		commandDuration := time.Since(commandStart)
 		closeErr := inst.Close()
 		cancel()

--- a/internal/vm/startup_benchmark_linux_arm64_test.go
+++ b/internal/vm/startup_benchmark_linux_arm64_test.go
@@ -27,6 +27,7 @@ type arm64StartupSample struct {
 
 type arm64StartupReport struct {
 	GOARCH                  string               `json:"goarch"`
+	Mode                    string               `json:"mode"`
 	MemoryMB                uint64               `json:"memory_mb"`
 	Samples                 []arm64StartupSample `json:"samples"`
 	MedianReadyNanos        int64                `json:"median_ready_nanos"`
@@ -49,16 +50,29 @@ func TestKVMARM64StartupBenchmark(t *testing.T) {
 		t.Fatalf("prepare kernel: %v", err)
 	}
 	backend := NewRuntimeBackend(kernelManager, oci.NewStore(filepath.Join(t.TempDir(), "images")), filepath.Join(cacheRoot, "guestinit"))
+	snapshotRoot := t.TempDir()
+	captureCtx, captureCancel := context.WithTimeout(context.Background(), runtimeBootTimeout())
+	capture, err := backend.StartBlankStream(captureCtx, client.StartInstanceRequest{MemoryMB: 768, CPUs: 1, SnapshotDir: snapshotRoot}, nil)
+	if err != nil {
+		captureCancel()
+		t.Fatalf("capture startup snapshot: %v", err)
+	}
+	if err := capture.Close(); err != nil {
+		captureCancel()
+		t.Fatalf("close snapshot capture: %v", err)
+	}
+	captureCancel()
+	snapshotPath := singleSnapshotPath(t, snapshotRoot, "")
 
 	const samples = 5
-	report := arm64StartupReport{GOARCH: "arm64", MemoryMB: 768, Samples: make([]arm64StartupSample, 0, samples)}
+	report := arm64StartupReport{GOARCH: "arm64", Mode: "snapshot_restore", MemoryMB: 768, Samples: make([]arm64StartupSample, 0, samples)}
 	readyValues := make([]int64, 0, samples)
 	commandValues := make([]int64, 0, samples)
 	for i := 0; i < samples; i++ {
 		recorder := timing.NewRecorder()
 		ctx, cancel := context.WithTimeout(timing.WithRecorder(context.Background(), recorder), runtimeBootTimeout())
 		readyStart := time.Now()
-		inst, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{MemoryMB: report.MemoryMB, CPUs: 1}, nil)
+		inst, err := backend.StartBlankStream(ctx, client.StartInstanceRequest{MemoryMB: report.MemoryMB, CPUs: 1, RestoreSnapshot: snapshotPath}, nil)
 		readyDuration := time.Since(readyStart)
 		if err != nil {
 			cancel()

--- a/internal/vm/startup_benchmark_linux_arm64_test.go
+++ b/internal/vm/startup_benchmark_linux_arm64_test.go
@@ -65,7 +65,13 @@ func TestKVMARM64StartupBenchmark(t *testing.T) {
 			t.Fatalf("sample %d boot: %v", i, err)
 		}
 		commandStart := time.Now()
-		_, commandErr := inst.Exec(ctx, client.ExecRequest{Command: []string{"true"}})
+		linuxInst, ok := inst.(*linuxInstance)
+		if !ok || linuxInst.managedInstance == nil || linuxInst.managedInstance.session == nil {
+			_ = inst.Close()
+			cancel()
+			t.Fatalf("sample %d did not return a managed Linux session", i)
+		}
+		_, commandErr := linuxInst.managedInstance.session.Exec(ctx, client.ExecRequest{Kind: "sync"})
 		commandDuration := time.Since(commandStart)
 		closeErr := inst.Close()
 		cancel()


### PR DESCRIPTION
Fixes #32

## Summary
- add Linux/KVM arm64 startup snapshot capture and copy-on-write restore, following the established Darwin/arm64 and Windows/arm64 checkpoint boundary
- persist guest RAM, the complete KVM arm64 vCPU register list, migration-safe VGICv2/v3 state, and virtio-fs/vsock/RNG state
- resume the checkpoint MMIO completion before reconnecting guest control, and make Linux arm64 KVM cancellation reliably interrupt an idle vCPU
- instrument snapshot load, VM/memory setup, device restore, machine-state restore, vCPU-to-control, control-to-ready, and first command latency
- make the gated benchmark capture once and measure five snapshot restores instead of five cold boots
- retain `quiet` for routine non-dmesg cold boots while preserving the diagnostic serial channel and verbose `Dmesg` behavior

## Design
The guest checkpoint is taken after non-unique init work (root mount, hostname/runtime filesystem, package-manager setup, binfmt, workdir) and before entropy seeding, deferred modules, vsock connection, and the ready marker. This is the same security boundary used by the existing Darwin/arm64 and Windows/arm64 implementations: restored guests do not reuse unique entropy or a live control connection.

KVM snapshots use `MAP_PRIVATE` for restored RAM. VGIC capture is deliberately limited to state-bearing migration registers; probing arbitrary GIC MMIO registers can acknowledge, deactivate, or synthesize interrupts.

## Native results
Fixture: Raspberry Pi 5 Model B Rev 1.0, 4x Cortex-A76 (max 2.4 GHz), Ubuntu kernel 6.8.0-1057-raspi, Go 1.25.5 linux/arm64, 768 MiB blank managed Linux guest, warm artifact cache, five samples.

Cold-boot baseline before this work:
- median ready: 564.35 ms
- median first guest control round trip: 5.73 ms

Snapshot restore:
- ready samples: 53.99–62.95 ms
- median ready: 57.95 ms (89.7% below the original cold baseline)
- median restored vCPU-to-control: 24.22 ms
- median control-to-ready: 5.93 ms
- median first guest control round trip: 5.50 ms

## Validation
- five consecutive capture/restore/exec behavior tests on `astra-pi5`
- native `go test ./internal/arm64vm ./internal/hv/kvm ./internal/vm -timeout 3m` on `astra-pi5`
- `CC_KVM_ARM64_STARTUP_BENCHMARK=1 go test ./internal/vm -run '^TestKVMARM64StartupBenchmark$' -v -count=1` on `astra-pi5`
- `GOOS=linux GOARCH=arm64 go test -c ./internal/vm`
- Darwin/arm64 full suite was run; one virtio-fs runtime feature test timed out once and passed immediately when rerun in isolation. The modified Linux-only packages and shared snapshot behavior test compile cleanly on Darwin.

Required hardware for the benchmark and behavior test: a Linux/arm64 host with readable `/dev/kvm` and VGIC support.
