### PR TITLE
Fix warm snapshot balloon retargeting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
             test_run: ^(TestBootNetBSD|TestNetBSD)
           - name: vm-runtime
             packages: ./internal/vm
-            test_run: ^TestRuntime(BootsLinux|OneShot|RejectsInvalidRequests|BootsPersistentLinux|Persistent|Isolated)
+            test_run: ^TestRuntime(BootsLinux|OneShot|RejectsInvalidRequests|BootsPersistentLinux|RestoresPersistentLinuxFromStartupSnapshot|Snapshot|Persistent|Isolated)
           - name: rootfs-support
             packages: ./internal/fsimage/ffs ./internal/netbsd/rootfs ./internal/openbsd/rootfs
             test_run: .

--- a/internal/hv/hvf/snapshot_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64.go
@@ -188,7 +188,7 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 	timingLog("hvf.restore device setup took=%s fsdevs=%d", time.Since(start), len(fsdevs))
 	start = time.Now()
 	if len(manifest.Devices) > 0 {
-		if err := restoreDeviceStates(manifest.Devices, console, rng, balloon, fsdevs, vsock, netdev); err != nil {
+		if err := restoreDeviceStates(manifest.Devices, console, rng, balloon, balloonTargetPages(req.BalloonMB), fsdevs, vsock, netdev); err != nil {
 			_ = listener.Close()
 			vm.Close()
 			return nil, err
@@ -455,7 +455,7 @@ func (s *snapshotTrigger) contains(addr uint64, size int) bool {
 
 func (s *snapshotTrigger) handleDataAbort(vm *VM, vcpuIndex int, info DataAbortInfo, value uint64) error {
 	if !info.Write {
-		if err := writeAbortValue(vm, vcpuIndex, info, snapshotTriggerMagic); err != nil {
+		if err := writeAbortValue(vm, vcpuIndex, info, s.readyValue()); err != nil {
 			return err
 		}
 		return vm.AdvanceProgramCounterForVCPU(vcpuIndex)
@@ -470,6 +470,13 @@ func (s *snapshotTrigger) handleDataAbort(vm *VM, vcpuIndex int, info DataAbortI
 		timingLog("snapshot trigger capture failed: %v", s.err)
 	}
 	return nil
+}
+
+func (s *snapshotTrigger) readyValue() uint64 {
+	if s != nil && s.devices.balloon != nil && !s.devices.balloon.AtTarget() {
+		return 0
+	}
+	return snapshotTriggerMagic
 }
 
 func (s *snapshotTrigger) capture(vm *VM, vcpuIndex int, value uint64) error {
@@ -704,7 +711,7 @@ func snapshotDeviceStates(devices snapshotDevices) map[string]virtio.MMIOState {
 	return out
 }
 
-func restoreDeviceStates(states map[string]virtio.MMIOState, console *virtio.Console, rng *virtio.RNG, balloon *virtio.Balloon, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net) error {
+func restoreDeviceStates(states map[string]virtio.MMIOState, console *virtio.Console, rng *virtio.RNG, balloon *virtio.Balloon, balloonTarget uint32, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net) error {
 	if state, ok := states["console"]; ok && console != nil {
 		if err := console.RestoreState(state); err != nil {
 			return fmt.Errorf("restore console state: %w", err)
@@ -718,6 +725,11 @@ func restoreDeviceStates(states map[string]virtio.MMIOState, console *virtio.Con
 	if state, ok := states["balloon"]; ok && balloon != nil {
 		if err := balloon.RestoreState(state); err != nil {
 			return fmt.Errorf("restore balloon state: %w", err)
+		}
+	}
+	if balloon != nil {
+		if err := balloon.SetTargetPages(balloonTarget); err != nil {
+			return fmt.Errorf("retarget restored balloon: %w", err)
 		}
 	}
 	if state, ok := states["vsock"]; ok && vsock != nil {
@@ -797,12 +809,6 @@ func validateSnapshotRequest(manifest snapshotManifest, req ContainerRunRequest)
 		want := arm64vm.MemorySizeBytes(req.MemoryMB)
 		if manifest.MemorySize != 0 && manifest.MemorySize != want {
 			return fmt.Errorf("snapshot memory size = %d, want %d for %d MB VM", manifest.MemorySize, want, req.MemoryMB)
-		}
-	}
-	if state, ok := manifest.Devices["balloon"]; ok {
-		want := balloonTargetPages(req.BalloonMB)
-		if state.NumPages != want {
-			return fmt.Errorf("snapshot balloon target pages = %d, want %d", state.NumPages, want)
 		}
 	}
 	return nil

--- a/internal/hv/hvf/snapshot_darwin_arm64_test.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64_test.go
@@ -10,7 +10,7 @@ import (
 	"j5.nz/cc/internal/vmruntime"
 )
 
-func TestValidateSnapshotRequestMatchesMemoryAndBalloon(t *testing.T) {
+func TestValidateSnapshotRequestRequiresMatchingMemory(t *testing.T) {
 	manifest := snapshotManifest{
 		MemorySize: arm64vm.MemorySizeBytes(4096),
 		Devices: map[string]virtio.MMIOState{
@@ -24,7 +24,45 @@ func TestValidateSnapshotRequestMatchesMemoryAndBalloon(t *testing.T) {
 	if err := validateSnapshotRequest(manifest, vmruntime.RunRequest{MemoryMB: 2048, BalloonMB: 1024}); err == nil {
 		t.Fatalf("validate mismatched memory succeeded")
 	}
-	if err := validateSnapshotRequest(manifest, vmruntime.RunRequest{MemoryMB: 4096, BalloonMB: 512}); err == nil {
-		t.Fatalf("validate mismatched balloon succeeded")
+	if err := validateSnapshotRequest(manifest, vmruntime.RunRequest{MemoryMB: 4096, BalloonMB: 512}); err != nil {
+		t.Fatalf("validate snapshot with a new balloon target: %v", err)
+	}
+}
+
+func TestRestoreDeviceStatesAppliesCurrentBalloonTarget(t *testing.T) {
+	balloon := virtio.NewBalloon(arm64vm.BalloonBase, arm64vm.BalloonSize, arm64vm.BalloonIRQ)
+	state := balloon.SnapshotState()
+	state.Status = 4
+	state.NumPages = balloonTargetPages(1024)
+
+	want := balloonTargetPages(512)
+	if err := restoreDeviceStates(map[string]virtio.MMIOState{"balloon": state}, nil, nil, balloon, want, nil, nil, nil); err != nil {
+		t.Fatalf("restore balloon state: %v", err)
+	}
+	if got := balloon.SnapshotState().NumPages; got != want {
+		t.Fatalf("restored balloon target pages = %d, want %d", got, want)
+	}
+}
+
+func TestSnapshotTriggerWaitsForBalloonTarget(t *testing.T) {
+	balloon := virtio.NewBalloon(arm64vm.BalloonBase, arm64vm.BalloonSize, arm64vm.BalloonIRQ)
+	state := balloon.SnapshotState()
+	state.Status = 4
+	state.NumPages = balloonTargetPages(160)
+	state.ActualPages = balloonTargetPages(128)
+	if err := balloon.RestoreState(state); err != nil {
+		t.Fatalf("restore balloon state: %v", err)
+	}
+	trigger := &snapshotTrigger{devices: snapshotDevices{balloon: balloon}}
+	if got := trigger.readyValue(); got != 0 {
+		t.Fatalf("snapshot trigger ready value = %#x before balloon target, want 0", got)
+	}
+
+	state.ActualPages = state.NumPages
+	if err := balloon.RestoreState(state); err != nil {
+		t.Fatalf("restore balloon target state: %v", err)
+	}
+	if got := trigger.readyValue(); got != snapshotTriggerMagic {
+		t.Fatalf("snapshot trigger ready value = %#x at balloon target, want %#x", got, snapshotTriggerMagic)
 	}
 }

--- a/internal/hv/kvm/snapshot_balloon_linux_amd64_test.go
+++ b/internal/hv/kvm/snapshot_balloon_linux_amd64_test.go
@@ -1,0 +1,28 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"testing"
+
+	"j5.nz/cc/internal/amd64vm"
+	"j5.nz/cc/internal/virtio"
+)
+
+func TestRestoreKVMDeviceStatesAppliesCurrentBalloonTarget(t *testing.T) {
+	balloon := virtio.NewBalloon(amd64vm.BalloonBase, amd64vm.BalloonSize, amd64vm.BalloonIRQ)
+	state := balloon.SnapshotState()
+	state.Status = 4
+	state.NumPages = balloonTargetPages(1024)
+
+	want := balloonTargetPages(512)
+	if err := restoreKVMDeviceStates(map[string]virtio.MMIOState{"balloon": state}, nil, nil, nil, balloon, nil); err != nil {
+		t.Fatalf("restore balloon state: %v", err)
+	}
+	if err := retargetRestoredBalloon(balloon, want); err != nil {
+		t.Fatalf("retarget restored balloon: %v", err)
+	}
+	if got := balloon.SnapshotState().NumPages; got != want {
+		t.Fatalf("restored balloon target pages = %d, want %d", got, want)
+	}
+}

--- a/internal/hv/kvm/snapshot_linux_amd64.go
+++ b/internal/hv/kvm/snapshot_linux_amd64.go
@@ -327,13 +327,6 @@ func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, m
 	}
 	vsock := virtio.NewVsock(amd64vm.VsockBase, amd64vm.VsockSize, amd64vm.VsockIRQ, vmruntime.GuestCID, backend)
 	balloon := virtio.NewBalloon(amd64vm.BalloonBase, amd64vm.BalloonSize, amd64vm.BalloonIRQ)
-	if targetPages := balloonTargetPages(balloonMB); targetPages != 0 {
-		if err := balloon.SetTargetPages(targetPages); err != nil {
-			_ = listener.Close()
-			vsock.Close()
-			return nil, fmt.Errorf("set balloon target: %w", err)
-		}
-	}
 	connCh := make(chan virtio.VsockConn, 1)
 	acceptErrCh := make(chan error, 1)
 	controlTranscript := vmruntime.NewSerialTranscript()
@@ -355,6 +348,15 @@ func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, m
 	}
 	vm, uart, rng, serialOut, err := restoreManagedVMFromSnapshot(manifest, memPath, memoryMB, dmesg, fsdevs, vsock, balloon, netdev, serialWriter)
 	if err != nil {
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, err
+	}
+	if err := retargetRestoredBalloon(balloon, balloonTargetPages(balloonMB)); err != nil {
+		closeVMWithFS(vm, fsdevs)
 		_ = listener.Close()
 		vsock.Close()
 		if bootWriter != nil {
@@ -807,6 +809,16 @@ func restoreKVMDeviceStates(states map[string]virtio.MMIOState, fsdevs []*virtio
 		if err := fsdev.RestoreState(state); err != nil {
 			return fmt.Errorf("restore fs device %#x state: %w", fsdev.Base, err)
 		}
+	}
+	return nil
+}
+
+func retargetRestoredBalloon(balloon *virtio.Balloon, target uint32) error {
+	if balloon == nil {
+		return nil
+	}
+	if err := balloon.SetTargetPages(target); err != nil {
+		return fmt.Errorf("retarget restored balloon: %w", err)
 	}
 	return nil
 }

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -622,9 +622,9 @@ func TestRuntimeRestoresPersistentLinuxFromStartupSnapshot(t *testing.T) {
 	requireGuestOutput(t, resp.Output, "restored-startup-snapshot", "Linux")
 }
 
-func TestRuntimeSnapshotWaitsForBalloonTarget(t *testing.T) {
-	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
-		t.Skip("virtio balloon startup snapshots are implemented on Linux amd64")
+func TestRuntimeSnapshotAppliesCurrentBalloonTarget(t *testing.T) {
+	if !((runtime.GOOS == "linux" && runtime.GOARCH == "amd64") || (runtime.GOOS == "darwin" && runtime.GOARCH == "arm64")) {
+		t.Skip("virtio balloon startup snapshots are implemented on Linux amd64 and Darwin arm64")
 	}
 	env := newRuntimeBootEnv(t)
 	snapshotRoot := t.TempDir()
@@ -665,12 +665,30 @@ func TestRuntimeSnapshotWaitsForBalloonTarget(t *testing.T) {
 	restored := startRuntimeInstance(t, env, client.CreateInstanceRequest{
 		RestoreSnapshot: snapshotPath,
 		MemoryMB:        256,
-		BalloonMB:       160,
+		BalloonMB:       64,
 		CPUs:            1,
 	})
 	defer restored.Close()
-	resp := execInRuntime(t, restored, []string{"sh", "-lc", "printf 'balloon-restored\\n'"})
-	requireGuestOutput(t, resp.Output, "balloon-restored")
+	resp := execInRuntime(t, restored, []string{"sh", "-lc", `
+for attempt in $(seq 1 100); do
+	memory_kb=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
+	if test "$memory_kb" -ge 143360; then
+		printf 'balloon-retargeted:%s\n' "$memory_kb"
+		exit 0
+	fi
+	sleep 0.02
+done
+printf 'balloon target was not applied; MemTotal=' >&2
+awk '/^MemTotal:/ { print $2 " kB" }' /proc/meminfo >&2
+exit 1
+`})
+	var memoryKB uint64
+	if _, err := fmt.Sscanf(strings.TrimSpace(resp.Output), "balloon-retargeted:%d", &memoryKB); err != nil {
+		t.Fatalf("parse restored guest memory from %q: %v", resp.Output, err)
+	}
+	if memoryKB < 143360 {
+		t.Fatalf("restored guest memory = %d kB, want at least 143360 kB after applying the current balloon target", memoryKB)
+	}
 }
 
 func TestRuntimePersistentRejectsRuntimeMountConflicts(t *testing.T) {
@@ -1183,9 +1201,14 @@ func newRuntimeBootEnv(t *testing.T) *runtimeBootEnv {
 	}
 
 	store := oci.NewStore(filepath.Join(t.TempDir(), "images"))
-	fixture := filepath.Join(root, "fixtures", "alpine.simg")
+	architecture := runtime.GOARCH
+	fixtureName := "alpine.simg"
+	if architecture == "arm64" {
+		fixtureName = "alpine-arm64.simg"
+	}
+	fixture := filepath.Join(root, "fixtures", fixtureName)
 	for _, name := range []string{runtimeBootImage, runtimeBootAltImage} {
-		if _, err := store.Pull(ctx, name, fixture, oci.PullOptions{Architecture: "amd64"}); err != nil {
+		if _, err := store.Pull(ctx, name, fixture, oci.PullOptions{Architecture: architecture}); err != nil {
 			t.Fatalf("import Alpine SIMG fixture as %s: %v", name, err)
 		}
 	}


### PR DESCRIPTION
## Summary

- allow startup snapshots to restore when the current balloon policy differs from the captured target
- retarget restored virtio balloons on HVF and KVM before resuming the guest
- make HVF wait for balloon convergence before capturing a startup snapshot
- exercise balloon retargeting with real runtime coverage on Linux amd64 and Darwin arm64

## Root cause

HVF treated the balloon target embedded in a snapshot as part of snapshot compatibility. vmshd recomputes balloon targets from current host pressure, so a changed target rejected an otherwise valid warm snapshot and vmsh silently rebuilt it through the cold-boot fallback. KVM accepted the snapshot but retained the stale target. HVF also exposed the snapshot trigger before its balloon reached the capture target.

## Impact

Warm startup snapshots remain reusable as memory pressure changes and across daemon restarts. The restored guest receives the current memory policy. On an Apple Silicon Mac, a 512 MiB vmsh startup snapshot restores in 57–62 ms end-to-end after a roughly 691 ms cold boot and capture.

## Validation

- `go test -short ./... -count=1 -timeout 30m`
- `go test -race -short ./internal/ccvmd ./internal/netstack ./internal/virtio ./internal/vm/... -count=1 -timeout 15m`
- `go vet ./...`
- Staticcheck correctness checks
- real Linux KVM startup snapshot and balloon-retarget tests
- native signed Apple Silicon HVF balloon-retarget test
- Darwin ARM64 HVF test cross-compilation