### PR TITLE
Fix balloon startup and IPv6 diagnostics

### DIFF
--- a/internal/netstack/netstack.go
+++ b/internal/netstack/netstack.go
@@ -282,7 +282,7 @@ type NetStack struct {
 	// Simple counters.
 	udpRxPackets     atomic.Uint64
 	udpTxPackets     atomic.Uint64
-	sourceViolations [5]atomic.Uint64
+	sourceViolations [6]atomic.Uint64
 	closeOnce        sync.Once
 }
 
@@ -752,7 +752,9 @@ func (ns *NetStack) handleEthernetFrameWithReuse(frame []byte, releaseUnsafe boo
 
 	expectedMAC := macFromUint64(macAddr(ns.guestMAC.Load()))
 	if violation := ValidateGuestSource(frame, expectedMAC, net.IP(ns.guestIPv4[:])); violation != SourceValid {
-		ns.recordSourceViolation(violation, src)
+		if violation != SourceUnsupportedProtocol {
+			ns.recordSourceViolation(violation, src)
+		}
 		return nil
 	}
 

--- a/internal/netstack/source_validation.go
+++ b/internal/netstack/source_validation.go
@@ -13,6 +13,7 @@ const (
 	SourceMACViolation
 	SourceARPViolation
 	SourceIPv4Violation
+	SourceUnsupportedProtocol
 )
 
 func (v SourceViolation) String() string {
@@ -25,6 +26,8 @@ func (v SourceViolation) String() string {
 		return "arp"
 	case SourceIPv4Violation:
 		return "ipv4"
+	case SourceUnsupportedProtocol:
+		return "unsupported"
 	default:
 		return "valid"
 	}
@@ -46,8 +49,8 @@ func ValidateGuestSource(frame []byte, expectedMAC net.HardwareAddr, expectedIPv
 		return validateARPSource(frame[ethernetHeaderLen:], expectedMAC, expectedIPv4.To4())
 	case uint16(etherTypeIPv4):
 		return validateIPv4Source(frame[ethernetHeaderLen:], expectedIPv4.To4())
-	case 0x86dd: // IPv6 has no assigned identity in the IPv4-only guest lease.
-		return SourceIPv4Violation
+	case 0x86dd: // The IPv4-only network drops ordinary guest IPv6 control traffic quietly.
+		return SourceUnsupportedProtocol
 	default:
 		return SourceValid
 	}

--- a/internal/netstack/source_validation_test.go
+++ b/internal/netstack/source_validation_test.go
@@ -18,7 +18,7 @@ func TestValidateGuestSource(t *testing.T) {
 		{name: "assigned IPv4", frame: sourceValidationIPv4Frame(mac, ip, 1, 0, 0), want: SourceValid},
 		{name: "spoofed Ethernet source", frame: sourceValidationIPv4Frame(net.HardwareAddr{0x02, 0x42, 0x0a, 0x2a, 0, 3}, ip, 1, 0, 0), want: SourceMACViolation},
 		{name: "spoofed IPv4 source", frame: sourceValidationIPv4Frame(mac, net.IPv4(10, 42, 0, 3), 1, 0, 0), want: SourceIPv4Violation},
-		{name: "unassigned IPv6", frame: sourceValidationEtherTypeFrame(mac, 0x86dd), want: SourceIPv4Violation},
+		{name: "unsupported IPv6", frame: sourceValidationEtherTypeFrame(mac, 0x86dd), want: SourceUnsupportedProtocol},
 		{name: "DHCP discovery", frame: sourceValidationIPv4Frame(mac, net.IPv4zero, byte(udpProtocolNumber), 68, 67), want: SourceValid},
 		{name: "non-DHCP unspecified IPv4", frame: sourceValidationIPv4Frame(mac, net.IPv4zero, byte(udpProtocolNumber), 1234, 67), want: SourceIPv4Violation},
 		{name: "assigned ARP", frame: sourceValidationARPFrame(mac, ip, net.IPv4(10, 42, 0, 1)), want: SourceValid},

--- a/internal/virtio/balloon.go
+++ b/internal/virtio/balloon.go
@@ -15,6 +15,7 @@ const (
 	balloonQueueInflate = 0
 	balloonQueueDeflate = 1
 	balloonPageSize     = 4096
+	balloonDriverOK     = 0x4
 )
 
 type PageReclaimer interface {
@@ -103,6 +104,9 @@ func (b *Balloon) SetTargetPages(pages uint32) error {
 	}
 	b.numPages = pages
 	b.configGeneration++
+	if b.status&balloonDriverOK == 0 {
+		return nil
+	}
 	b.interruptStatus |= intConfig
 	return b.updateIRQLocked()
 }
@@ -225,9 +229,13 @@ func (b *Balloon) Write(addr uint64, size int, value uint64) error {
 		b.interruptStatus &^= uint32(value)
 		return b.updateIRQLocked()
 	case regStatus:
+		wasReady := b.status&balloonDriverOK != 0
 		b.status = uint32(value)
 		if b.status == 0 {
 			b.resetLocked()
+		} else if !wasReady && b.status&balloonDriverOK != 0 && b.actualPages != b.numPages {
+			b.interruptStatus |= intConfig
+			return b.updateIRQLocked()
 		}
 	case regQueueNotify:
 		if int(value) == balloonQueueInflate || int(value) == balloonQueueDeflate {

--- a/internal/virtio/balloon_test.go
+++ b/internal/virtio/balloon_test.go
@@ -42,6 +42,9 @@ func TestBalloonTargetRaisesConfigInterrupt(t *testing.T) {
 	irq := &testIRQ{}
 	dev := NewBalloon(0, 0x1000, 12)
 	dev.Attach(make(testGuestMemory, 0x10000), irq)
+	if err := dev.Write(regStatus, 4, balloonDriverOK); err != nil {
+		t.Fatalf("mark driver ready: %v", err)
+	}
 
 	if err := dev.SetTargetPages(16); err != nil {
 		t.Fatalf("SetTargetPages: %v", err)
@@ -60,6 +63,32 @@ func TestBalloonTargetRaisesConfigInterrupt(t *testing.T) {
 	}
 	if irq.level {
 		t.Fatalf("config ack left IRQ asserted")
+	}
+}
+
+func TestBalloonTargetBeforeDriverReadyDefersConfigInterrupt(t *testing.T) {
+	irq := &testIRQ{}
+	dev := NewBalloon(0, 0x1000, 12)
+	dev.Attach(make(testGuestMemory, 0x10000), irq)
+
+	if err := dev.SetTargetPages(16); err != nil {
+		t.Fatalf("set initial target: %v", err)
+	}
+	if irq.level {
+		t.Fatal("initial target asserted IRQ before the guest driver was ready")
+	}
+	if got, err := dev.Read(regInterruptStatus, 4); err != nil || got != 0 {
+		t.Fatalf("interrupt status = %#x, %v; want 0 before driver readiness", got, err)
+	}
+	if got, err := dev.Read(regConfig, 4); err != nil || got != 16 {
+		t.Fatalf("target pages = %d, %v; want 16, nil", got, err)
+	}
+
+	if err := dev.Write(regStatus, 4, balloonDriverOK); err != nil {
+		t.Fatalf("mark driver ready: %v", err)
+	}
+	if !irq.level {
+		t.Fatal("driver readiness did not publish the pending balloon target")
 	}
 }
 

--- a/internal/vm/sidecar_resources_darwin_arm64.go
+++ b/internal/vm/sidecar_resources_darwin_arm64.go
@@ -454,7 +454,7 @@ type darwinSidecarSwitch struct {
 	mu               sync.Mutex
 	leases           map[string]darwinSidecarLease
 	endpoints        map[string]darwinSidecarEndpoint
-	sourceViolations [5]uint64
+	sourceViolations [6]uint64
 }
 
 type darwinSidecarLease struct {
@@ -541,7 +541,9 @@ func (s *darwinSidecarSwitch) Forward(sourceID string, frame []byte) {
 		return
 	}
 	if violation := netstack.ValidateGuestSource(frame, source.mac, source.ip); violation != netstack.SourceValid {
-		s.recordSourceViolation(sourceID, violation)
+		if violation != netstack.SourceUnsupportedProtocol {
+			s.recordSourceViolation(sourceID, violation)
+		}
 		return
 	}
 	dst := append(net.HardwareAddr(nil), frame[0:6]...)

--- a/internal/vm/sidecar_resources_darwin_arm64_test.go
+++ b/internal/vm/sidecar_resources_darwin_arm64_test.go
@@ -73,6 +73,22 @@ func TestDarwinSidecarSwitchDropsSpoofedSources(t *testing.T) {
 	if got := switcher.sourceViolationCount(netstack.SourceMACViolation); got != 1 {
 		t.Fatalf("MAC violation count = %d, want 1", got)
 	}
+
+	switcher.Forward("a", darwinSidecarEtherTypeFrame(macB, macA, 0x86dd))
+	if received != 1 {
+		t.Fatalf("unsupported IPv6 frame reached target: deliveries = %d", received)
+	}
+	if got := switcher.sourceViolationCount(netstack.SourceUnsupportedProtocol); got != 0 {
+		t.Fatalf("ordinary unsupported frame violation count = %d, want 0", got)
+	}
+}
+
+func darwinSidecarEtherTypeFrame(destinationMAC, sourceMAC net.HardwareAddr, etherType uint16) []byte {
+	frame := make([]byte, 14)
+	copy(frame[0:6], destinationMAC)
+	copy(frame[6:12], sourceMAC)
+	binary.BigEndian.PutUint16(frame[12:14], etherType)
+	return frame
 }
 
 func darwinSidecarIPv4Frame(destinationMAC, sourceMAC net.HardwareAddr, sourceIP net.IP) []byte {


### PR DESCRIPTION
## Summary

- defer virtio-balloon configuration interrupts until the guest driver reaches `DRIVER_OK`
- classify ordinary IPv6 multicast traffic as unsupported instead of an IPv4 source-identity violation
- suppress misleading worker and sidecar warnings for that unsupported traffic while continuing to drop it

## User impact

On Apple Silicon, setting the balloon target before the guest driver was ready could trigger a level interrupt storm while Linux loaded `virtio_balloon`, including `irq 15: nobody cared`, delaying guest boot. Normal IPv6 MLD frames could also produce duplicate scary source-identity warnings even though the guest was not spoofing traffic.

## Validation

- `go test ./internal/virtio ./internal/netstack ./internal/vm -count=1`
- `go test ./... -count=1 -timeout 30m`
- `go vet ./...`
- Darwin/arm64 `internal/vm` test binary cross-compiled with CGO disabled
- KVM balloon boot and snapshot target integration tests passed
- live unsigned M4 macOS build completed the interactive `@alpine` context-selection workflow without the interrupt-storm or invalid-source warnings
