### PR TITLE
Add Windows graphical VM support

### DIFF
--- a/internal/hv/whp/acpi_windows_amd64.go
+++ b/internal/hv/whp/acpi_windows_amd64.go
@@ -5,6 +5,8 @@ package whp
 import (
 	"encoding/binary"
 	"fmt"
+
+	"j5.nz/cc/internal/amd64vm"
 )
 
 const (
@@ -89,7 +91,7 @@ func buildBootMADT() []byte {
 	body = binary.LittleEndian.AppendUint32(body, 0)
 
 	body = appendMADTInterruptOverride(body, 0, 2, 0)
-	for _, irq := range []byte{5, 6, 7, 8, 9, 10} {
+	for irq := byte(5); irq <= amd64vm.PointerIRQ; irq++ {
 		body = appendMADTInterruptOverride(body, irq, uint32(irq), 0x000d)
 	}
 	return body

--- a/internal/hv/whp/acpi_windows_amd64_test.go
+++ b/internal/hv/whp/acpi_windows_amd64_test.go
@@ -1,0 +1,30 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"j5.nz/cc/internal/amd64vm"
+)
+
+func TestBootMADTMarksVirtioIRQsLevelTriggered(t *testing.T) {
+	body := buildBootMADT()
+	overrides := make(map[byte]uint16)
+	for offset := 28; offset+2 <= len(body); {
+		length := int(body[offset+1])
+		if length < 2 || offset+length > len(body) {
+			t.Fatalf("invalid MADT entry at offset %d", offset)
+		}
+		if body[offset] == 2 && length == 10 {
+			overrides[body[offset+3]] = binary.LittleEndian.Uint16(body[offset+8:])
+		}
+		offset += length
+	}
+	for irq := byte(amd64vm.RootFSIRQ); irq <= amd64vm.PointerIRQ; irq++ {
+		if flags := overrides[irq]; flags != 0x000d {
+			t.Fatalf("IRQ %d override flags = %#x, want active-high level-triggered", irq, flags)
+		}
+	}
+}

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -324,34 +324,35 @@ func BootInitramfsToMarkerWithTimeout(kernel []byte, initrd []byte, memoryMB uin
 }
 
 type bootPlatform struct {
-	vm            *VM
-	uart          *serial.UART8250
-	pic           bootPIC
-	pit           *bootPIT
-	ioapic        bootIOAPIC
-	hpet          bootHPET
-	fsdevs        []*virtio.FS
-	vsock         *virtio.Vsock
-	rng           *virtio.RNG
-	netdev        *virtio.Net
-	pci           *PCIBus
-	i8042         *I8042
-	rtc           *CMOSRTC
-	acpiPM        *ACPIPM
-	snapshot      *snapshotTrigger
-	start         time.Time
-	irqAttempts   uint64
-	irqDelivered  uint64
-	irqFailed     uint64
-	irqSuppressed uint64
-	irqLine       [16]uint64
-	deviceIRQLine [ioapicRedirEntries]bool
-	deferredIRQ   [ioapicRedirEntries]bool
-	pendingMu     sync.Mutex
-	pendingIRQ    [256]bool
-	pendingIRQs   []pendingIRQ
-	lastExitMu    sync.Mutex
-	lastExit      bootPlatformExitSnapshot
+	vm             *VM
+	uart           *serial.UART8250
+	pic            bootPIC
+	pit            *bootPIT
+	ioapic         bootIOAPIC
+	hpet           bootHPET
+	fsdevs         []*virtio.FS
+	vsock          *virtio.Vsock
+	rng            *virtio.RNG
+	netdev         *virtio.Net
+	displayDevices []virtio.MMIODevice
+	pci            *PCIBus
+	i8042          *I8042
+	rtc            *CMOSRTC
+	acpiPM         *ACPIPM
+	snapshot       *snapshotTrigger
+	start          time.Time
+	irqAttempts    uint64
+	irqDelivered   uint64
+	irqFailed      uint64
+	irqSuppressed  uint64
+	irqLine        [16]uint64
+	deviceIRQLine  [ioapicRedirEntries]bool
+	deferredIRQ    [ioapicRedirEntries]bool
+	pendingMu      sync.Mutex
+	pendingIRQ     [256]bool
+	pendingIRQs    []pendingIRQ
+	lastExitMu     sync.Mutex
+	lastExit       bootPlatformExitSnapshot
 }
 
 type pendingIRQ struct {
@@ -503,6 +504,23 @@ func (p *bootPlatform) AttachNet(netdev *virtio.Net) {
 	netdev.Attach(p.vm, p)
 }
 
+func (p *bootPlatform) AttachDisplayDevices(devices []virtio.MMIODevice) {
+	for _, device := range devices {
+		if device == nil {
+			continue
+		}
+		p.displayDevices = append(p.displayDevices, device)
+		switch typed := device.(type) {
+		case *virtio.GPU:
+			p.markDeviceIRQ(typed.IRQ)
+			typed.Attach(p.vm, p)
+		case *virtio.Input:
+			p.markDeviceIRQ(typed.IRQ)
+			typed.Attach(p.vm, p)
+		}
+	}
+}
+
 func (p *bootPlatform) AttachPCI(pci *PCIBus) {
 	p.pci = pci
 	if pci == nil {
@@ -643,6 +661,16 @@ func (p *bootPlatform) ReadMMIO(addr uint64, data []byte) error {
 		putUint64(data, value)
 		return nil
 	}
+	for _, device := range p.displayDevices {
+		if device != nil && device.Contains(addr, len(data)) {
+			value, err := device.Read(addr, len(data))
+			if err != nil {
+				return err
+			}
+			putUint64(data, value)
+			return nil
+		}
+	}
 	if handled, err := p.pci.ReadMMIO(addr, data); handled || err != nil {
 		return err
 	}
@@ -673,6 +701,11 @@ func (p *bootPlatform) WriteMMIO(addr uint64, data []byte) error {
 	}
 	if p.netdev != nil && p.netdev.Contains(addr, len(data)) {
 		return p.netdev.Write(addr, len(data), readUint64(data))
+	}
+	for _, device := range p.displayDevices {
+		if device != nil && device.Contains(addr, len(data)) {
+			return device.Write(addr, len(data), readUint64(data))
+		}
 	}
 	if handled, err := p.pci.WriteMMIO(addr, data); handled || err != nil {
 		return err

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -886,6 +886,22 @@ func (p *bootPlatform) resampleDeviceIRQs() {
 			p.injectIOAPIC(route, true)
 		}
 	}
+	for _, device := range p.displayDevices {
+		var irq uint32
+		var asserted bool
+		switch typed := device.(type) {
+		case *virtio.GPU:
+			irq, asserted = typed.IRQ, typed.IRQAsserted()
+		case *virtio.Input:
+			irq, asserted = typed.IRQ, typed.IRQAsserted()
+		}
+		if asserted {
+			line := uint8(irq)
+			if route, pending := p.ioapic.assert(line, true); pending {
+				p.injectIOAPIC(route, true)
+			}
+		}
+	}
 }
 
 func (p *bootPlatform) deliverPICOutput() bool {
@@ -1163,6 +1179,18 @@ func (p *bootPlatform) usePendingInterruptionFallback(line uint8) bool {
 			return true
 		}
 	}
+	for _, device := range p.displayDevices {
+		switch typed := device.(type) {
+		case *virtio.GPU:
+			if typed.IRQ == uint32(line) {
+				return true
+			}
+		case *virtio.Input:
+			if typed.IRQ == uint32(line) {
+				return true
+			}
+		}
+	}
 	return false
 }
 
@@ -1231,6 +1259,10 @@ func canSetPendingInterruption(ctx *runVPExitContext, vector uint8) bool {
 		return true
 	}
 	if ctx.VpContext.ExecutionState.interruptionPending() || ctx.VpContext.ExecutionState.interruptShadow() {
+		return false
+	}
+	const rflagsInterruptEnable = uint64(1 << 9)
+	if ctx.VpContext.Rflags&rflagsInterruptEnable == 0 {
 		return false
 	}
 	priority := vector >> 4

--- a/internal/hv/whp/clipboard_windows_amd64.go
+++ b/internal/hv/whp/clipboard_windows_amd64.go
@@ -1,0 +1,60 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+func serveClipboardConnections(ctx context.Context, listener virtio.VsockListener, clipboard *virtio.Clipboard) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = serveClipboardConnection(ctx, conn, clipboard)
+		_ = conn.Close()
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+func serveClipboardConnection(ctx context.Context, conn virtio.VsockConn, clipboard *virtio.Clipboard) error {
+	if text, generation := clipboard.FrontendSnapshot(); generation != 0 {
+		if err := vmruntime.WriteClipboardText(conn, text); err != nil {
+			return err
+		}
+	}
+	readErr := make(chan error, 1)
+	go func() {
+		for {
+			text, err := vmruntime.ReadClipboardText(conn)
+			if err != nil {
+				readErr <- err
+				return
+			}
+			clipboard.SetFromGuest(text)
+		}
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-readErr:
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		case text := <-clipboard.ToGuest():
+			if err := vmruntime.WriteClipboardText(conn, text); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/hv/whp/display_windows_amd64.go
+++ b/internal/hv/whp/display_windows_amd64.go
@@ -1,0 +1,41 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"context"
+
+	"j5.nz/cc/internal/virtio"
+	"j5.nz/cc/internal/vmruntime"
+)
+
+func serveDisplayConnections(ctx context.Context, listener virtio.VsockListener, desktop *virtio.Desktop) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = serveDisplayConnection(ctx, conn, desktop)
+		_ = conn.Close()
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+func serveDisplayConnection(ctx context.Context, conn virtio.VsockConn, desktop *virtio.Desktop) error {
+	width, height := desktop.Framebuffer.Size()
+	if err := vmruntime.WriteDisplaySize(conn, uint32(width), uint32(height)); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case size := <-desktop.ResizeRequests():
+			if err := vmruntime.WriteDisplaySize(conn, size.Width, size.Height); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/hv/whp/exec_windows_amd64.go
+++ b/internal/hv/whp/exec_windows_amd64.go
@@ -50,7 +50,7 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 		_, _ = io.Copy(controlTranscript, conn)
 	}()
 
-	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, "", nil)
+	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, nil, "", nil)
 	if err != nil {
 		return client.ExecResponse{}, "", err
 	}
@@ -151,7 +151,7 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 	return client.ExecResponse{ExitCode: code, Output: output, Usage: usage}, serialOut.String(), nil
 }
 
-func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, snapshotDir string, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
+func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, displayDevices []virtio.MMIODevice, snapshotDir string, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
 	vm, err := newBootVM(amd64vm.MemorySizeBytes(memoryMB))
 	if err != nil {
 		return nil, nil, nil, err
@@ -169,6 +169,13 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 	}
 	if netdev != nil {
 		extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(netdev.Base, netdev.IRQ))
+	}
+	if len(displayDevices) != 0 {
+		extraCmdline = append(extraCmdline,
+			amd64vm.VirtioMMIODeviceArg(amd64vm.GPUBase, amd64vm.GPUIRQ),
+			amd64vm.VirtioMMIODeviceArg(amd64vm.KeyboardBase, amd64vm.KeyboardIRQ),
+			amd64vm.VirtioMMIODeviceArg(amd64vm.PointerBase, amd64vm.PointerIRQ),
+		)
 	}
 	rng := virtio.NewRNG(amd64vm.RNGBase, amd64vm.RNGSize, amd64vm.RNGIRQ)
 	extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(rng.Base, rng.IRQ))
@@ -211,6 +218,7 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 	if netdev != nil {
 		platform.AttachNet(netdev)
 	}
+	platform.AttachDisplayDevices(displayDevices)
 	platform.AttachRNG(rng)
 	if err := vm.EnableEmulation(platform); err != nil {
 		platform.Close()

--- a/internal/hv/whp/host_windows_amd64.go
+++ b/internal/hv/whp/host_windows_amd64.go
@@ -24,6 +24,8 @@ type LinuxManagedMachine struct {
 	Initrd          []byte
 	FSDevices       []*virtio.FS
 	NetDevice       *virtio.Net
+	DisplayWidth    uint32
+	DisplayHeight   uint32
 	SnapshotDir     string
 	RestoreSnapshot string
 }
@@ -31,6 +33,8 @@ type LinuxManagedMachine struct {
 type LinuxManagedAttachments struct {
 	FSDevices       []*virtio.FS
 	NetDevice       *virtio.Net
+	DisplayWidth    uint32
+	DisplayHeight   uint32
 	SnapshotDir     string
 	RestoreSnapshot string
 }
@@ -117,6 +121,8 @@ func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEven
 		Initrd:          req.Artifact.Initrd,
 		FSDevices:       attachments.FSDevices,
 		NetDevice:       attachments.NetDevice,
+		DisplayWidth:    attachments.DisplayWidth,
+		DisplayHeight:   attachments.DisplayHeight,
 		SnapshotDir:     attachments.SnapshotDir,
 		RestoreSnapshot: attachments.RestoreSnapshot,
 	}, onEvent)
@@ -127,6 +133,8 @@ func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, 
 	opts := ManagedSessionOptions{
 		SnapshotDir:     strings.TrimSpace(machine.SnapshotDir),
 		RestoreSnapshot: strings.TrimSpace(machine.RestoreSnapshot),
+		DisplayWidth:    machine.DisplayWidth,
+		DisplayHeight:   machine.DisplayHeight,
 	}
 	return StartManagedSessionWithNetOptions(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, opts, onEvent)
 }

--- a/internal/hv/whp/host_windows_amd64_test.go
+++ b/internal/hv/whp/host_windows_amd64_test.go
@@ -9,6 +9,7 @@ import (
 	managedhost "j5.nz/cc/internal/managed/host"
 	"j5.nz/cc/internal/managed/machine"
 	"j5.nz/cc/internal/managed/rootartifact"
+	"j5.nz/cc/internal/virtio"
 )
 
 func TestNormalizeLinuxManagedMachineDefaultsSpec(t *testing.T) {
@@ -44,5 +45,22 @@ func TestWHPHostRejectsUnexpectedLinuxAttachments(t *testing.T) {
 	}, nil)
 	if err == nil {
 		t.Fatalf("Start unexpected attachments error = %v", err)
+	}
+}
+
+func TestManagedDesktopProvidesFramebufferAndInput(t *testing.T) {
+	desktop, devices, clipboardListener, displayListener, err := newManagedDesktop(virtio.NewSimpleVsockBackend(), 1440, 900)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeManagedDisplayListeners(clipboardListener, displayListener)
+	if desktop == nil || desktop.GPU == nil || desktop.Keyboard == nil || desktop.Pointer == nil || desktop.Clipboard == nil {
+		t.Fatalf("desktop is incomplete: %+v", desktop)
+	}
+	if width, height := desktop.Framebuffer.Size(); width != 1440 || height != 900 {
+		t.Fatalf("framebuffer size = %dx%d, want 1440x900", width, height)
+	}
+	if len(devices) != 3 {
+		t.Fatalf("display device count = %d, want 3", len(devices))
 	}
 }

--- a/internal/hv/whp/platform_amd64_windows_test.go
+++ b/internal/hv/whp/platform_amd64_windows_test.go
@@ -126,3 +126,19 @@ func TestBootIOAPICActiveLowLevelLineUsesAssertedState(t *testing.T) {
 		t.Fatalf("deviceHighRoute after deassert = true, want false")
 	}
 }
+
+func TestPendingInterruptionWaitsUntilGuestEnablesInterrupts(t *testing.T) {
+	ctx := &runVPExitContext{
+		VpContext: vpExitContext{
+			Rflags: 0x2,
+		},
+	}
+	if canSetPendingInterruption(ctx, 0x3b) {
+		t.Fatal("pending interruption accepted while guest interrupts are disabled")
+	}
+
+	ctx.VpContext.Rflags |= 1 << 9
+	if !canSetPendingInterruption(ctx, 0x3b) {
+		t.Fatal("pending interruption rejected after guest enabled interrupts")
+	}
+}

--- a/internal/hv/whp/session_windows_amd64.go
+++ b/internal/hv/whp/session_windows_amd64.go
@@ -22,25 +22,30 @@ import (
 )
 
 type ManagedSession struct {
-	cancel     context.CancelFunc
-	doneCh     chan error
-	control    io.ReadWriteCloser
-	listener   io.Closer
-	vsock      *virtio.Vsock
-	bootWriter *vmruntime.BootEventWriter
-	transcript *vmruntime.SerialTranscript
-	serialOut  *vmruntime.SerialTranscript
-	platform   *bootPlatform
-	waitOnce   sync.Once
-	waitErr    error
-	sendMu     sync.Mutex
-	nextID     atomic.Uint64
-	dmesg      bool
+	cancel            context.CancelFunc
+	doneCh            chan error
+	control           io.ReadWriteCloser
+	listener          io.Closer
+	clipboardListener io.Closer
+	displayListener   io.Closer
+	vsock             *virtio.Vsock
+	desktop           *virtio.Desktop
+	bootWriter        *vmruntime.BootEventWriter
+	transcript        *vmruntime.SerialTranscript
+	serialOut         *vmruntime.SerialTranscript
+	platform          *bootPlatform
+	waitOnce          sync.Once
+	waitErr           error
+	sendMu            sync.Mutex
+	nextID            atomic.Uint64
+	dmesg             bool
 }
 
 type ManagedSessionOptions struct {
 	SnapshotDir     string
 	RestoreSnapshot string
+	DisplayWidth    uint32
+	DisplayHeight   uint32
 }
 
 const (
@@ -57,6 +62,10 @@ func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byt
 }
 
 func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if (strings.TrimSpace(opts.SnapshotDir) != "" || strings.TrimSpace(opts.RestoreSnapshot) != "") &&
+		(opts.DisplayWidth != 0 || opts.DisplayHeight != 0) {
+		return nil, fmt.Errorf("display-enabled VMs do not support startup snapshots")
+	}
 	if snapshotPath := strings.TrimSpace(opts.RestoreSnapshot); snapshotPath != "" {
 		return StartManagedSessionFromSnapshot(ctx, snapshotPath, memoryMB, dmesg, fsdevs, netdev, onEvent)
 	}
@@ -70,6 +79,12 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	}
 
 	vsock := virtio.NewVsock(amd64vm.VsockBase, amd64vm.VsockSize, amd64vm.VsockIRQ, vmruntime.GuestCID, backend)
+	desktop, displayDevices, clipboardListener, displayListener, err := newManagedDesktop(backend, opts.DisplayWidth, opts.DisplayHeight)
+	if err != nil {
+		_ = listener.Close()
+		vsock.Close()
+		return nil, err
+	}
 	connCh := make(chan virtio.VsockConn, 1)
 	acceptErrCh := make(chan error, 1)
 	controlTranscript := vmruntime.NewSerialTranscript()
@@ -89,8 +104,9 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = bootWriter
 	}
-	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, strings.TrimSpace(opts.SnapshotDir), serialWriter)
+	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, displayDevices, strings.TrimSpace(opts.SnapshotDir), serialWriter)
 	if err != nil {
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = listener.Close()
 		vsock.Close()
 		if bootWriter != nil {
@@ -100,6 +116,12 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	}
 
 	runCtx, cancel := context.WithCancel(context.Background())
+	if clipboardListener != nil {
+		go serveClipboardConnections(runCtx, clipboardListener, desktop.Clipboard)
+	}
+	if displayListener != nil {
+		go serveDisplayConnections(runCtx, displayListener, desktop)
+	}
 	doneCh := make(chan error, 1)
 	go func() {
 		err := runManagedExecVM(runCtx, vm, platform, serialOut)
@@ -112,6 +134,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	select {
 	case err := <-acceptErrCh:
 		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = listener.Close()
 		vsock.Close()
 		if bootWriter != nil {
@@ -122,6 +145,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 		control = conn
 	case err := <-doneCh:
 		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = listener.Close()
 		vsock.Close()
 		if bootWriter != nil {
@@ -130,6 +154,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
 	case <-ctx.Done():
 		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = listener.Close()
 		vsock.Close()
 		if bootWriter != nil {
@@ -142,6 +167,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 		return strings.Contains(text, vmruntime.InstanceReadyMarker) || vmruntime.HasFatalBootText(text)
 	}); err != nil {
 		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = control.Close()
 		_ = listener.Close()
 		vsock.Close()
@@ -155,6 +181,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	}
 	if vmruntime.HasFatalBootText(controlTranscript.String()) {
 		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = control.Close()
 		_ = listener.Close()
 		vsock.Close()
@@ -165,6 +192,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	}
 	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
 		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = control.Close()
 		_ = listener.Close()
 		vsock.Close()
@@ -175,17 +203,67 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	}
 
 	return &ManagedSession{
-		cancel:     cancel,
-		doneCh:     doneCh,
-		control:    control,
-		listener:   listener,
-		vsock:      vsock,
-		bootWriter: bootWriter,
-		transcript: controlTranscript,
-		serialOut:  serialOut,
-		platform:   platform,
-		dmesg:      dmesg,
+		cancel:            cancel,
+		doneCh:            doneCh,
+		control:           control,
+		listener:          listener,
+		clipboardListener: clipboardListener,
+		displayListener:   displayListener,
+		vsock:             vsock,
+		desktop:           desktop,
+		bootWriter:        bootWriter,
+		transcript:        controlTranscript,
+		serialOut:         serialOut,
+		platform:          platform,
+		dmesg:             dmesg,
 	}, nil
+}
+
+func newManagedDesktop(backend *virtio.SimpleVsockBackend, width, height uint32) (*virtio.Desktop, []virtio.MMIODevice, virtio.VsockListener, virtio.VsockListener, error) {
+	if width == 0 && height == 0 {
+		return nil, nil, nil, nil, nil
+	}
+	framebuffer, err := virtio.NewFramebuffer(int(width), int(height))
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("create display: %w", err)
+	}
+	gpu := virtio.NewGPU(amd64vm.GPUBase, amd64vm.GPUSize, amd64vm.GPUIRQ, framebuffer)
+	keyboard := virtio.NewKeyboardInput(amd64vm.KeyboardBase, amd64vm.KeyboardSize, amd64vm.KeyboardIRQ)
+	pointer := virtio.NewAbsolutePointerInput(amd64vm.PointerBase, amd64vm.PointerSize, amd64vm.PointerIRQ, width, height)
+	clipboard := virtio.NewClipboard()
+	clipboardListener, err := backend.Listen(vmruntime.ClipboardPort)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("listen for guest clipboard bridge: %w", err)
+	}
+	displayListener, err := backend.Listen(vmruntime.DisplayPort)
+	if err != nil {
+		_ = clipboardListener.Close()
+		return nil, nil, nil, nil, fmt.Errorf("listen for guest display bridge: %w", err)
+	}
+	desktop := &virtio.Desktop{
+		Framebuffer: framebuffer,
+		GPU:         gpu,
+		Keyboard:    keyboard,
+		Pointer:     pointer,
+		Clipboard:   clipboard,
+	}
+	return desktop, []virtio.MMIODevice{gpu, keyboard, pointer}, clipboardListener, displayListener, nil
+}
+
+func closeManagedDisplayListeners(clipboardListener, displayListener io.Closer) {
+	if clipboardListener != nil {
+		_ = clipboardListener.Close()
+	}
+	if displayListener != nil {
+		_ = displayListener.Close()
+	}
+}
+
+func (s *ManagedSession) Desktop() *virtio.Desktop {
+	if s == nil {
+		return nil
+	}
+	return s.desktop
 }
 
 func (s *ManagedSession) Exec(ctx context.Context, req client.ExecRequest) (client.ExecResponse, error) {
@@ -433,6 +511,7 @@ func (s *ManagedSession) Close() error {
 	if s.listener != nil {
 		_ = s.listener.Close()
 	}
+	closeManagedDisplayListeners(s.clipboardListener, s.displayListener)
 	if s.vsock != nil {
 		_ = s.vsock.Close()
 	}

--- a/internal/virtio/gpu.go
+++ b/internal/virtio/gpu.go
@@ -125,6 +125,12 @@ func (g *GPU) Attach(mem GuestMemory, irq IRQController) {
 	g.irq = irq
 }
 
+func (g *GPU) IRQAsserted() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.irqHigh
+}
+
 func (g *GPU) Contains(addr uint64, size int) bool {
 	if size <= 0 || addr < g.Base {
 		return false

--- a/internal/virtio/input.go
+++ b/internal/virtio/input.go
@@ -100,6 +100,12 @@ func (i *Input) Attach(mem GuestMemory, irq IRQController) {
 	i.irq = irq
 }
 
+func (i *Input) IRQAsserted() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.irqHigh
+}
+
 func (i *Input) Contains(addr uint64, size int) bool {
 	if size <= 0 || addr < i.Base {
 		return false

--- a/internal/vm/backend_display_windows_amd64_test.go
+++ b/internal/vm/backend_display_windows_amd64_test.go
@@ -1,0 +1,22 @@
+//go:build windows && amd64
+
+package vm
+
+import (
+	"slices"
+	"testing"
+
+	"j5.nz/cc/client"
+)
+
+func TestWindowsAMD64AdvertisesGraphicalVMs(t *testing.T) {
+	if !HostCapabilities().SupportsDisplay {
+		t.Fatal("windows/amd64 host does not advertise graphical VM support")
+	}
+	vars := windowsRuntimeConfigVars(&client.DisplayConfig{Width: 1440, Height: 900})
+	for _, required := range []string{"CONFIG_DRM_VIRTIO_GPU", "CONFIG_VIRTIO_INPUT", "CONFIG_INPUT_EVDEV"} {
+		if !slices.Contains(vars, required) {
+			t.Fatalf("display kernel requirements omit %s", required)
+		}
+	}
+}

--- a/internal/vm/backend_windows_amd64.go
+++ b/internal/vm/backend_windows_amd64.go
@@ -102,6 +102,8 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 			Attachments: whp.LinuxManagedAttachments{
 				FSDevices:       fsdevs,
 				NetDevice:       windowsNetworkDevice(network),
+				DisplayWidth:    displayWidthWindows(req.Display),
+				DisplayHeight:   displayHeightWindows(req.Display),
 				SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
 				RestoreSnapshot: restoreSnapshot,
 			},
@@ -129,7 +131,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, err
 	}
-	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(), windowsRuntimeModuleMap())
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(req.Display), windowsRuntimeModuleMap())
 	if err != nil {
 		return nil, err
 	}
@@ -163,6 +165,8 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		Attachments: whp.LinuxManagedAttachments{
 			FSDevices:       fsdevs,
 			NetDevice:       windowsNetworkDevice(network),
+			DisplayWidth:    displayWidthWindows(req.Display),
+			DisplayHeight:   displayHeightWindows(req.Display),
 			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
 			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
@@ -244,6 +248,8 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Attachments: whp.LinuxManagedAttachments{
 				FSDevices:       fsdevs,
 				NetDevice:       windowsNetworkDevice(network),
+				DisplayWidth:    displayWidthWindows(req.Display),
+				DisplayHeight:   displayHeightWindows(req.Display),
 				SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
 				RestoreSnapshot: restoreSnapshot,
 			},
@@ -269,7 +275,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if err != nil {
 		return nil, err
 	}
-	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(), windowsRuntimeModuleMap())
+	modules, err := b.kernel.PlanModuleLoad(windowsRuntimeConfigVars(req.Display), windowsRuntimeModuleMap())
 	if err != nil {
 		return nil, err
 	}
@@ -303,6 +309,8 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		Attachments: whp.LinuxManagedAttachments{
 			FSDevices:       fsdevs,
 			NetDevice:       windowsNetworkDevice(network),
+			DisplayWidth:    displayWidthWindows(req.Display),
+			DisplayHeight:   displayHeightWindows(req.Display),
 			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
 			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
 		},
@@ -757,6 +765,17 @@ func (i *windowsInstance) NetworkIPv4() string {
 	return netstate.IPv4(i.network.networkRuntime, "")
 }
 
+func (i *windowsInstance) Desktop() *virtio.Desktop {
+	if i == nil || i.core() == nil {
+		return nil
+	}
+	provider, _ := i.core().Session().(interface{ Desktop() *virtio.Desktop })
+	if provider == nil {
+		return nil
+	}
+	return provider.Desktop()
+}
+
 func windowsGuestInitConfig(modules []alpine.Module, managedExec bool) vmruntime.GuestInitConfig {
 	cfg := vmruntime.GuestInitConfig{
 		Modules:            vmruntime.ModulePaths(modules),
@@ -776,8 +795,12 @@ func windowsGuestInitConfig(modules []alpine.Module, managedExec bool) vmruntime
 	return cfg
 }
 
-func windowsRuntimeConfigVars() []string {
-	return []string{"CONFIG_VIRTIO_MMIO", "CONFIG_FUSE_FS", "CONFIG_VIRTIO_FS", "CONFIG_VSOCKETS", "CONFIG_VIRTIO_VSOCKETS", "CONFIG_HW_RANDOM", "CONFIG_HW_RANDOM_VIRTIO", "CONFIG_VIRTIO_NET", "CONFIG_OVERLAY_FS"}
+func windowsRuntimeConfigVars(display ...*client.DisplayConfig) []string {
+	vars := []string{"CONFIG_VIRTIO_MMIO", "CONFIG_FUSE_FS", "CONFIG_VIRTIO_FS", "CONFIG_VSOCKETS", "CONFIG_VIRTIO_VSOCKETS", "CONFIG_HW_RANDOM", "CONFIG_HW_RANDOM_VIRTIO", "CONFIG_VIRTIO_NET", "CONFIG_OVERLAY_FS"}
+	if len(display) != 0 && display[0] != nil {
+		vars = append(vars, "CONFIG_DRM_VIRTIO_GPU", "CONFIG_VIRTIO_INPUT", "CONFIG_INPUT_EVDEV")
+	}
+	return vars
 }
 
 func windowsRuntimeModuleMap() map[string]string {
@@ -791,7 +814,24 @@ func windowsRuntimeModuleMap() map[string]string {
 		"CONFIG_HW_RANDOM_VIRTIO": "kernel/drivers/char/hw_random/virtio-rng.ko.gz",
 		"CONFIG_VIRTIO_NET":       "kernel/drivers/net/virtio_net.ko.gz",
 		"CONFIG_OVERLAY_FS":       "kernel/fs/overlayfs/overlay.ko.gz",
+		"CONFIG_DRM_VIRTIO_GPU":   "kernel/drivers/gpu/drm/virtio/virtio-gpu.ko.gz",
+		"CONFIG_VIRTIO_INPUT":     "kernel/drivers/virtio/virtio_input.ko.gz",
+		"CONFIG_INPUT_EVDEV":      "kernel/drivers/input/evdev.ko.gz",
 	}
+}
+
+func displayWidthWindows(config *client.DisplayConfig) uint32 {
+	if config == nil {
+		return 0
+	}
+	return config.Width
+}
+
+func displayHeightWindows(config *client.DisplayConfig) uint32 {
+	if config == nil {
+		return 0
+	}
+	return config.Height
 }
 
 func withWindowsRuntimeMountDirs(image *oci.Image) *oci.Image {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -224,7 +224,8 @@ func HostCapabilities() client.CapabilitiesResponse {
 		caps.Notes = append(caps.Notes, "macOS HVF currently limits ccx3 to one running instance")
 	}
 	if (runtime.GOOS == "linux" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) ||
-		(runtime.GOOS == "darwin" && runtime.GOARCH == "arm64") {
+		(runtime.GOOS == "darwin" && runtime.GOARCH == "arm64") ||
+		(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
 		caps.SupportsDisplay = true
 	}
 	if runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64") {


### PR DESCRIPTION
## What changed

- attach virtio GPU, keyboard, pointer, display-resize, and clipboard devices to Windows/amd64 WHP managed sessions
- expose the WHP desktop session to ccvmd and advertise graphical VM capability
- load the virtio GPU and input kernel modules when a Windows VM requests a display
- reject display-enabled startup snapshots until that state is supported

## Why

NeurodeskAppX requested networking and a graphical display, but Windows/amd64 did not advertise display support and the WHP session had no display devices. Placement therefore rejected the host before boot with a misleading coordinator L2 capacity error.

## Validation

- native 8 GiB WHP boot on Windows reached `guest ready`, obtained `10.42.0.2`, and exposed the graphical framebuffer over VNC
- guest dmesg confirmed virtio GPU framebuffer, keyboard, and absolute pointer initialization
- `GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./internal/hv/whp ./internal/vm`
- `go test ./internal/virtio ./internal/vm/host`
