### PR TITLE
Boot requested init system on Windows

### DIFF
--- a/internal/vm/backend_windows_amd64.go
+++ b/internal/vm/backend_windows_amd64.go
@@ -139,7 +139,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
 	}
-	initCfg := windowsGuestInitConfig(modules, true)
+	initCfg := windowsGuestInitConfig(modules, true, req.InitSystem)
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
 	initCfg.WorkDir = workDir
@@ -283,7 +283,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
 	}
-	initCfg := windowsGuestInitConfig(modules, true)
+	initCfg := windowsGuestInitConfig(modules, true, req.InitSystem)
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	initCfg.Env = vmruntime.WithDefaultEnv(nil)
 	initCfg.WorkDir = "/"
@@ -394,7 +394,7 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 	if network != nil {
 		defer network.Close()
 	}
-	initCfg := windowsGuestInitConfig(modules, len(req.Command) != 0)
+	initCfg := windowsGuestInitConfig(modules, len(req.Command) != 0, req.InitSystem)
 	if len(fsdevs) != 0 {
 		initCfg.RootFSTag = vmruntime.RootFSTag
 	}
@@ -776,18 +776,18 @@ func (i *windowsInstance) Desktop() *virtio.Desktop {
 	return provider.Desktop()
 }
 
-func windowsGuestInitConfig(modules []alpine.Module, managedExec bool) vmruntime.GuestInitConfig {
+func windowsGuestInitConfig(modules []alpine.Module, managedExec bool, initSystem string) vmruntime.GuestInitConfig {
 	cfg := vmruntime.GuestInitConfig{
-		Modules:            vmruntime.ModulePaths(modules),
-		ReadyMarker:        windowsInitReadyMarker,
-		BeginMarker:        vmruntime.CommandBeginMarker,
-		OutputMarkerPref:   vmruntime.CommandOutputMarker,
-		ErrorMarkerPref:    vmruntime.CommandErrorMarker,
-		ControlMarkerPref:  vmruntime.CommandControlMarker,
-		UsageMarkerPref:    vmruntime.CommandUsageMarker,
-		ExitMarkerPrefix:   vmruntime.CommandExitMarkerPref,
-		DisableCgroupMount: true,
-		UnixTime:           time.Now().Unix(),
+		Modules:           vmruntime.ModulePaths(modules),
+		InitSystem:        strings.TrimSpace(initSystem),
+		ReadyMarker:       windowsInitReadyMarker,
+		BeginMarker:       vmruntime.CommandBeginMarker,
+		OutputMarkerPref:  vmruntime.CommandOutputMarker,
+		ErrorMarkerPref:   vmruntime.CommandErrorMarker,
+		ControlMarkerPref: vmruntime.CommandControlMarker,
+		UsageMarkerPref:   vmruntime.CommandUsageMarker,
+		ExitMarkerPrefix:  vmruntime.CommandExitMarkerPref,
+		UnixTime:          time.Now().Unix(),
 	}
 	if managedExec {
 		cfg.VsockPort = vmruntime.ControlPort

--- a/internal/vm/backend_windows_amd64_test.go
+++ b/internal/vm/backend_windows_amd64_test.go
@@ -1,0 +1,15 @@
+//go:build windows && amd64
+
+package vm
+
+import "testing"
+
+func TestWindowsGuestPreservesRequestedInitSystem(t *testing.T) {
+	cfg := windowsGuestInitConfig(nil, true, " systemd ")
+	if cfg.InitSystem != "systemd" {
+		t.Fatalf("init system = %q, want systemd", cfg.InitSystem)
+	}
+	if cfg.DisableCgroupMount {
+		t.Fatal("cgroup filesystem disabled for a managed Windows guest")
+	}
+}

--- a/internal/vm/backend_windows_arm64.go
+++ b/internal/vm/backend_windows_arm64.go
@@ -166,7 +166,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if trace {
 		_, _ = fmt.Fprintf(os.Stderr, "whp-arm64 backend +%s: kernel read bytes=%d\n", time.Since(startTime).Round(time.Millisecond), len(kernel))
 	}
-	initCfg := windowsGuestInitConfig(modules, true)
+	initCfg := windowsGuestInitConfig(modules, true, req.InitSystem)
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	if qemuX8664 != "" {
 		initCfg.EmulatorTag = vmruntime.EmulatorTag
@@ -290,7 +290,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if err != nil {
 		return nil, fmt.Errorf("build guest init: %w", err)
 	}
-	initCfg := windowsGuestInitConfig(modules, true)
+	initCfg := windowsGuestInitConfig(modules, true, req.InitSystem)
 	initCfg.RootFSTag = vmruntime.RootFSTag
 	initCfg.Env = vmruntime.WithDefaultEnv(nil)
 	initCfg.WorkDir = "/"
@@ -672,18 +672,18 @@ func (i *windowsInstance) NetworkIPv4() string {
 	return netstate.IPv4(i.network.networkRuntime, "")
 }
 
-func windowsGuestInitConfig(modules []alpine.Module, managedExec bool) vmruntime.GuestInitConfig {
+func windowsGuestInitConfig(modules []alpine.Module, managedExec bool, initSystem string) vmruntime.GuestInitConfig {
 	cfg := vmruntime.GuestInitConfig{
-		Modules:            vmruntime.ModulePaths(modules),
-		ReadyMarker:        windowsInitReadyMarker,
-		BeginMarker:        vmruntime.CommandBeginMarker,
-		OutputMarkerPref:   vmruntime.CommandOutputMarker,
-		ErrorMarkerPref:    vmruntime.CommandErrorMarker,
-		ControlMarkerPref:  vmruntime.CommandControlMarker,
-		UsageMarkerPref:    vmruntime.CommandUsageMarker,
-		ExitMarkerPrefix:   vmruntime.CommandExitMarkerPref,
-		DisableCgroupMount: true,
-		UnixTime:           time.Now().Unix(),
+		Modules:           vmruntime.ModulePaths(modules),
+		InitSystem:        strings.TrimSpace(initSystem),
+		ReadyMarker:       windowsInitReadyMarker,
+		BeginMarker:       vmruntime.CommandBeginMarker,
+		OutputMarkerPref:  vmruntime.CommandOutputMarker,
+		ErrorMarkerPref:   vmruntime.CommandErrorMarker,
+		ControlMarkerPref: vmruntime.CommandControlMarker,
+		UsageMarkerPref:   vmruntime.CommandUsageMarker,
+		ExitMarkerPrefix:  vmruntime.CommandExitMarkerPref,
+		UnixTime:          time.Now().Unix(),
 	}
 	if managedExec {
 		cfg.VsockPort = vmruntime.ControlPort


### PR DESCRIPTION
## Summary
- propagate the requested init system into Windows managed guests
- mount cgroup2 on Windows guests so systemd and managed command containment work
- cover the systemd/cgroup guest configuration contract

## Root cause
The Windows backends discarded `InitSystem` and explicitly disabled cgroup mounting. NeurodeskAppX therefore reported the VM as ready while `/init` remained PID 1; no desktop session started, and subsequent managed commands failed while creating their command cgroup.

## Validation
- Windows amd64 guest boots with systemd as PID 1
- cgroup2 mounted at `/sys/fs/cgroup`
- native Gowin window reaches the complete LX desktop framebuffer
- zero failed systemd units
- passwordless sudo and `~/neurodesktop-storage` symlink verified
- `GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./internal/vm ./internal/hv/whp`
- `GOOS=windows GOARCH=arm64 go test -exec=/usr/bin/true ./internal/vm`