### PR TITLE
Optimize sparse KVM snapshot capture

### DIFF
--- a/internal/hv/kvm/snapshot_linux_amd64.go
+++ b/internal/hv/kvm/snapshot_linux_amd64.go
@@ -3,7 +3,9 @@
 package kvm
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 	"j5.nz/cc/client"
@@ -277,33 +280,96 @@ func writeSparseFile(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	defer file.Close()
-	const chunkSize = 4096
-	for off := 0; off < len(data); {
-		end := off + chunkSize
-		if end > len(data) {
-			end = len(data)
-		}
-		chunk := data[off:end]
-		if !allZero(chunk) {
-			if _, err := file.WriteAt(chunk, int64(off)); err != nil {
-				return err
-			}
-		}
-		off = end
-	}
 	if err := file.Truncate(int64(len(data))); err != nil {
+		return err
+	}
+	pageSize := unix.Getpagesize()
+	resident, ok := residentSnapshotPages(data, pageSize)
+	if !ok {
+		resident = nil
+	}
+	if err := writePopulatedSnapshotPages(file, data, resident, pageSize); err != nil {
 		return err
 	}
 	return file.Close()
 }
 
-func allZero(data []byte) bool {
-	for _, b := range data {
-		if b != 0 {
-			return false
+// residentSnapshotPages identifies anonymous guest-memory pages that currently
+// have backing storage. Non-resident, non-swapped pages in the guest's private
+// anonymous mapping have never been populated (or were reclaimed by the
+// balloon) and will read as zero, so snapshot capture can avoid faulting and
+// scanning the entire configured address space.
+func residentSnapshotPages(data []byte, pageSize int) ([]bool, bool) {
+	if len(data) == 0 {
+		return nil, true
+	}
+	base := uintptr(unsafe.Pointer(&data[0]))
+	if pageSize <= 0 || base%uintptr(pageSize) != 0 {
+		return nil, false
+	}
+	file, err := os.Open("/proc/self/pagemap")
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+
+	pageCount := (len(data) + pageSize - 1) / pageSize
+	resident := make([]bool, pageCount)
+	const entriesPerRead = 32 * 1024
+	entries := make([]byte, entriesPerRead*8)
+	firstVirtualPage := base / uintptr(pageSize)
+	for first := 0; first < pageCount; first += entriesPerRead {
+		count := min(entriesPerRead, pageCount-first)
+		buf := entries[:count*8]
+		offset := int64(firstVirtualPage+uintptr(first)) * 8
+		n, err := file.ReadAt(buf, offset)
+		if n != len(buf) || (err != nil && err != io.EOF) {
+			return nil, false
+		}
+		for i := 0; i < count; i++ {
+			entry := binary.LittleEndian.Uint64(buf[i*8:])
+			const presentOrSwapped = uint64(3) << 62
+			resident[first+i] = entry&presentOrSwapped != 0
 		}
 	}
-	return true
+	return resident, true
+}
+
+func writePopulatedSnapshotPages(file *os.File, data []byte, resident []bool, pageSize int) error {
+	runStart := -1
+	flush := func(end int) error {
+		if runStart < 0 {
+			return nil
+		}
+		_, err := file.WriteAt(data[runStart:end], int64(runStart))
+		runStart = -1
+		return err
+	}
+	for off, page := 0, 0; off < len(data); off, page = off+pageSize, page+1 {
+		end := min(off+pageSize, len(data))
+		if resident != nil && !resident[page] {
+			if err := flush(off); err != nil {
+				return err
+			}
+			continue
+		}
+		if allZero(data[off:end]) {
+			if err := flush(off); err != nil {
+				return err
+			}
+			continue
+		}
+		if runStart < 0 {
+			runStart = off
+		}
+	}
+	return flush(len(data))
+}
+
+var zeroSnapshotPage = make([]byte, unix.Getpagesize())
+
+func allZero(data []byte) bool {
+	return len(data) <= len(zeroSnapshotPage) && bytes.Equal(data, zeroSnapshotPage[:len(data)])
 }
 
 func StartManagedSessionFromSnapshot(ctx context.Context, snapshotPath string, memoryMB uint64, balloonMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {

--- a/internal/hv/kvm/snapshot_sparse_linux_amd64_test.go
+++ b/internal/hv/kvm/snapshot_sparse_linux_amd64_test.go
@@ -1,0 +1,110 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSparseSnapshotMemoryPreservesGuestRAMWithoutAllocatingEmptyPages(t *testing.T) {
+	const memorySize = 64 << 20
+	mem, err := unix.Mmap(-1, 0, memorySize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANONYMOUS|unix.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("map guest memory: %v", err)
+	}
+	defer unix.Munmap(mem)
+
+	pageSize := unix.Getpagesize()
+	for _, offset := range []int{0, memorySize / 2, memorySize - pageSize} {
+		for i := 0; i < pageSize; i++ {
+			mem[offset+i] = byte(i*31 + offset/pageSize)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "memory.bin")
+	if err := writeSparseFile(path, mem, 0o600); err != nil {
+		t.Fatalf("write sparse snapshot memory: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat snapshot memory: %v", err)
+	}
+	if info.Size() != memorySize {
+		t.Fatalf("snapshot logical size = %d, want %d", info.Size(), memorySize)
+	}
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		t.Fatalf("stat snapshot blocks: %v", err)
+	}
+	allocated := stat.Blocks * 512
+	if allocated >= 1<<20 {
+		t.Fatalf("snapshot allocated %d bytes for three populated pages in %d bytes of guest RAM", allocated, memorySize)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open snapshot memory: %v", err)
+	}
+	defer file.Close()
+	restored, err := unix.Mmap(int(file.Fd()), 0, memorySize, unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("map snapshot memory: %v", err)
+	}
+	defer unix.Munmap(restored)
+	if !bytes.Equal(restored, mem) {
+		t.Fatal("restored sparse snapshot memory differs from captured guest RAM")
+	}
+}
+
+func TestSparseSnapshotMemoryFallsBackForUnalignedGuestRAM(t *testing.T) {
+	pageSize := unix.Getpagesize()
+	storage := make([]byte, pageSize*3+1)
+	mem := storage[1:]
+	copy(mem[pageSize-8:], []byte("fallback-data"))
+
+	path := filepath.Join(t.TempDir(), "memory.bin")
+	if err := writeSparseFile(path, mem, 0o600); err != nil {
+		t.Fatalf("write sparse snapshot memory: %v", err)
+	}
+	restored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot memory: %v", err)
+	}
+	if !bytes.Equal(restored, mem) {
+		t.Fatal("restored fallback snapshot memory differs from captured guest RAM")
+	}
+}
+
+func BenchmarkWriteSparseSnapshotMemory(b *testing.B) {
+	const memorySize = 2 << 30
+	mem, err := unix.Mmap(-1, 0, memorySize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANONYMOUS|unix.MAP_PRIVATE)
+	if err != nil {
+		b.Fatalf("map guest memory: %v", err)
+	}
+	defer unix.Munmap(mem)
+
+	const populated = 64 << 20
+	for i := 0; i < populated; i++ {
+		mem[i] = byte(i*31 + 1)
+	}
+	dir := b.TempDir()
+	b.SetBytes(memorySize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		path := filepath.Join(dir, "memory.bin")
+		if err := writeSparseFile(path, mem, 0o600); err != nil {
+			b.Fatalf("write sparse snapshot memory: %v", err)
+		}
+		b.StopTimer()
+		if err := os.Remove(path); err != nil {
+			b.Fatalf("remove snapshot memory: %v", err)
+		}
+		b.StartTimer()
+	}
+}


### PR DESCRIPTION
## Summary

- discover populated Linux/amd64 guest-memory pages through `/proc/self/pagemap`
- skip untouched and balloon-reclaimed anonymous pages without faulting or scanning the full configured address space
- coalesce adjacent populated pages into larger snapshot writes
- retain the zero-page scan as a correctness-first fallback
- preserve the existing full logical `memory.bin` size and mmap restore format
- add regression coverage for sparse allocation, byte-for-byte restore integrity, and fallback behavior

## Root cause

The existing Linux/amd64 writer already created sparse files, but it still scanned every 4 KiB page byte-by-byte and issued a separate `WriteAt` for each populated page. Capture time therefore scaled with configured guest RAM even when almost all of that address space was untouched.

## Results

For a 2 GiB anonymous guest mapping with 64 MiB populated:

- before: 842 ms
- after: 19.5–20.2 ms
- improvement: about 43×

A real 12 GiB KVM boot produced:

- logical snapshot size: 12 GiB
- physically allocated snapshot blocks: 268 MiB
- cold boot plus capture: 661 ms
- snapshot restore: 26.8 ms

The snapshot manifest and restore path are unchanged.

Darwin/arm64 follow-up is tracked in #181.

## Validation

- `go test ./...`
- `go test -race ./internal/hv/kvm -run '^TestSparseSnapshotMemory' -count=1`
- `go vet ./internal/hv/kvm`
- `go test ./internal/vm -run '^TestRuntimeRestoresPersistentLinuxFromStartupSnapshot$' -count=1 -v`
- `go test ./internal/hv/kvm -run '^$' -bench '^BenchmarkWriteSparseSnapshotMemory$' -benchtime=1x -count=5`
