### PR TITLE
Centralize runtime artifact download safety

### DIFF
--- a/cmd/cvmfs/main.go
+++ b/cmd/cvmfs/main.go
@@ -1,22 +1,27 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	intcvmfs "j5.nz/cc/internal/cvmfs"
 )
 
 func main() {
-	if err := run(os.Args[1:], os.Stdout); err != nil {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	if err := run(ctx, os.Args[1:], os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, "cvmfs:", err)
 		os.Exit(1)
 	}
 }
 
-func run(args []string, stdout io.Writer) error {
+func run(ctx context.Context, args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("cvmfs", flag.ExitOnError)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -26,6 +31,7 @@ func run(args []string, stdout io.Writer) error {
 		return fmt.Errorf("usage: cvmfs <ls|cat> <target>")
 	}
 	client := intcvmfs.NewClient()
+	client.Context = ctx
 	switch args[0] {
 	case "ls":
 		entries, err := client.ReadDir(args[1])

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -1146,6 +1146,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			return
 		}
 		cvmfsClient := intcvmfs.NewClient()
+		cvmfsClient.Context = r.Context()
 		cvmfsClient.CacheDir = cvmfsRequestCacheDir(req.CacheDir, srvState.cvmfsCacheDir)
 		cvmfsClient.Mirrors = req.Mirrors
 		if watchdog != nil {
@@ -1185,6 +1186,7 @@ func newMux(srvState *server, watchdog *watchdogController, shutdown func(), opt
 			return
 		}
 		cvmfsClient := intcvmfs.NewClient()
+		cvmfsClient.Context = r.Context()
 		cvmfsClient.CacheDir = cvmfsRequestCacheDir(req.CacheDir, srvState.cvmfsCacheDir)
 		cvmfsClient.Mirrors = req.Mirrors
 		if watchdog != nil {

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -3,6 +3,7 @@ package cvmfs
 import (
 	"bytes"
 	"compress/zlib"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -21,11 +22,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"j5.nz/cc/internal/download"
 	"j5.nz/cc/internal/linuxabi"
 	intsqlite "j5.nz/cc/internal/sqlite"
 )
 
 const DefaultMirror = "https://cvmfs.neurodesk.org/cvmfs"
+const maxCVMFSExpandedObjectBytes int64 = 4 << 30
 
 const (
 	flagDir          = 1
@@ -112,6 +115,7 @@ type WalkEntry struct {
 
 type Client struct {
 	HTTPClient   *http.Client
+	Context      context.Context
 	CacheDir     string
 	TraceLogPath string
 	OnActivity   func(ActivityEvent)
@@ -923,7 +927,16 @@ func (r *repository) getFromMirrors(op string, urlFor func(string) string, handl
 	for _, mirror := range r.orderedMirrors() {
 		url := urlFor(mirror)
 		id, started := r.client.traceStart(op, "", url, "")
-		resp, err := r.client.HTTPClient.Get(url)
+		ctx := r.client.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		resp, err := r.client.HTTPClient.Do(req)
 		if err != nil {
 			r.client.traceDone(id, started, op, "", url, "", 0, 0, err)
 			r.client.recordMirrorResult(mirror, time.Since(started), err, 0)
@@ -936,6 +949,17 @@ func (r *repository) getFromMirrors(op string, urlFor func(string) string, handl
 				what = "fetch manifest"
 			}
 			err := fmt.Errorf("%s: unexpected status %s", what, resp.Status)
+			_ = resp.Body.Close()
+			r.client.traceDone(id, started, op, "", url, "", 0, resp.StatusCode, err)
+			r.client.recordMirrorResult(mirror, time.Since(started), err, resp.StatusCode)
+			lastErr = err
+			continue
+		}
+		maxBytes := int64(0)
+		if op == "HTTPManifest" {
+			maxBytes = 16 << 20
+		}
+		if err := download.BoundResponse(resp, maxBytes); err != nil {
 			_ = resp.Body.Close()
 			r.client.traceDone(id, started, op, "", url, "", 0, resp.StatusCode, err)
 			r.client.recordMirrorResult(mirror, time.Since(started), err, resp.StatusCode)
@@ -1347,7 +1371,11 @@ func (r *repository) fetchManifest() ([]byte, error) {
 	err := r.getFromMirrors("HTTPManifest", func(mirror string) string {
 		return fmt.Sprintf("%s/%s/.cvmfspublished", mirror, r.repo)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
-		data, readErr := io.ReadAll(resp.Body)
+		ctx := r.client.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		data, readErr := download.ReadAllReader(ctx, resp.Body, 16<<20)
 		if readErr != nil {
 			r.client.traceDone(id, started, "HTTPManifest", "", url, "", len(data), resp.StatusCode, readErr)
 			return readErr
@@ -1435,7 +1463,11 @@ func (r *repository) fetchCatalogDB(hash string) ([]byte, error) {
 		return nil, err
 	}
 	defer zr.Close()
-	return io.ReadAll(zr)
+	ctx := r.client.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return download.ReadAllReader(ctx, zr, maxCVMFSExpandedObjectBytes)
 }
 
 func (r *repository) fetchDataObject(hash string, partial bool) ([]byte, error) {
@@ -1452,7 +1484,11 @@ func (r *repository) fetchDataObject(hash string, partial bool) ([]byte, error) 
 		return nil, err
 	}
 	defer zr.Close()
-	return io.ReadAll(zr)
+	ctx := r.client.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return download.ReadAllReader(ctx, zr, maxCVMFSExpandedObjectBytes)
 }
 
 func (r *repository) fetchCompressedObject(hash, suffix string) ([]byte, error) {

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -114,17 +114,25 @@ type WalkEntry struct {
 }
 
 type Client struct {
-	HTTPClient   *http.Client
-	Context      context.Context
-	CacheDir     string
-	TraceLogPath string
-	OnActivity   func(ActivityEvent)
-	Mirrors      []string
+	HTTPClient             *http.Client
+	Context                context.Context
+	MaxExpandedObjectBytes int64
+	CacheDir               string
+	TraceLogPath           string
+	OnActivity             func(ActivityEvent)
+	Mirrors                []string
 
 	mu           sync.Mutex
 	repos        map[string]*repository
 	mirrorStats  map[string]*mirrorStat
 	mirrorCursor uint64
+}
+
+func (c *Client) expandedObjectBudget() int64 {
+	if c != nil && c.MaxExpandedObjectBytes > 0 {
+		return c.MaxExpandedObjectBytes
+	}
+	return maxCVMFSExpandedObjectBytes
 }
 
 type ActivityEvent struct {
@@ -1467,7 +1475,7 @@ func (r *repository) fetchCatalogDB(hash string) ([]byte, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return download.ReadAllReader(ctx, zr, maxCVMFSExpandedObjectBytes)
+	return download.ReadAllReader(ctx, zr, r.client.expandedObjectBudget())
 }
 
 func (r *repository) fetchDataObject(hash string, partial bool) ([]byte, error) {
@@ -1488,7 +1496,7 @@ func (r *repository) fetchDataObject(hash string, partial bool) ([]byte, error) 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return download.ReadAllReader(ctx, zr, maxCVMFSExpandedObjectBytes)
+	return download.ReadAllReader(ctx, zr, r.client.expandedObjectBudget())
 }
 
 func (r *repository) fetchCompressedObject(hash, suffix string) ([]byte, error) {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -1,0 +1,288 @@
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type LimitError struct {
+	Limit  int64
+	Actual int64
+}
+
+func (e *LimitError) Error() string {
+	return fmt.Sprintf("download exceeds byte budget: limit=%d actual=%d", e.Limit, e.Actual)
+}
+
+type LengthError struct {
+	Expected int64
+	Actual   int64
+}
+
+func (e *LengthError) Error() string {
+	return fmt.Sprintf("download length mismatch: expected=%d actual=%d", e.Expected, e.Actual)
+}
+
+type DigestError struct {
+	Expected string
+	Actual   string
+}
+
+func (e *DigestError) Error() string {
+	return fmt.Sprintf("download digest mismatch: expected=%s actual=%s", e.Expected, e.Actual)
+}
+
+type Budget struct {
+	MaxBytes       int64
+	ExpectedBytes  int64
+	ExpectedSHA256 string
+}
+
+type LimitWriter struct {
+	dst     io.Writer
+	limit   int64
+	written int64
+}
+
+func NewLimitWriter(dst io.Writer, maxBytes int64) (*LimitWriter, error) {
+	if dst == nil || maxBytes <= 0 {
+		return nil, fmt.Errorf("positive output byte budget and writer are required")
+	}
+	return &LimitWriter{dst: dst, limit: maxBytes}, nil
+}
+
+func (w *LimitWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - w.written
+	if remaining <= 0 {
+		return 0, &LimitError{Limit: w.limit, Actual: w.written + int64(len(p))}
+	}
+	requested := len(p)
+	overBudget := int64(requested) > remaining
+	if overBudget {
+		p = p[:remaining]
+	}
+	n, err := w.dst.Write(p)
+	w.written += int64(n)
+	if err != nil {
+		return n, err
+	}
+	if overBudget {
+		return n, &LimitError{Limit: w.limit, Actual: w.written + int64(requested-n)}
+	}
+	if n < requested {
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
+
+func ReadAll(ctx context.Context, resp *http.Response, budget Budget) ([]byte, error) {
+	var out bytesWriter
+	if _, err := Copy(ctx, &out, resp, budget); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func ReadAllReader(ctx context.Context, r io.Reader, maxBytes int64) ([]byte, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("download context is required")
+	}
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("positive expanded byte budget is required")
+	}
+	var out bytesWriter
+	n, err := io.Copy(&out, &contextReader{ctx: ctx, r: io.LimitReader(r, maxBytes+1)})
+	if err != nil {
+		return nil, err
+	}
+	if n > maxBytes {
+		return nil, &LimitError{Limit: maxBytes, Actual: n}
+	}
+	return out.Bytes(), nil
+}
+
+func CopyReader(ctx context.Context, dst io.Writer, r io.Reader, maxBytes int64) (int64, error) {
+	if ctx == nil {
+		return 0, fmt.Errorf("download context is required")
+	}
+	if maxBytes <= 0 {
+		return 0, fmt.Errorf("positive expanded byte budget is required")
+	}
+	n, err := io.Copy(dst, &contextReader{ctx: ctx, r: io.LimitReader(r, maxBytes+1)})
+	if err != nil {
+		return n, err
+	}
+	if n > maxBytes {
+		return n, &LimitError{Limit: maxBytes, Actual: n}
+	}
+	return n, nil
+}
+
+// BoundResponse applies a wire-byte budget to callers that consume the body
+// incrementally. A zero max uses the server-declared Content-Length as the
+// exact budget; chunked/unsized artifact responses are rejected because they
+// cannot be admitted safely before consumption.
+func BoundResponse(resp *http.Response, maxBytes int64) error {
+	if resp == nil || resp.Body == nil {
+		return fmt.Errorf("download response body is required")
+	}
+	if resp.ContentLength <= 0 {
+		return fmt.Errorf("artifact response requires a positive content length")
+	}
+	if maxBytes > 0 && resp.ContentLength > maxBytes {
+		return &LimitError{Limit: maxBytes, Actual: resp.ContentLength}
+	}
+	resp.Body = &boundedBody{body: resp.Body, expected: resp.ContentLength, remaining: resp.ContentLength}
+	return nil
+}
+
+type boundedBody struct {
+	body      io.ReadCloser
+	expected  int64
+	remaining int64
+	done      bool
+}
+
+func (r *boundedBody) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	if r.remaining == 0 {
+		var probe [1]byte
+		n, err := r.body.Read(probe[:])
+		if n > 0 {
+			return 0, &LengthError{Expected: r.expected, Actual: r.expected + int64(n)}
+		}
+		if err == nil {
+			return 0, &LengthError{Expected: r.expected, Actual: r.expected + 1}
+		}
+		r.done = true
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.body.Read(p)
+	r.remaining -= int64(n)
+	if errors.Is(err, io.EOF) && r.remaining != 0 {
+		r.done = true
+		return n, &LengthError{Expected: r.expected, Actual: r.expected - r.remaining}
+	}
+	return n, err
+}
+
+func (r *boundedBody) Close() error { return r.body.Close() }
+
+func Copy(ctx context.Context, dst io.Writer, resp *http.Response, budget Budget) (int64, error) {
+	if ctx == nil {
+		return 0, fmt.Errorf("download context is required")
+	}
+	if resp == nil || resp.Body == nil {
+		return 0, fmt.Errorf("download response body is required")
+	}
+	if budget.MaxBytes <= 0 {
+		return 0, fmt.Errorf("positive download byte budget is required")
+	}
+	if resp.ContentLength > budget.MaxBytes {
+		return 0, &LimitError{Limit: budget.MaxBytes, Actual: resp.ContentLength}
+	}
+	if budget.ExpectedBytes > 0 && resp.ContentLength >= 0 && resp.ContentLength != budget.ExpectedBytes {
+		return 0, &LengthError{Expected: budget.ExpectedBytes, Actual: resp.ContentLength}
+	}
+
+	var digest hash.Hash
+	w := dst
+	if budget.ExpectedSHA256 != "" {
+		digest = sha256.New()
+		w = io.MultiWriter(dst, digest)
+	}
+	reader := &contextReader{ctx: ctx, r: io.LimitReader(resp.Body, budget.MaxBytes+1)}
+	n, err := io.Copy(w, reader)
+	if err != nil {
+		return n, err
+	}
+	if n > budget.MaxBytes {
+		return n, &LimitError{Limit: budget.MaxBytes, Actual: n}
+	}
+	if budget.ExpectedBytes > 0 && n != budget.ExpectedBytes {
+		return n, &LengthError{Expected: budget.ExpectedBytes, Actual: n}
+	}
+	if resp.ContentLength >= 0 && n != resp.ContentLength {
+		return n, &LengthError{Expected: resp.ContentLength, Actual: n}
+	}
+	if digest != nil {
+		actual := hex.EncodeToString(digest.Sum(nil))
+		expected := trimSHA256(budget.ExpectedSHA256)
+		if actual != expected {
+			return n, &DigestError{Expected: "sha256:" + expected, Actual: "sha256:" + actual}
+		}
+	}
+	return n, nil
+}
+
+func trimSHA256(value string) string {
+	if len(value) > 7 && value[:7] == "sha256:" {
+		return value[7:]
+	}
+	return value
+}
+
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r *contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := r.r.Read(p)
+	if err != nil && r.ctx.Err() != nil {
+		return n, r.ctx.Err()
+	}
+	return n, err
+}
+
+type bytesWriter struct{ data []byte }
+
+func (w *bytesWriter) Write(p []byte) (int, error) {
+	w.data = append(w.data, p...)
+	return len(p), nil
+}
+
+func (w *bytesWriter) Bytes() []byte { return w.data }
+
+func IsLimit(err error) bool {
+	var target *LimitError
+	return errors.As(err, &target)
+}
+
+func FilesystemBudget(path string) (int64, error) {
+	probe := path
+	for {
+		if _, err := os.Stat(probe); err == nil {
+			break
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			break
+		}
+		probe = parent
+	}
+	available, err := filesystemAvailableBytes(probe)
+	if err != nil {
+		return 0, err
+	}
+	if available == 0 || available > uint64(^uint64(0)>>1) {
+		return 0, fmt.Errorf("filesystem at %s has no representable available-byte budget", probe)
+	}
+	return int64(available), nil
+}

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -1,0 +1,70 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCopyRejectsOversizeBeforePublication(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader("oversized")), ContentLength: 9}
+	var dst strings.Builder
+	_, err := Copy(context.Background(), &dst, resp, Budget{MaxBytes: 8})
+	var limitErr *LimitError
+	if !errors.As(err, &limitErr) || limitErr.Limit != 8 || limitErr.Actual != 9 {
+		t.Fatalf("error = %#v", err)
+	}
+	if dst.Len() != 0 {
+		t.Fatalf("published %d bytes before rejecting content length", dst.Len())
+	}
+}
+
+func TestCopyReportsLengthAndDigestMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		budget Budget
+		match  any
+	}{
+		{name: "length", budget: Budget{MaxBytes: 8, ExpectedBytes: 4}, match: &LengthError{}},
+		{name: "digest", budget: Budget{MaxBytes: 8, ExpectedSHA256: strings.Repeat("0", 64)}, match: &DigestError{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader("abc")), ContentLength: 3}
+			_, err := Copy(context.Background(), io.Discard, resp, tc.budget)
+			switch target := tc.match.(type) {
+			case *LengthError:
+				if !errors.As(err, &target) {
+					t.Fatalf("error = %v", err)
+				}
+			case *DigestError:
+				if !errors.As(err, &target) {
+					t.Fatalf("error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestBoundResponseReportsTruncatedBody(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader("abc")), ContentLength: 4}
+	if err := BoundResponse(resp, 8); err != nil {
+		t.Fatal(err)
+	}
+	_, err := io.ReadAll(resp.Body)
+	var lengthErr *LengthError
+	if !errors.As(err, &lengthErr) || lengthErr.Expected != 4 || lengthErr.Actual != 3 {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestReadAllReaderHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := ReadAllReader(ctx, strings.NewReader("artifact"), 16)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
+	}
+}

--- a/internal/download/space_freebsd.go
+++ b/internal/download/space_freebsd.go
@@ -1,0 +1,16 @@
+//go:build freebsd
+
+package download
+
+import "golang.org/x/sys/unix"
+
+func filesystemAvailableBytes(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	if stat.Bavail <= 0 {
+		return 0, nil
+	}
+	return uint64(stat.Bavail) * stat.Bsize, nil
+}

--- a/internal/download/space_netbsd.go
+++ b/internal/download/space_netbsd.go
@@ -1,0 +1,13 @@
+//go:build netbsd
+
+package download
+
+import "golang.org/x/sys/unix"
+
+func filesystemAvailableBytes(path string) (uint64, error) {
+	var stat unix.Statvfs_t
+	if err := unix.Statvfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return stat.Bavail * stat.Frsize, nil
+}

--- a/internal/download/space_openbsd.go
+++ b/internal/download/space_openbsd.go
@@ -1,0 +1,16 @@
+//go:build openbsd
+
+package download
+
+import "golang.org/x/sys/unix"
+
+func filesystemAvailableBytes(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	if stat.F_bavail <= 0 {
+		return 0, nil
+	}
+	return uint64(stat.F_bavail) * uint64(stat.F_bsize), nil
+}

--- a/internal/download/space_unix.go
+++ b/internal/download/space_unix.go
@@ -1,0 +1,13 @@
+//go:build linux || darwin
+
+package download
+
+import "golang.org/x/sys/unix"
+
+func filesystemAvailableBytes(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return stat.Bavail * uint64(stat.Bsize), nil
+}

--- a/internal/download/space_windows.go
+++ b/internal/download/space_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package download
+
+import "golang.org/x/sys/windows"
+
+func filesystemAvailableBytes(path string) (uint64, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(name, &available, nil, nil); err != nil {
+		return 0, err
+	}
+	return available, nil
+}

--- a/internal/kernel/alpine/kernel.go
+++ b/internal/kernel/alpine/kernel.go
@@ -6,6 +6,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,11 +17,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"j5.nz/cc/client"
+	"j5.nz/cc/internal/download"
 )
 
 var debugTiming = strings.TrimSpace(os.Getenv("CCX3_DEBUG_TIMING")) != ""
@@ -69,9 +74,11 @@ type metadata struct {
 }
 
 type indexEntry struct {
-	Name    string
-	Version string
-	Arch    string
+	Name     string
+	Version  string
+	Arch     string
+	Size     int64
+	Checksum string
 }
 
 type tarIndexEntry struct {
@@ -336,7 +343,7 @@ func (m *Manager) ensureDownloaded(ctx context.Context, report progressReporter)
 	apkPath := filepath.Join(destDir, filename)
 	tarPath := filepath.Join(destDir, fmt.Sprintf("%s-%s.tar", entry.Name, entry.Version))
 
-	if err := m.downloadFile(ctx, m.packageURL(filename), apkPath, report); err != nil {
+	if err := m.downloadFile(ctx, m.packageURL(filename), apkPath, entry, report); err != nil {
 		return err
 	}
 	if err := decompressAPKToTar(apkPath, tarPath); err != nil {
@@ -516,7 +523,7 @@ func (m *Manager) readModuleFile(path string) ([]byte, error) {
 			return nil, fmt.Errorf("open module gzip %q: %w", path, err)
 		}
 		defer gzr.Close()
-		data, err = io.ReadAll(gzr)
+		data, err = download.ReadAllReader(context.Background(), gzr, 256<<20)
 		if err != nil {
 			return nil, fmt.Errorf("read module %q: %w", path, err)
 		}
@@ -586,6 +593,9 @@ func (m *Manager) fetchIndexEntry(ctx context.Context) (indexEntry, error) {
 		return indexEntry{}, fmt.Errorf("download kernel index: %w", err)
 	}
 	defer resp.Body.Close()
+	if err := download.BoundResponse(resp, 64<<20); err != nil {
+		return indexEntry{}, fmt.Errorf("download kernel index: %w", err)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return indexEntry{}, fmt.Errorf("download kernel index: status %s", resp.Status)
@@ -606,7 +616,7 @@ func (m *Manager) fetchIndexEntry(ctx context.Context) (indexEntry, error) {
 	return entry, nil
 }
 
-func (m *Manager) downloadFile(ctx context.Context, url, destPath string, report progressReporter) error {
+func (m *Manager) downloadFile(ctx context.Context, url, destPath string, entry indexEntry, report progressReporter) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -616,6 +626,9 @@ func (m *Manager) downloadFile(ctx context.Context, url, destPath string, report
 		return fmt.Errorf("download kernel package: %w", err)
 	}
 	defer resp.Body.Close()
+	if err := download.BoundResponse(resp, 0); err != nil {
+		return fmt.Errorf("download kernel package: %w", err)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download kernel package: status %s", resp.Status)
@@ -626,7 +639,8 @@ func (m *Manager) downloadFile(ctx context.Context, url, destPath string, report
 	if err != nil {
 		return fmt.Errorf("create kernel package file: %w", err)
 	}
-	if err := copyWithProgress(f, resp.Body, resp.ContentLength, filepath.Base(destPath), report); err != nil {
+	hasher := sha1.New()
+	if err := copyWithProgress(io.MultiWriter(f, hasher), resp.Body, resp.ContentLength, filepath.Base(destPath), report); err != nil {
 		f.Close()
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("write kernel package: %w", err)
@@ -634,6 +648,17 @@ func (m *Manager) downloadFile(ctx context.Context, url, destPath string, report
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("close kernel package: %w", err)
+	}
+	if entry.Size > 0 && resp.ContentLength != entry.Size {
+		_ = os.Remove(tmpPath)
+		return &download.LengthError{Expected: entry.Size, Actual: resp.ContentLength}
+	}
+	if expected, ok := alpineChecksumHex(entry.Checksum); ok {
+		actual := hex.EncodeToString(hasher.Sum(nil))
+		if !strings.EqualFold(expected, actual) {
+			_ = os.Remove(tmpPath)
+			return &download.DigestError{Expected: "sha1:" + expected, Actual: "sha1:" + actual}
+		}
 	}
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		_ = os.Remove(tmpPath)
@@ -873,6 +898,10 @@ func parseAPKIndex(r io.Reader) (map[string]indexEntry, error) {
 			current.Version = value
 		case "A":
 			current.Arch = value
+		case "S":
+			current.Size, _ = strconv.ParseInt(value, 10, 64)
+		case "C":
+			current.Checksum = value
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -880,6 +909,17 @@ func parseAPKIndex(r io.Reader) (map[string]indexEntry, error) {
 	}
 	flush()
 	return out, nil
+}
+
+func alpineChecksumHex(value string) (string, bool) {
+	if !strings.HasPrefix(value, "Q1") {
+		return "", false
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, "Q1"))
+	if err != nil || len(raw) != sha1.Size {
+		return "", false
+	}
+	return hex.EncodeToString(raw), true
 }
 
 func (m *Manager) readMetadata() (metadata, error) {

--- a/internal/kernel/alpine/package_reader.go
+++ b/internal/kernel/alpine/package_reader.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"j5.nz/cc/internal/download"
 	"j5.nz/cc/internal/timing"
 )
 
@@ -40,7 +41,7 @@ func (m *Manager) ReadPackageFile(ctx context.Context, repo, packageName, innerP
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("stat package file: %w", err)
 		}
-		if err := m.downloadFile(ctx, m.repoPackageURL(repo, filename), apkPath, nil); err != nil {
+		if err := m.downloadFile(ctx, m.repoPackageURL(repo, filename), apkPath, entry, nil); err != nil {
 			return nil, fmt.Errorf("download package %q: %w", packageName, err)
 		}
 	}
@@ -111,7 +112,7 @@ func (m *Manager) ExtractPackageFileWithProgress(
 			return "", fmt.Errorf("stat package file: %w", err)
 		}
 		start = time.Now()
-		if err := m.downloadFile(ctx, m.repoPackageURL(repo, filename), apkPath, report); err != nil {
+		if err := m.downloadFile(ctx, m.repoPackageURL(repo, filename), apkPath, entry, report); err != nil {
 			return "", fmt.Errorf("download package %q: %w", packageName, err)
 		}
 		timing.Since(ctx, "kernel.extract_package.download_apk", start)
@@ -263,6 +264,9 @@ func (m *Manager) lookupPackageEntry(ctx context.Context, repo, packageName stri
 	timing.Since(ctx, "kernel.lookup_package_entry.http_do", start)
 	if resp.StatusCode != http.StatusOK {
 		return indexEntry{}, fmt.Errorf("request APKINDEX: status %s", resp.Status)
+	}
+	if err := download.BoundResponse(resp, 64<<20); err != nil {
+		return indexEntry{}, fmt.Errorf("request APKINDEX: %w", err)
 	}
 	start = time.Now()
 	indexData, err := readAPKIndex(resp.Body)

--- a/internal/kernel/ubuntu/kernel.go
+++ b/internal/kernel/ubuntu/kernel.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 
+	"j5.nz/cc/internal/download"
 	"j5.nz/cc/internal/kernel/alpine"
 )
 
@@ -65,6 +67,8 @@ type packageEntry struct {
 	Depends       []string `json:"depends,omitempty"`
 	RawDepends    string   `json:"raw_depends,omitempty"`
 	InstalledSize string   `json:"installed_size,omitempty"`
+	Size          int64    `json:"size,omitempty"`
+	SHA256        string   `json:"sha256,omitempty"`
 }
 
 type resolvedPackages struct {
@@ -364,20 +368,20 @@ func decompressModule(path string, data []byte) ([]byte, error) {
 			return nil, fmt.Errorf("open zstd module %q: %w", path, err)
 		}
 		defer dec.Close()
-		return io.ReadAll(dec)
+		return download.ReadAllReader(context.Background(), dec, 256<<20)
 	case strings.HasSuffix(path, ".xz"):
 		dec, err := xz.NewReader(bytes.NewReader(data))
 		if err != nil {
 			return nil, fmt.Errorf("open xz module %q: %w", path, err)
 		}
-		return io.ReadAll(dec)
+		return download.ReadAllReader(context.Background(), dec, 256<<20)
 	case strings.HasSuffix(path, ".gz"):
 		dec, err := gzip.NewReader(bytes.NewReader(data))
 		if err != nil {
 			return nil, fmt.Errorf("open gzip module %q: %w", path, err)
 		}
 		defer dec.Close()
-		return io.ReadAll(dec)
+		return download.ReadAllReader(context.Background(), dec, 256<<20)
 	default:
 		return data, nil
 	}
@@ -501,6 +505,9 @@ func (m *Manager) packageIndex(ctx context.Context) (map[string]packageEntry, er
 		return nil, fmt.Errorf("request Ubuntu package index: %w", err)
 	}
 	defer resp.Body.Close()
+	if err := download.BoundResponse(resp, 64<<20); err != nil {
+		return nil, fmt.Errorf("request Ubuntu package index: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("request Ubuntu package index: status %s", resp.Status)
 	}
@@ -540,7 +547,9 @@ func parsePackagesIndex(r io.Reader) (map[string]packageEntry, error) {
 			Depends:       depends,
 			RawDepends:    fields["Depends"],
 			InstalledSize: fields["Installed-Size"],
+			SHA256:        fields["SHA256"],
 		}
+		entry.Size, _ = strconv.ParseInt(fields["Size"], 10, 64)
 		if entry.Name != "" && entry.Filename != "" {
 			index[entry.Name] = entry
 		}
@@ -606,6 +615,9 @@ func (m *Manager) ensurePackage(ctx context.Context, entry packageEntry) (string
 		return "", fmt.Errorf("download Ubuntu package %q: %w", entry.Name, err)
 	}
 	defer resp.Body.Close()
+	if err := download.BoundResponse(resp, 0); err != nil {
+		return "", fmt.Errorf("download Ubuntu package %q: %w", entry.Name, err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("download Ubuntu package %q: status %s", entry.Name, resp.Status)
 	}
@@ -614,7 +626,15 @@ func (m *Manager) ensurePackage(ctx context.Context, entry packageEntry) (string
 	if err != nil {
 		return "", fmt.Errorf("create Ubuntu package %q: %w", entry.Name, err)
 	}
-	if _, err := io.Copy(f, resp.Body); err != nil {
+	budget := download.Budget{MaxBytes: resp.ContentLength, ExpectedBytes: resp.ContentLength}
+	if entry.Size > 0 {
+		budget.MaxBytes = entry.Size
+		budget.ExpectedBytes = entry.Size
+	}
+	if entry.SHA256 != "" {
+		budget.ExpectedSHA256 = entry.SHA256
+	}
+	if _, err := download.Copy(ctx, f, resp, budget); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
 		return "", fmt.Errorf("write Ubuntu package %q: %w", entry.Name, err)

--- a/internal/managed/release/release.go
+++ b/internal/managed/release/release.go
@@ -2,12 +2,15 @@ package release
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"j5.nz/cc/internal/download"
 )
 
 type ReaderFactory func(io.Reader) (io.ReadCloser, error)
@@ -111,7 +114,25 @@ func Download(ctx context.Context, url, target string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download %s: unexpected HTTP status %s", url, resp.Status)
 	}
-	return writeFileAtomically(ctx, target, resp.Body)
+	if resp.ContentLength <= 0 {
+		return fmt.Errorf("download %s: server did not provide a positive content length", url)
+	}
+	return writeResponseAtomically(ctx, target, resp)
+}
+
+func writeResponseAtomically(ctx context.Context, target string, resp *http.Response) error {
+	tmp := target + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmp, err)
+	}
+	_, copyErr := download.Copy(ctx, out, resp, download.Budget{MaxBytes: resp.ContentLength, ExpectedBytes: resp.ContentLength})
+	closeErr := out.Close()
+	if copyErr != nil || closeErr != nil {
+		_ = os.Remove(tmp)
+		return errors.Join(copyErr, closeErr)
+	}
+	return os.Rename(tmp, target)
 }
 
 func writeFileAtomically(ctx context.Context, target string, r io.Reader) error {
@@ -120,7 +141,13 @@ func writeFileAtomically(ctx context.Context, target string, r io.Reader) error 
 	if err != nil {
 		return fmt.Errorf("create %s: %w", tmp, err)
 	}
-	_, copyErr := io.Copy(out, contextReader{ctx: ctx, r: r})
+	maxBytes, budgetErr := download.FilesystemBudget(target)
+	if budgetErr != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("determine expanded artifact budget: %w", budgetErr)
+	}
+	_, copyErr := download.CopyReader(ctx, out, r, maxBytes)
 	closeErr := out.Close()
 	if copyErr != nil {
 		_ = os.Remove(tmp)
@@ -135,16 +162,4 @@ func writeFileAtomically(ctx context.Context, target string, r io.Reader) error 
 		return fmt.Errorf("install %s: %w", target, err)
 	}
 	return nil
-}
-
-type contextReader struct {
-	ctx context.Context
-	r   io.Reader
-}
-
-func (r contextReader) Read(p []byte) (int, error) {
-	if err := r.ctx.Err(); err != nil {
-		return 0, err
-	}
-	return r.r.Read(p)
 }

--- a/internal/oci/indexedfs.go
+++ b/internal/oci/indexedfs.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	intcvmfs "j5.nz/cc/internal/cvmfs"
+	"j5.nz/cc/internal/download"
 	"j5.nz/cc/internal/fsmeta"
 	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/linuxabi"
@@ -463,11 +465,15 @@ func writeLayerTarFromReader(dstPath, mediaType string, body io.Reader) error {
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 		return err
 	}
-	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	tmpPath := dstPath + ".tmp"
+	dst, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
-	defer dst.Close()
+	defer func() {
+		_ = dst.Close()
+		_ = os.Remove(tmpPath)
+	}()
 	buffered := bufio.NewReader(body)
 	var src io.Reader = buffered
 	gzipLayer := strings.Contains(mediaType, "gzip")
@@ -484,10 +490,17 @@ func writeLayerTarFromReader(dstPath, mediaType string, body io.Reader) error {
 		defer gzr.Close()
 		src = gzr
 	}
-	if _, err := io.Copy(dst, src); err != nil {
+	maxBytes, err := download.FilesystemBudget(dstPath)
+	if err != nil {
+		return fmt.Errorf("determine expanded layer budget: %w", err)
+	}
+	if _, err := download.CopyReader(context.Background(), dst, src, maxBytes); err != nil {
 		return err
 	}
-	return dst.Close()
+	if err := dst.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, dstPath)
 }
 
 type countingReader struct {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ulikunitz/xz"
 	"j5.nz/cc/client"
 	intcvmfs "j5.nz/cc/internal/cvmfs"
+	"j5.nz/cc/internal/download"
 	"j5.nz/cc/internal/fsmeta"
 	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/simg"
@@ -46,6 +47,7 @@ const (
 )
 
 const internalScratchSource = "scratch"
+const maxRegistryMetadataBytes int64 = 16 << 20
 
 type Store struct {
 	root          string
@@ -422,7 +424,7 @@ func (s *Store) Pull(ctx context.Context, name, source string, options ...PullOp
 		reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
 		return s.Get(name)
 	}
-	if state, ok, err := s.existingState(name, spec, opts.Architecture); err != nil {
+	if state, ok, err := s.existingState(ctx, name, spec, opts.Architecture); err != nil {
 		return client.ImageState{}, err
 	} else if ok {
 		reportPullProgress(opts.Report, client.ProgressEvent{Status: "available", Artifact: name})
@@ -432,7 +434,7 @@ func (s *Store) Pull(ctx context.Context, name, source string, options ...PullOp
 		reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
 		return state, nil
 	}
-	if state, ok, err := s.restoreFromSharedCache(name, spec, opts.Architecture); err != nil {
+	if state, ok, err := s.restoreFromSharedCache(ctx, name, spec, opts.Architecture); err != nil {
 		return client.ImageState{}, err
 	} else if ok {
 		reportPullProgress(opts.Report, client.ProgressEvent{Status: "restored", Artifact: name})
@@ -477,7 +479,7 @@ func (s *Store) pull(ctx context.Context, name string, spec SourceSpec, options 
 	sharedName := sharedImageKey(spec, options.Architecture)
 	shared := NewStore(s.sharedRoot())
 	shared.httpClient = s.httpClient
-	if _, ok, err := shared.existingState(sharedName, spec, options.Architecture); err != nil {
+	if _, ok, err := shared.existingState(ctx, sharedName, spec, options.Architecture); err != nil {
 		return err
 	} else if !ok {
 		if err := shared.pullDirect(ctx, sharedName, spec, options); err != nil {
@@ -568,10 +570,12 @@ func (s *Store) pullCVMFSDirect(ctx context.Context, name string, spec SourceSpe
 	}
 	cvmfsClient := &intcvmfs.Client{
 		HTTPClient: s.httpClient,
+		Context:    ctx,
 		CacheDir:   cvmfsCacheDir(s.sharedRoot()),
 		OnActivity: s.cvmfsActivity,
 		Mirrors:    options.CVMFSMirrors,
 	}
+	defer func() { cvmfsClient.Context = nil }()
 	normalizedSource := normalizeCVMFSSource(spec.Raw)
 	rootTarget, isDir, err := resolveCVMFSRootTarget(cvmfsClient, normalizedSource)
 	if err != nil {
@@ -766,6 +770,7 @@ func (s *Store) maybePrefetchCVMFSImage(ctx context.Context, name string, spec S
 	}
 	cvmfsClient := &intcvmfs.Client{
 		HTTPClient: s.httpClient,
+		Context:    ctx,
 		CacheDir:   cvmfsCacheDir(s.sharedRoot()),
 		OnActivity: s.cvmfsActivity,
 		Mirrors:    options.CVMFSMirrors,
@@ -823,11 +828,14 @@ func (s *Store) fetchSIMG(ctx context.Context, source, destPath string) error {
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("download simg: status %s", resp.Status)
 		}
+		if err := download.BoundResponse(resp, 0); err != nil {
+			return fmt.Errorf("download simg: %w", err)
+		}
 		dst, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {
 			return err
 		}
-		if _, err := io.Copy(dst, resp.Body); err != nil {
+		if _, err := download.Copy(ctx, dst, resp, download.Budget{MaxBytes: resp.ContentLength, ExpectedBytes: resp.ContentLength}); err != nil {
 			_ = dst.Close()
 			_ = os.Remove(tmpPath)
 			return err
@@ -873,6 +881,10 @@ func (s *Store) fetchRootFSTar(ctx context.Context, name, source, destPath strin
 			resp.Body.Close()
 			return fmt.Errorf("download rootfs tar: status %s (%s)", resp.Status, strings.TrimSpace(string(body)))
 		}
+		if err := download.BoundResponse(resp, 0); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("download rootfs tar: %w", err)
+		}
 		src = resp.Body
 		if resp.ContentLength > 0 {
 			totalBytes = resp.ContentLength
@@ -893,7 +905,19 @@ func (s *Store) fetchRootFSTar(ctx context.Context, name, source, destPath strin
 		return err
 	}
 	progress := newDownloadProgressReader(src, name, "rootfs", totalBytes, report)
-	if err := writeUncompressedTar(dst, source, progress); err != nil {
+	expandedBudget, err := download.FilesystemBudget(destPath)
+	if err != nil {
+		_ = dst.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("determine rootfs expansion budget: %w", err)
+	}
+	budgetedDst, err := download.NewLimitWriter(dst, expandedBudget)
+	if err != nil {
+		_ = dst.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := writeUncompressedTar(budgetedDst, source, progress); err != nil {
 		_ = dst.Close()
 		_ = os.Remove(tmpPath)
 		return err
@@ -930,7 +954,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 		return err
 	}
 
-	cfgBlob, err := s.fetchBlob(ctx, reg, imageName, mani.Config.Digest)
+	cfgBlob, err := s.fetchBlob(ctx, reg, imageName, mani.Config)
 	if err != nil {
 		return fmt.Errorf("fetch config blob: %w", err)
 	}
@@ -1027,7 +1051,7 @@ func (s *Store) finalizeIndexedImage(name string, spec SourceSpec, imageDir, tmp
 	return nil
 }
 
-func (s *Store) existingState(name string, spec SourceSpec, architecture string) (client.ImageState, bool, error) {
+func (s *Store) existingState(ctx context.Context, name string, spec SourceSpec, architecture string) (client.ImageState, bool, error) {
 	meta, err := s.readMetadata(name)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -1045,7 +1069,7 @@ func (s *Store) existingState(name string, spec SourceSpec, architecture string)
 		if meta.CVMFSRootHash == "" {
 			return client.ImageState{}, false, nil
 		}
-		currentHash, err := s.currentCVMFSRootHash(spec, meta.CVMFSMirrors)
+		currentHash, err := s.currentCVMFSRootHash(ctx, spec, meta.CVMFSMirrors)
 		if err != nil {
 			return client.ImageState{}, false, err
 		}
@@ -1059,7 +1083,7 @@ func (s *Store) existingState(name string, spec SourceSpec, architecture string)
 	return client.ImageState{Name: meta.Name, Source: meta.Source, SourceKind: meta.SourceKind, Status: "downloaded"}, true, nil
 }
 
-func (s *Store) restoreFromSharedCache(name string, spec SourceSpec, architecture string) (client.ImageState, bool, error) {
+func (s *Store) restoreFromSharedCache(ctx context.Context, name string, spec SourceSpec, architecture string) (client.ImageState, bool, error) {
 	shared := NewStore(s.sharedRoot())
 	sharedName := sharedImageKey(spec, architecture)
 	meta, err := shared.readMetadata(sharedName)
@@ -1079,7 +1103,7 @@ func (s *Store) restoreFromSharedCache(name string, spec SourceSpec, architectur
 		if meta.CVMFSRootHash == "" {
 			return client.ImageState{}, false, nil
 		}
-		currentHash, err := s.currentCVMFSRootHash(spec, meta.CVMFSMirrors)
+		currentHash, err := s.currentCVMFSRootHash(ctx, spec, meta.CVMFSMirrors)
 		if err != nil {
 			return client.ImageState{}, false, err
 		}
@@ -1096,9 +1120,10 @@ func (s *Store) restoreFromSharedCache(name string, spec SourceSpec, architectur
 	return client.ImageState{Name: name, Source: spec.Raw, SourceKind: spec.Kind, Status: "downloaded"}, true, nil
 }
 
-func (s *Store) currentCVMFSRootHash(spec SourceSpec, mirrors []string) (string, error) {
+func (s *Store) currentCVMFSRootHash(ctx context.Context, spec SourceSpec, mirrors []string) (string, error) {
 	cvmfsClient := &intcvmfs.Client{
 		HTTPClient: s.httpClient,
+		Context:    ctx,
 		CacheDir:   cvmfsCacheDir(s.sharedRoot()),
 		OnActivity: s.cvmfsActivity,
 		Mirrors:    mirrors,
@@ -1220,21 +1245,13 @@ func resolvedOCISource(registry, imageName, digest string) string {
 	return registry + "/" + imageName + "@" + digest
 }
 
-func (s *Store) fetchBlob(ctx context.Context, reg *registryContext, imageName, digest string) ([]byte, error) {
-	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(digest))
+func (s *Store) fetchBlob(ctx context.Context, reg *registryContext, imageName string, blob descriptor) ([]byte, error) {
+	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(blob.Digest))
 	if data, err := os.ReadFile(blobPath); err == nil {
 		return data, nil
 	}
 
-	body, _, err := s.getJSONBlob(ctx, reg, "/"+imageName+"/blobs/"+digest, nil)
-	if err == nil {
-		if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err == nil {
-			_ = os.WriteFile(blobPath, body, 0o644)
-		}
-		return body, nil
-	}
-
-	data, err := s.getRawBlob(ctx, reg, "/"+imageName+"/blobs/"+digest)
+	data, err := s.getRawBlob(ctx, reg, "/"+imageName+"/blobs/"+blob.Digest, blob)
 	if err != nil {
 		return nil, err
 	}
@@ -1256,7 +1273,33 @@ func (s *Store) fetchLayerTar(ctx context.Context, reg *registryContext, imageNa
 		return err
 	}
 	defer resp.Body.Close()
-	return writeLayerTarFromReader(dstPath, layer.MediaType, resp.Body)
+	if layer.Size <= 0 {
+		return fmt.Errorf("layer %s has invalid size %d", layer.Digest, layer.Size)
+	}
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		return err
+	}
+	tmp := blobPath + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	_, copyErr := download.Copy(ctx, out, resp, download.Budget{MaxBytes: layer.Size, ExpectedBytes: layer.Size, ExpectedSHA256: layer.Digest})
+	closeErr := out.Close()
+	if copyErr != nil || closeErr != nil {
+		_ = os.Remove(tmp)
+		return errors.Join(copyErr, closeErr)
+	}
+	if err := os.Rename(tmp, blobPath); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	file, err := os.Open(blobPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return writeLayerTarFromReader(dstPath, layer.MediaType, file)
 }
 
 func (s *Store) getJSONBlob(ctx context.Context, reg *registryContext, path string, accept []string) ([]byte, string, error) {
@@ -1270,25 +1313,31 @@ func (s *Store) getJSONBlobWithDigest(ctx context.Context, reg *registryContext,
 		return nil, "", "", err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	data, err := download.ReadAll(ctx, resp, download.Budget{MaxBytes: maxRegistryMetadataBytes})
 	if err != nil {
 		return nil, "", "", fmt.Errorf("read response body: %w", err)
 	}
 	digest := strings.TrimSpace(resp.Header.Get("Docker-Content-Digest"))
+	sum := sha256.Sum256(data)
+	actualDigest := "sha256:" + hex.EncodeToString(sum[:])
 	if digest == "" {
-		sum := sha256.Sum256(data)
-		digest = "sha256:" + hex.EncodeToString(sum[:])
+		digest = actualDigest
+	} else if strings.HasPrefix(digest, "sha256:") && !strings.EqualFold(digest, actualDigest) {
+		return nil, "", "", &download.DigestError{Expected: digest, Actual: actualDigest}
 	}
 	return data, resp.Header.Get("Content-Type"), digest, nil
 }
 
-func (s *Store) getRawBlob(ctx context.Context, reg *registryContext, path string) ([]byte, error) {
+func (s *Store) getRawBlob(ctx context.Context, reg *registryContext, path string, blob descriptor) ([]byte, error) {
 	resp, err := reg.do(ctx, path, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	if blob.Size <= 0 {
+		return nil, fmt.Errorf("blob %s has invalid size %d", blob.Digest, blob.Size)
+	}
+	data, err := download.ReadAll(ctx, resp, download.Budget{MaxBytes: blob.Size, ExpectedBytes: blob.Size, ExpectedSHA256: blob.Digest})
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}
@@ -1321,9 +1370,13 @@ func (reg *registryContext) do(ctx context.Context, path string, accept []string
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 			resp.Body.Close()
 			return nil, fmt.Errorf("registry request failed: %s (%s)", resp.Status, strings.TrimSpace(string(body)))
+		}
+		if err := download.BoundResponse(resp, 0); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("registry response: %w", err)
 		}
 		return resp, nil
 	}
@@ -1358,6 +1411,9 @@ func (reg *registryContext) authorize(ctx context.Context, header string) error 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("token request failed: %s", resp.Status)
+	}
+	if err := download.BoundResponse(resp, 1<<20); err != nil {
+		return fmt.Errorf("registry token response: %w", err)
 	}
 	var token tokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {

--- a/internal/vm/builtin/bsd_oci.go
+++ b/internal/vm/builtin/bsd_oci.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"j5.nz/cc/internal/download"
 	freebsdrootfs "j5.nz/cc/internal/freebsd/rootfs"
 	"j5.nz/cc/internal/managed/machine"
 	"j5.nz/cc/internal/managed/rootartifact"
@@ -19,6 +20,7 @@ import (
 )
 
 const bsdKernelMediaType = "application/vnd.tinyrange.bsd.kernel.v1"
+const maxBSDRegistryMetadataBytes int64 = 16 << 20
 
 type bsdOCIManifest struct {
 	Layers []struct {
@@ -135,23 +137,26 @@ func ensureBSDOCIArtifact(ctx context.Context, cacheDir, repo, tag string) (stri
 		return "", nil, fmt.Errorf("decode BSD OCI manifest: %w", err)
 	}
 	var rootDigest, kernelDigest string
+	var rootSize, kernelSize int64
 	for _, layer := range manifest.Layers {
 		if strings.Contains(layer.MediaType, "tar+gzip") {
 			rootDigest = layer.Digest
+			rootSize = layer.Size
 		}
 		if layer.MediaType == bsdKernelMediaType {
 			kernelDigest = layer.Digest
+			kernelSize = layer.Size
 		}
 	}
 	if rootDigest == "" || kernelDigest == "" {
 		return "", nil, fmt.Errorf("BSD OCI manifest missing rootfs or kernel layer")
 	}
 	rootPath := filepath.Join(cacheDir, digestFile(rootDigest)+".tar.gz")
-	if err := ensureRegistryBlob(ctx, repo, rootDigest, rootPath); err != nil {
+	if err := ensureRegistryBlob(ctx, repo, rootDigest, rootSize, rootPath); err != nil {
 		return "", nil, err
 	}
 	kernelPath := filepath.Join(cacheDir, digestFile(kernelDigest)+".kernel")
-	if err := ensureRegistryBlob(ctx, repo, kernelDigest, kernelPath); err != nil {
+	if err := ensureRegistryBlob(ctx, repo, kernelDigest, kernelSize, kernelPath); err != nil {
 		return "", nil, err
 	}
 	kernel, err := os.ReadFile(kernelPath)
@@ -161,7 +166,7 @@ func ensureBSDOCIArtifact(ctx context.Context, cacheDir, repo, tag string) (stri
 	return rootPath, kernel, nil
 }
 
-func ensureRegistryBlob(ctx context.Context, repo, digest, target string) error {
+func ensureRegistryBlob(ctx context.Context, repo, digest string, size int64, target string) error {
 	if st, err := os.Stat(target); err == nil && st.Size() > 0 {
 		return nil
 	}
@@ -170,12 +175,15 @@ func ensureRegistryBlob(ctx context.Context, repo, digest, target string) error 
 		return err
 	}
 	defer resp.Body.Close()
+	if size <= 0 {
+		return fmt.Errorf("registry blob %s has invalid size %d", digest, size)
+	}
 	tmp := target + ".tmp"
 	out, err := os.Create(tmp)
 	if err != nil {
 		return err
 	}
-	_, copyErr := io.Copy(out, resp.Body)
+	_, copyErr := download.Copy(ctx, out, resp, download.Budget{MaxBytes: size, ExpectedBytes: size, ExpectedSHA256: digest})
 	closeErr := out.Close()
 	if copyErr != nil {
 		_ = os.Remove(tmp)
@@ -198,7 +206,7 @@ func registryGet(ctx context.Context, rawURL, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
+	return download.ReadAll(ctx, resp, download.Budget{MaxBytes: maxBSDRegistryMetadataBytes})
 }
 
 func registryDo(ctx context.Context, rawURL, accept string) (*http.Response, error) {
@@ -232,6 +240,10 @@ func registryDo(ctx context.Context, rawURL, accept string) (*http.Response, err
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		_ = resp.Body.Close()
 		return nil, fmt.Errorf("GET %s: %s", rawURL, resp.Status)
+	}
+	if err := download.BoundResponse(resp, 0); err != nil {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
 	}
 	return resp, nil
 }
@@ -280,7 +292,7 @@ func registryBearerToken(ctx context.Context, header string) (string, error) {
 	var out struct {
 		Token string `json:"token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBSDRegistryMetadataBytes)).Decode(&out); err != nil {
 		return "", err
 	}
 	if out.Token == "" {


### PR DESCRIPTION
Fixes #115

## Summary
- add one context-aware download layer with typed byte-limit, length-mismatch, and digest-mismatch errors
- require a positive wire budget for artifact responses; descriptor-backed OCI/BSD blobs use their exact declared size and digest, while other file responses use their exact HTTP content length
- cap registry/index metadata before allocation and bound in-memory module/CVMFS expansion
- stream OCI layers, rootfs archives, managed BSD releases, and local decompression through destination-filesystem capacity budgets
- publish caches only after complete length/hash validation; failed refreshes leave existing published content intact
- thread request/signal contexts through CVMFS HTTP operations and retain caller-controlled total deadlines rather than inventing a universal timeout
- preserve standard Go redirect/proxy behavior and existing registry auth retry behavior

Fixed metadata ceilings are format-specific: 16 MiB for OCI/CVMFS metadata, 64 MiB for package indexes, 1 MiB for registry tokens, and 256 MiB for one expanded kernel module. Large runtime data is streamed and admitted against the actual available destination filesystem rather than an arbitrary artifact-size default. CVMFS expanded in-memory objects retain a configurable architectural ceiling of 4 GiB.

## Validation
- behavior coverage for pre-publication oversize rejection, truncated responses, digest mismatches, and cancellation
- `go test ./...`
- cross-compiled the download layer for Linux, Darwin, Windows, FreeBSD, NetBSD, and OpenBSD
- cross-compiled OCI for Linux/arm64 and built-in BSD artifacts for Windows/arm64

No special hardware is required.