### PR TITLE
Fix Windows high-memory VM mapping

### DIFF
--- a/internal/hv/whp/emulator_windows_amd64.go
+++ b/internal/hv/whp/emulator_windows_amd64.go
@@ -184,12 +184,11 @@ func emulatorMemoryCallback(ctx, access uintptr) uintptr {
 		emu.vm.emuErr = fmt.Errorf("unsupported MMIO size %d", size)
 		return emulatorCallbackFailure
 	}
-	if info.GPA < emu.vm.memSize && info.GPA+uint64(size) <= emu.vm.memSize {
-		mem := emu.vm.Memory()
+	if mem, err := emu.vm.SliceIPA(info.GPA, size); err == nil {
 		if info.Direction == emulatorMemoryRead {
-			copy(info.Data[:size], mem[info.GPA:info.GPA+uint64(size)])
+			copy(info.Data[:size], mem)
 		} else {
-			copy(mem[info.GPA:info.GPA+uint64(size)], info.Data[:size])
+			copy(mem, info.Data[:size])
 		}
 		return 0
 	}

--- a/internal/hv/whp/snapshot_windows_amd64.go
+++ b/internal/hv/whp/snapshot_windows_amd64.go
@@ -347,7 +347,7 @@ func restoreManagedVMFromSnapshot(manifest whpSnapshotManifest, memPath string, 
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("map snapshot memory: %w", err)
 	}
-	vm, err := newVMWithAllocation(memorySize, true, mem)
+	vm, err := newVMWithAllocation(memorySize, true, true, mem)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -8,19 +8,27 @@ import (
 	"fmt"
 	"sync/atomic"
 	"unsafe"
+
+	"j5.nz/cc/internal/amd64vm"
 )
 
 type VM struct {
 	part         partitionHandle
 	mem          *allocation
-	memGPA       uint64
 	memSize      uint64
+	memRegions   []guestMemoryRegion
 	vcpuCreated  bool
 	emulator     emulatorHandle
 	emuCallbacks emulatorCallbacks
 	emuContext   *emulatorContext
 	emuErr       error
 	running      atomic.Bool
+}
+
+type guestMemoryRegion struct {
+	guestPhysAddr uint64
+	memoryOffset  uint64
+	size          uint64
 }
 
 type Exit struct {
@@ -60,14 +68,14 @@ func NewVM(memorySize uint64) (*VM, error) {
 }
 
 func newBootVM(memorySize uint64) (*VM, error) {
-	return newVM(memorySize, true)
+	return newVMWithAllocation(memorySize, true, true, nil)
 }
 
 func newVM(memorySize uint64, localAPIC bool) (*VM, error) {
-	return newVMWithAllocation(memorySize, localAPIC, nil)
+	return newVMWithAllocation(memorySize, localAPIC, false, nil)
 }
 
-func newVMWithAllocation(memorySize uint64, localAPIC bool, mem *allocation) (*VM, error) {
+func newVMWithAllocation(memorySize uint64, localAPIC bool, splitAMD64Memory bool, mem *allocation) (*VM, error) {
 	if memorySize == 0 {
 		return nil, fmt.Errorf("memory size must be non-zero")
 	}
@@ -119,9 +127,17 @@ func newVMWithAllocation(memorySize uint64, localAPIC bool, mem *allocation) (*V
 	}
 	vm.mem = mem
 	vm.memSize = memorySize
-	if err := mapGPARange(part, unsafe.Pointer(mem.addr), 0, memorySize, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("map guest memory: %w", err)
+	regions := []guestMemoryRegion{{size: memorySize}}
+	if splitAMD64Memory {
+		regions = amd64GuestMemoryRegions(memorySize)
+	}
+	for _, region := range regions {
+		hostAddr := unsafe.Pointer(mem.addr + uintptr(region.memoryOffset))
+		if err := mapGPARange(part, hostAddr, region.guestPhysAddr, region.size, mapGPARangeFlagRead|mapGPARangeFlagWrite|mapGPARangeFlagExecute); err != nil {
+			_ = vm.Close()
+			return nil, fmt.Errorf("map guest memory at gpa %#x: %w", region.guestPhysAddr, err)
+		}
+		vm.memRegions = append(vm.memRegions, region)
 	}
 	if err := createVirtualProcessor(part, 0); err != nil {
 		_ = vm.Close()
@@ -129,6 +145,22 @@ func newVMWithAllocation(memorySize uint64, localAPIC bool, mem *allocation) (*V
 	}
 	vm.vcpuCreated = true
 	return vm, nil
+}
+
+func amd64GuestMemoryRegions(memorySize uint64) []guestMemoryRegion {
+	lowSize := min(memorySize, uint64(amd64vm.LowMemorySize))
+	regions := []guestMemoryRegion{{
+		guestPhysAddr: amd64vm.MemoryBase,
+		size:          lowSize,
+	}}
+	if highSize := memorySize - lowSize; highSize > 0 {
+		regions = append(regions, guestMemoryRegion{
+			guestPhysAddr: amd64vm.HighMemoryBase,
+			memoryOffset:  lowSize,
+			size:          highSize,
+		})
+	}
+	return regions
 }
 
 func (v *VM) Close() error {
@@ -149,10 +181,13 @@ func (v *VM) Close() error {
 		}
 		v.vcpuCreated = false
 	}
-	if v.part != 0 && v.mem != nil {
-		if err := unmapGPARange(v.part, v.memGPA, v.memSize); err != nil && first == nil {
-			first = err
+	if v.part != 0 {
+		for _, region := range v.memRegions {
+			if err := unmapGPARange(v.part, region.guestPhysAddr, region.size); err != nil && first == nil {
+				first = err
+			}
 		}
+		v.memRegions = nil
 	}
 	if v.mem != nil {
 		if err := v.mem.free(); err != nil && first == nil {
@@ -188,13 +223,11 @@ func (v *VM) ReadIPA(addr uint64, size int) ([]byte, error) {
 }
 
 func (v *VM) ReadIPAInto(addr uint64, dst []byte) error {
-	if v == nil || v.mem == nil {
-		return fmt.Errorf("guest memory is not mapped")
+	mem, err := v.SliceIPA(addr, len(dst))
+	if err != nil {
+		return fmt.Errorf("read ipa %#x size %d: %w", addr, len(dst), err)
 	}
-	if addr > v.memSize || uint64(len(dst)) > v.memSize-addr {
-		return fmt.Errorf("read ipa %#x size %d out of range %#x", addr, len(dst), v.memSize)
-	}
-	copy(dst, v.mem.bytes()[addr:addr+uint64(len(dst))])
+	copy(dst, mem)
 	return nil
 }
 
@@ -205,20 +238,26 @@ func (v *VM) SliceIPA(addr uint64, size int) ([]byte, error) {
 	if v == nil || v.mem == nil {
 		return nil, fmt.Errorf("guest memory is not mapped")
 	}
-	if addr > v.memSize || uint64(size) > v.memSize-addr {
-		return nil, fmt.Errorf("slice ipa %#x size %d out of range %#x", addr, size, v.memSize)
+	for _, region := range v.memRegions {
+		if addr < region.guestPhysAddr {
+			continue
+		}
+		regionOffset := addr - region.guestPhysAddr
+		if regionOffset > region.size || uint64(size) > region.size-regionOffset {
+			continue
+		}
+		memoryOffset := region.memoryOffset + regionOffset
+		return v.mem.bytes()[memoryOffset : memoryOffset+uint64(size)], nil
 	}
-	return v.mem.bytes()[addr : addr+uint64(size)], nil
+	return nil, fmt.Errorf("guest physical range is not mapped")
 }
 
 func (v *VM) WriteIPA(addr uint64, data []byte) error {
-	if v == nil || v.mem == nil {
-		return fmt.Errorf("guest memory is not mapped")
+	mem, err := v.SliceIPA(addr, len(data))
+	if err != nil {
+		return fmt.Errorf("write ipa %#x size %d: %w", addr, len(data), err)
 	}
-	if addr > v.memSize || uint64(len(data)) > v.memSize-addr {
-		return fmt.Errorf("write ipa %#x size %d out of range %#x", addr, len(data), v.memSize)
-	}
-	copy(v.mem.bytes()[addr:addr+uint64(len(data))], data)
+	copy(mem, data)
 	return nil
 }
 

--- a/internal/hv/whp/vm_windows_amd64_test.go
+++ b/internal/hv/whp/vm_windows_amd64_test.go
@@ -1,0 +1,34 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"testing"
+
+	"j5.nz/cc/internal/amd64vm"
+)
+
+func TestAMD64GuestMemoryRegionsLeaveDeviceHole(t *testing.T) {
+	const memorySize = 12 << 30
+
+	regions := amd64GuestMemoryRegions(memorySize)
+	want := []guestMemoryRegion{
+		{
+			guestPhysAddr: amd64vm.MemoryBase,
+			size:          3 << 30,
+		},
+		{
+			guestPhysAddr: amd64vm.HighMemoryBase,
+			memoryOffset:  3 << 30,
+			size:          9 << 30,
+		},
+	}
+	if len(regions) != len(want) {
+		t.Fatalf("len(amd64GuestMemoryRegions()) = %d, want %d", len(regions), len(want))
+	}
+	for i := range want {
+		if regions[i] != want[i] {
+			t.Errorf("region %d = %#v, want %#v", i, regions[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- split Windows amd64 boot RAM around the reserved 3–4 GiB PCI/MMIO hole
- translate guest physical memory accesses through the low/high region map, including emulator fast-path accesses
- restore snapshot-backed VMs with the same split physical layout
- add a deterministic regression test for the high-memory region contract

## Root cause

The amd64 boot tables advertise at most 3 GiB of low RAM and place the remainder at 4 GiB, but the Windows WHP backend mapped the entire host allocation as one contiguous GPA range starting at zero. Configurations above 3 GiB therefore overlapped the reserved device window and did not back the high-memory addresses described by E820.

## Impact

Windows amd64 VMs can now boot with RAM configurations above 3 GiB, including configurations above 8 GiB, using the same physical memory contract as the Linux amd64 backend. Virtio and emulated accesses to high guest memory resolve to the correct offset in the contiguous host allocation.

## Validation

- `go.exe test ./internal/hv/whp`
- `go.exe test ./... -short`
- native Windows WHP managed boot probes at 4096 MiB and 9216 MiB, with the guest reporting the high-memory allocation through `/proc/meminfo`
