### PR TITLE
Optimize sparse HVF snapshot capture

### DIFF
--- a/internal/hv/hvf/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings_darwin_arm64.go
@@ -214,7 +214,7 @@ var (
 	hvGICGetRedistributorBaseAlignment func(alignment *uintptr) Return
 	hvGICCreate                        func(config GICConfig) Return
 	machVMPageQuery                    func(targetMap uint32, offset uint64, disposition *int32, refCount *int32) int32
-	machTaskSelf                       uintptr
+	taskSelfTrap                       func() uint32
 
 	osRelease func(obj uintptr)
 )
@@ -271,7 +271,7 @@ func load() error {
 		registerOptionalLibFunc(&hvGICGetRedistributorBaseAlignment, hvLib, "hv_gic_get_redistributor_base_alignment")
 		registerOptionalLibFunc(&hvGICCreate, hvLib, "hv_gic_create")
 		registerOptionalLibFunc(&machVMPageQuery, sysLib, "mach_vm_page_query")
-		machTaskSelf, _ = purego.Dlsym(sysLib, "mach_task_self_")
+		registerOptionalLibFunc(&taskSelfTrap, sysLib, "task_self_trap")
 
 		purego.RegisterLibFunc(&osRelease, sysLib, "os_release")
 	})

--- a/internal/hv/hvf/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings_darwin_arm64.go
@@ -213,6 +213,8 @@ var (
 	hvGICGetDistributorBaseAlignment   func(alignment *uintptr) Return
 	hvGICGetRedistributorBaseAlignment func(alignment *uintptr) Return
 	hvGICCreate                        func(config GICConfig) Return
+	machVMPageQuery                    func(targetMap uint32, offset uint64, disposition *int32, refCount *int32) int32
+	machTaskSelf                       uintptr
 
 	osRelease func(obj uintptr)
 )
@@ -268,6 +270,8 @@ func load() error {
 		registerOptionalLibFunc(&hvGICGetDistributorBaseAlignment, hvLib, "hv_gic_get_distributor_base_alignment")
 		registerOptionalLibFunc(&hvGICGetRedistributorBaseAlignment, hvLib, "hv_gic_get_redistributor_base_alignment")
 		registerOptionalLibFunc(&hvGICCreate, hvLib, "hv_gic_create")
+		registerOptionalLibFunc(&machVMPageQuery, sysLib, "mach_vm_page_query")
+		machTaskSelf, _ = purego.Dlsym(sysLib, "mach_task_self_")
 
 		purego.RegisterLibFunc(&osRelease, sysLib, "os_release")
 	})

--- a/internal/hv/hvf/snapshot_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64.go
@@ -94,7 +94,11 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 		return nil, err
 	}
 	timing.Since(ctx, "hvf.restore.load_snapshot", start)
-	timingLog("hvf.restore load snapshot took=%s size=%d", time.Since(start), len(mem))
+	if allocated, err := snapshotMemoryAllocatedBytes(snapshotMemoryPath(snapshotPath, manifest.MemoryFile)); err == nil {
+		timingLog("hvf.restore load snapshot took=%s logical=%d allocated=%d", time.Since(start), len(mem), allocated)
+	} else {
+		timingLog("hvf.restore load snapshot took=%s logical=%d", time.Since(start), len(mem))
+	}
 	if req.CPUs <= 0 {
 		req.CPUs = 1
 	}
@@ -467,7 +471,7 @@ func (s *snapshotTrigger) handleDataAbort(vm *VM, vcpuIndex int, info DataAbortI
 		s.err = s.capture(vm, vcpuIndex, value)
 	})
 	if s.err != nil {
-		timingLog("snapshot trigger capture failed: %v", s.err)
+		fmt.Fprintf(os.Stderr, "ccx3: startup snapshot capture failed: %v\n", s.err)
 	}
 	return nil
 }
@@ -490,8 +494,15 @@ func (s *snapshotTrigger) capture(vm *VM, vcpuIndex int, value uint64) error {
 	}
 	defer capture.Abort()
 	outDir := capture.Dir()
-	if err := os.WriteFile(filepath.Join(outDir, "memory.bin"), s.mem, 0o600); err != nil {
+	memoryPath := filepath.Join(outDir, "memory.bin")
+	memoryStarted := time.Now()
+	if err := writeSparseSnapshotMemory(memoryPath, s.mem, 0o600); err != nil {
 		return fmt.Errorf("write snapshot memory: %w", err)
+	}
+	if allocated, err := snapshotMemoryAllocatedBytes(memoryPath); err == nil {
+		timingLog("hvf.snapshot memory capture took=%s logical=%d allocated=%d", time.Since(memoryStarted), len(s.mem), allocated)
+	} else {
+		timingLog("hvf.snapshot memory capture took=%s logical=%d", time.Since(memoryStarted), len(s.mem))
 	}
 	manifest := snapshotManifest{
 		Format:       "ccx3-hvf-snapshot-v0",
@@ -802,6 +813,18 @@ func loadSnapshot(path string) (snapshotManifest, []byte, error) {
 		return snapshotManifest{}, nil, fmt.Errorf("mmap snapshot memory: %w", err)
 	}
 	return manifest, mem, nil
+}
+
+func snapshotMemoryPath(snapshotPath, memoryFile string) string {
+	manifestPath := strings.TrimSpace(snapshotPath)
+	if info, err := os.Stat(manifestPath); err == nil && info.IsDir() {
+		manifestPath = filepath.Join(manifestPath, "manifest.json")
+	}
+	path, err := vmruntime.ResolveSnapshotMemoryPath(manifestPath, memoryFile)
+	if err != nil {
+		return ""
+	}
+	return path
 }
 
 func validateSnapshotRequest(manifest snapshotManifest, req ContainerRunRequest) error {

--- a/internal/hv/hvf/snapshot_darwin_arm64_test.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64_test.go
@@ -70,8 +70,42 @@ func assertSparseSnapshotMemory(t *testing.T, path string, want []byte) {
 		t.Fatalf("snapshot stat has type %T", info.Sys())
 	}
 	if allocated := stat.Blocks * 512; allocated >= info.Size() {
+		if !filesystemReportsSparseAllocation(t, filepath.Dir(path), info.Size()) {
+			t.Logf("filesystem reports dense allocation for sparse probe; skipping physical allocation assertion")
+			return
+		}
 		t.Fatalf("allocated snapshot bytes = %d, logical bytes = %d", allocated, info.Size())
 	}
+}
+
+func filesystemReportsSparseAllocation(t *testing.T, dir string, size int64) bool {
+	t.Helper()
+	path := filepath.Join(dir, "sparse-allocation-probe.bin")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("create sparse allocation probe: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+	if _, err := file.WriteAt([]byte{1}, 0); err != nil {
+		_ = file.Close()
+		t.Fatalf("write sparse allocation probe: %v", err)
+	}
+	if err := file.Truncate(size); err != nil {
+		_ = file.Close()
+		t.Fatalf("truncate sparse allocation probe: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close sparse allocation probe: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sparse allocation probe: %v", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("sparse allocation probe stat has type %T", info.Sys())
+	}
+	return stat.Blocks*512 < info.Size()
 }
 
 func BenchmarkWriteSparseSnapshotMemory(b *testing.B) {

--- a/internal/hv/hvf/snapshot_darwin_arm64_test.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64_test.go
@@ -17,13 +17,13 @@ import (
 
 func TestWriteSparseSnapshotMemoryPreservesDataAndHoles(t *testing.T) {
 	pageSize := os.Getpagesize()
-	memory, err := syscall.Mmap(-1, 0, pageSize*16, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	memory, err := syscall.Mmap(-1, 0, 16<<20, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
 	if err != nil {
 		t.Fatalf("mmap guest memory: %v", err)
 	}
 	defer syscall.Munmap(memory)
 	copy(memory[pageSize:pageSize+4], "left")
-	copy(memory[pageSize*12:pageSize*12+5], "right")
+	copy(memory[12<<20:(12<<20)+5], "right")
 
 	path := filepath.Join(t.TempDir(), "memory.bin")
 	if err := writeSparseSnapshotMemory(path, memory, 0o600); err != nil {
@@ -33,10 +33,9 @@ func TestWriteSparseSnapshotMemoryPreservesDataAndHoles(t *testing.T) {
 }
 
 func TestWriteSparseSnapshotMemoryFallsBackWhenPageQueryFails(t *testing.T) {
-	pageSize := os.Getpagesize()
-	memory := make([]byte, pageSize*8)
-	copy(memory[pageSize*2:], "first")
-	copy(memory[pageSize*6:], "second")
+	memory := make([]byte, 8<<20)
+	copy(memory[2<<20:], "first")
+	copy(memory[6<<20:], "second")
 	queries := 0
 	query := func(uintptr) (int32, error) {
 		queries++

--- a/internal/hv/hvf/snapshot_darwin_arm64_test.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64_test.go
@@ -3,12 +3,107 @@
 package hvf
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
 	"j5.nz/cc/internal/arm64vm"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
 )
+
+func TestWriteSparseSnapshotMemoryPreservesDataAndHoles(t *testing.T) {
+	pageSize := os.Getpagesize()
+	memory, err := syscall.Mmap(-1, 0, pageSize*16, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("mmap guest memory: %v", err)
+	}
+	defer syscall.Munmap(memory)
+	copy(memory[pageSize:pageSize+4], "left")
+	copy(memory[pageSize*12:pageSize*12+5], "right")
+
+	path := filepath.Join(t.TempDir(), "memory.bin")
+	if err := writeSparseSnapshotMemory(path, memory, 0o600); err != nil {
+		t.Fatalf("write sparse snapshot memory: %v", err)
+	}
+	assertSparseSnapshotMemory(t, path, memory)
+}
+
+func TestWriteSparseSnapshotMemoryFallsBackWhenPageQueryFails(t *testing.T) {
+	pageSize := os.Getpagesize()
+	memory := make([]byte, pageSize*8)
+	copy(memory[pageSize*2:], "first")
+	copy(memory[pageSize*6:], "second")
+	queries := 0
+	query := func(uintptr) (int32, error) {
+		queries++
+		return 0, fmt.Errorf("page query unavailable")
+	}
+
+	path := filepath.Join(t.TempDir(), "memory.bin")
+	if err := writeSparseSnapshotMemoryWithQuery(path, memory, 0o600, query); err != nil {
+		t.Fatalf("write fallback sparse snapshot memory: %v", err)
+	}
+	if queries != 1 {
+		t.Fatalf("page queries = %d, want 1 before fallback", queries)
+	}
+	assertSparseSnapshotMemory(t, path, memory)
+}
+
+func assertSparseSnapshotMemory(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot memory: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("restored memory differs from captured memory")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat snapshot memory: %v", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("snapshot stat has type %T", info.Sys())
+	}
+	if allocated := stat.Blocks * 512; allocated >= info.Size() {
+		t.Fatalf("allocated snapshot bytes = %d, logical bytes = %d", allocated, info.Size())
+	}
+}
+
+func BenchmarkWriteSparseSnapshotMemory(b *testing.B) {
+	for _, size := range []int{512 << 20, 12 << 30} {
+		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+			memory, err := syscall.Mmap(-1, 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+			if err != nil {
+				b.Fatalf("mmap guest memory: %v", err)
+			}
+			defer syscall.Munmap(memory)
+			for offset := 0; offset < 64<<20; offset += os.Getpagesize() {
+				memory[offset] = 1
+			}
+			path := filepath.Join(b.TempDir(), "memory.bin")
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				if err := writeSparseSnapshotMemory(path, memory, 0o600); err != nil {
+					b.Fatalf("write sparse snapshot memory: %v", err)
+				}
+			}
+			b.StopTimer()
+			info, err := os.Stat(path)
+			if err != nil {
+				b.Fatalf("stat snapshot memory: %v", err)
+			}
+			stat := info.Sys().(*syscall.Stat_t)
+			b.ReportMetric(float64(stat.Blocks*512)/(1<<20), "allocated-MiB")
+		})
+	}
+}
 
 func TestValidateSnapshotRequestRequiresMatchingMemory(t *testing.T) {
 	manifest := snapshotManifest{

--- a/internal/hv/hvf/snapshot_darwin_arm64_test.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64_test.go
@@ -86,13 +86,13 @@ func filesystemReportsSparseAllocation(t *testing.T, dir string, size int64) boo
 		t.Fatalf("create sparse allocation probe: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(path) })
-	if _, err := file.WriteAt([]byte{1}, 0); err != nil {
-		_ = file.Close()
-		t.Fatalf("write sparse allocation probe: %v", err)
-	}
 	if err := file.Truncate(size); err != nil {
 		_ = file.Close()
 		t.Fatalf("truncate sparse allocation probe: %v", err)
+	}
+	if _, err := file.WriteAt([]byte{1}, 0); err != nil {
+		_ = file.Close()
+		t.Fatalf("write sparse allocation probe: %v", err)
 	}
 	if err := file.Close(); err != nil {
 		t.Fatalf("close sparse allocation probe: %v", err)

--- a/internal/hv/hvf/snapshot_memory_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_memory_darwin_arm64.go
@@ -1,0 +1,157 @@
+//go:build darwin && arm64
+
+package hvf
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	machPagePresent  = int32(0x01)
+	machPagePagedOut = int32(0x10)
+	machPageReusable = int32(0x800)
+)
+
+type snapshotPageQuery func(address uintptr) (int32, error)
+
+type snapshotMemoryRange struct {
+	start int
+	end   int
+}
+
+// writeSparseSnapshotMemory preserves the logical guest-memory size while
+// writing only pages which have meaningful contents. Mach page information
+// avoids faulting untouched anonymous guest pages into the host process. If
+// that information is unavailable, a correctness-first zero-page scan keeps
+// the file sparse without relying on page residency.
+func writeSparseSnapshotMemory(path string, data []byte, perm os.FileMode) error {
+	return writeSparseSnapshotMemoryWithQuery(path, data, perm, querySnapshotMemoryPage)
+}
+
+func writeSparseSnapshotMemoryWithQuery(path string, data []byte, perm os.FileMode, query snapshotPageQuery) error {
+	ranges, err := populatedSnapshotMemoryRanges(data, query)
+	if err != nil {
+		ranges = nonzeroSnapshotMemoryRanges(data, os.Getpagesize())
+	}
+	return writeSnapshotMemoryRanges(path, data, perm, ranges)
+}
+
+func writeSnapshotMemoryRanges(path string, data []byte, perm os.FileMode, ranges []snapshotMemoryRange) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = file.Close()
+		}
+	}()
+	for _, span := range ranges {
+		if _, err := file.WriteAt(data[span.start:span.end], int64(span.start)); err != nil {
+			return err
+		}
+	}
+	if err := file.Truncate(int64(len(data))); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	closed = true
+	return nil
+}
+
+func populatedSnapshotMemoryRanges(data []byte, query snapshotPageQuery) ([]snapshotMemoryRange, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	pageSize := os.Getpagesize()
+	base := uintptr(unsafe.Pointer(&data[0]))
+	var ranges []snapshotMemoryRange
+	for start := 0; start < len(data); {
+		address := base + uintptr(start)
+		pageEnd := start + pageSize - int(address%uintptr(pageSize))
+		if pageEnd > len(data) {
+			pageEnd = len(data)
+		}
+		disposition, err := query(address)
+		if err != nil {
+			return nil, err
+		}
+		populated := disposition&(machPagePresent|machPagePagedOut) != 0 && disposition&machPageReusable == 0
+		if populated && !allZeroSnapshotMemory(data[start:pageEnd]) {
+			ranges = appendSnapshotMemoryRange(ranges, start, pageEnd)
+		}
+		start = pageEnd
+	}
+	return ranges, nil
+}
+
+func nonzeroSnapshotMemoryRanges(data []byte, pageSize int) []snapshotMemoryRange {
+	if pageSize <= 0 {
+		pageSize = 4096
+	}
+	var ranges []snapshotMemoryRange
+	for start := 0; start < len(data); start += pageSize {
+		end := min(start+pageSize, len(data))
+		if !allZeroSnapshotMemory(data[start:end]) {
+			ranges = appendSnapshotMemoryRange(ranges, start, end)
+		}
+	}
+	return ranges
+}
+
+func appendSnapshotMemoryRange(ranges []snapshotMemoryRange, start, end int) []snapshotMemoryRange {
+	if len(ranges) != 0 && ranges[len(ranges)-1].end == start {
+		ranges[len(ranges)-1].end = end
+		return ranges
+	}
+	return append(ranges, snapshotMemoryRange{start: start, end: end})
+}
+
+func allZeroSnapshotMemory(data []byte) bool {
+	for len(data) >= 8 {
+		if *(*uint64)(unsafe.Pointer(&data[0])) != 0 {
+			return false
+		}
+		data = data[8:]
+	}
+	for _, value := range data {
+		if value != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func querySnapshotMemoryPage(address uintptr) (int32, error) {
+	if err := load(); err != nil {
+		return 0, err
+	}
+	if machVMPageQuery == nil || machTaskSelf == 0 {
+		return 0, fmt.Errorf("Mach page query unavailable")
+	}
+	task := *(*uint32)(unsafe.Pointer(machTaskSelf))
+	var disposition int32
+	var refCount int32
+	if result := machVMPageQuery(task, uint64(address), &disposition, &refCount); result != 0 {
+		return 0, fmt.Errorf("Mach page query at %#x: error %d", address, result)
+	}
+	return disposition, nil
+}
+
+func snapshotMemoryAllocatedBytes(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("snapshot stat has type %T", info.Sys())
+	}
+	return stat.Blocks * 512, nil
+}

--- a/internal/hv/hvf/snapshot_memory_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_memory_darwin_arm64.go
@@ -132,10 +132,10 @@ func querySnapshotMemoryPage(address uintptr) (int32, error) {
 	if err := load(); err != nil {
 		return 0, err
 	}
-	if machVMPageQuery == nil || machTaskSelf == 0 {
+	if machVMPageQuery == nil || taskSelfTrap == nil {
 		return 0, fmt.Errorf("Mach page query unavailable")
 	}
-	task := *(*uint32)(unsafe.Pointer(machTaskSelf))
+	task := taskSelfTrap()
 	var disposition int32
 	var refCount int32
 	if result := machVMPageQuery(task, uint64(address), &disposition, &refCount); result != 0 {

--- a/internal/hv/hvf/snapshot_memory_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_memory_darwin_arm64.go
@@ -50,13 +50,16 @@ func writeSnapshotMemoryRanges(path string, data []byte, perm os.FileMode, range
 			_ = file.Close()
 		}
 	}()
+	// Establish the logical length before writing populated ranges. On APFS,
+	// extending the file with a write beyond EOF can allocate the intervening
+	// range, while writes into a pre-truncated sparse file preserve its holes.
+	if err := file.Truncate(int64(len(data))); err != nil {
+		return err
+	}
 	for _, span := range ranges {
 		if _, err := file.WriteAt(data[span.start:span.end], int64(span.start)); err != nil {
 			return err
 		}
-	}
-	if err := file.Truncate(int64(len(data))); err != nil {
-		return err
 	}
 	if err := file.Close(); err != nil {
 		return err

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -593,9 +593,11 @@ while IFS= read -r __vmsh_line; do eval "$__vmsh_line"; done`
 	}
 }
 
-func TestRuntimeRestoresPersistentLinuxFromStartupSnapshot(t *testing.T) {
-	if runtime.GOOS != "linux" || (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64") {
-		t.Skip("KVM startup snapshots are implemented on Linux amd64 and arm64")
+func TestRuntimeRestoresPersistentFromStartupSnapshot(t *testing.T) {
+	supported := (runtime.GOOS == "linux" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) ||
+		(runtime.GOOS == "darwin" && runtime.GOARCH == "arm64")
+	if !supported {
+		t.Skip("startup snapshots are implemented on Linux amd64/arm64 and Darwin arm64")
 	}
 	env := newRuntimeBootEnv(t)
 	snapshotRoot := t.TempDir()


### PR DESCRIPTION
Fixes #181.

## What changed

- replace the dense Darwin/arm64 HVF memory dump with a Mach page-aware sparse writer
- preserve the full logical `memory.bin` size while skipping untouched, reusable, and zero-filled pages
- coalesce adjacent populated pages into larger writes
- fall back to a correctness-first zero-page scan when Mach page queries are unavailable
- report logical and physically allocated snapshot sizes in timing diagnostics
- surface startup snapshot capture failures without requiring `CCX3_DEBUG_TIMING`
- enable the persistent startup-snapshot restore test on Darwin/arm64

## Root cause

The HVF capture path used `os.WriteFile` on the entire guest RAM mapping. Snapshot cost and disk allocation therefore scaled with configured memory rather than populated guest memory, causing large but lightly populated guests to exhaust local disk space.

## User impact

Interactive vmsh systems can persist and reuse startup snapshots on Apple Silicon even when their configured RAM is much larger than the guest's populated working set. Restore compatibility is unchanged because the sparse file retains the configured logical length.

## Validation

- `go test ./internal/hv/hvf -run '^TestWriteSparseSnapshotMemory' -count=1`
- `go test ./internal/vm -run '^TestRuntimeRestoresPersistentFromStartupSnapshot$' -count=1`
- `go test ./... -run '^$'`
- real vmsh interactive capture/restore: 512 MiB logical snapshot, about 65.5 MiB allocated, 68.5 ms capture, 12.8 ms warm activation
- sparse writer benchmark with 64 MiB populated:
  - 512 MiB logical: 76.4 ms, 64 MiB allocated
  - 12 GiB logical: 483 ms, 64 MiB allocated
