### PR TITLE
Fix Windows filesystem budget checks for existing files

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -263,7 +263,10 @@ func (w *bytesWriter) Bytes() []byte { return w.data }
 func FilesystemBudget(path string) (int64, error) {
 	probe := path
 	for {
-		if _, err := os.Stat(probe); err == nil {
+		if info, err := os.Stat(probe); err == nil {
+			if !info.IsDir() {
+				probe = filepath.Dir(probe)
+			}
 			break
 		}
 		parent := filepath.Dir(probe)

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -5,9 +5,25 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestFilesystemBudgetAcceptsFilePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "layer.tar")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	budget, err := FilesystemBudget(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if budget <= 0 {
+		t.Fatalf("budget = %d, want a positive number of available bytes", budget)
+	}
+}
 
 func TestCopyRejectsOversizeBeforePublication(t *testing.T) {
 	resp := &http.Response{Body: io.NopCloser(strings.NewReader("oversized")), ContentLength: 9}


### PR DESCRIPTION
## What changed

- Resolve existing file paths to their parent directory before querying filesystem capacity.
- Add a behavior-level regression test that requests a budget for an existing layer file.

## Why

On Windows, `GetDiskFreeSpaceEx` requires a directory or volume path. OCI layer expansion passed its destination path to `FilesystemBudget`; when an empty layer already existed, that file path reached the Windows API and failed with `The directory name is invalid.` This prevented NeurodeskAppX from preparing the Neurodesktop image despite ample free space.

## Validation

- `go test ./internal/download ./internal/oci` on macOS
- Cross-compiled and ran `TestFilesystemBudgetAcceptsFilePath` successfully on Windows 11 (`astra-windev`)
- Re-ran NeurodeskAppX image preparation on the affected Windows host; all layers expanded and the image indexed and published successfully
- Broad `go test ./...` run was stopped after unrelated `internal/fsimage/vm` exceeded three minutes; all packages completed before it were green