### PR TITLE
Stream OCI updates and repair persistent filesystems

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -250,6 +250,16 @@ func (c *Client) GetImageContext(ctx context.Context, name string) (ImageState, 
 	return ret, err
 }
 
+func (c *Client) PlanImagePull(name string, req PullImageRequest) (ImagePullPlan, error) {
+	return c.PlanImagePullContext(context.Background(), name, req)
+}
+
+func (c *Client) PlanImagePullContext(ctx context.Context, name string, req PullImageRequest) (ImagePullPlan, error) {
+	var ret ImagePullPlan
+	err := c.postJSONExpectOKContext(ctx, "/image/"+imagePathName(name)+"/plan", req, &ret)
+	return ret, err
+}
+
 func (c *Client) PullImage(name string, req PullImageRequest) error {
 	return c.PullImageContext(context.Background(), name, req)
 }

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -80,6 +80,8 @@ type ProgressEvent struct {
 	Status             string  `json:"status"`
 	Artifact           string  `json:"artifact,omitempty"`
 	Progress           float64 `json:"progress,omitempty"`
+	DownloadProgress   float64 `json:"download_progress,omitempty"`
+	IndexProgress      float64 `json:"index_progress,omitempty"`
 	BytesDownloaded    int64   `json:"bytes_downloaded,omitempty"`
 	BytesTotal         int64   `json:"bytes_total,omitempty"`
 	FilesDownloaded    int64   `json:"files_downloaded,omitempty"`
@@ -91,11 +93,26 @@ type ProgressEvent struct {
 }
 
 type ImageState struct {
-	Name       string `json:"name"`
-	Source     string `json:"source,omitempty"`
-	SourceKind string `json:"source_kind,omitempty"`
-	Status     string `json:"status"`
-	Error      string `json:"error,omitempty"`
+	Name           string `json:"name"`
+	Source         string `json:"source,omitempty"`
+	ResolvedSource string `json:"resolved_source,omitempty"`
+	SourceKind     string `json:"source_kind,omitempty"`
+	Status         string `json:"status"`
+	Error          string `json:"error,omitempty"`
+}
+
+type ImagePullPlan struct {
+	Name            string `json:"name"`
+	Source          string `json:"source"`
+	Architecture    string `json:"architecture,omitempty"`
+	Installed       bool   `json:"installed"`
+	Available       bool   `json:"available"`
+	BytesTotal      int64  `json:"bytes_total,omitempty"`
+	BytesCached     int64  `json:"bytes_cached,omitempty"`
+	BytesToDownload int64  `json:"bytes_to_download,omitempty"`
+	LayersTotal     int64  `json:"layers_total,omitempty"`
+	LayersCached    int64  `json:"layers_cached,omitempty"`
+	ResolvedSource  string `json:"resolved_source,omitempty"`
 }
 
 type SaveImageRequest struct {
@@ -110,6 +127,7 @@ type PullImageRequest struct {
 	CacheDir        string       `json:"cache_dir,omitempty"`
 	Prefetch        bool         `json:"prefetch,omitempty"`
 	PrefetchWorkers int          `json:"prefetch_workers,omitempty"`
+	Refresh         bool         `json:"refresh,omitempty"`
 }
 
 type ImageSource struct {
@@ -179,6 +197,9 @@ func (r PullImageRequest) MarshalJSON() ([]byte, error) {
 	if r.PrefetchWorkers > 0 {
 		payload["prefetch_workers"] = r.PrefetchWorkers
 	}
+	if r.Refresh {
+		payload["refresh"] = true
+	}
 	return json.Marshal(payload)
 }
 
@@ -189,6 +210,7 @@ func (r *PullImageRequest) UnmarshalJSON(data []byte) error {
 		CacheDir        string          `json:"cache_dir,omitempty"`
 		Prefetch        bool            `json:"prefetch,omitempty"`
 		PrefetchWorkers int             `json:"prefetch_workers,omitempty"`
+		Refresh         bool            `json:"refresh,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -199,6 +221,7 @@ func (r *PullImageRequest) UnmarshalJSON(data []byte) error {
 	r.CacheDir = raw.CacheDir
 	r.Prefetch = raw.Prefetch
 	r.PrefetchWorkers = raw.PrefetchWorkers
+	r.Refresh = raw.Refresh
 	if len(raw.Source) == 0 || string(raw.Source) == "null" {
 		return nil
 	}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -366,6 +366,32 @@
         }
       }
     },
+    "/image/{image}/plan": {
+      "post": {
+        "tags": ["images"],
+        "summary": "Resolve an image and report the remaining download without pulling layers",
+        "parameters": [{ "$ref": "#/components/parameters/ImageName" }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/PullImageRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Image pull plan",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImagePullPlan" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
     "/image/{image}/qemu/download": {
       "post": {
         "tags": ["images"],
@@ -930,6 +956,8 @@
           "status": { "type": "string" },
           "artifact": { "type": "string" },
           "progress": { "type": "number" },
+          "download_progress": { "type": "number" },
+          "index_progress": { "type": "number" },
           "bytes_downloaded": { "type": "integer", "format": "int64" },
           "bytes_total": { "type": "integer", "format": "int64" },
           "files_downloaded": { "type": "integer", "format": "int64" },
@@ -946,9 +974,27 @@
         "properties": {
           "name": { "type": "string" },
           "source": { "type": "string" },
+          "resolved_source": { "type": "string" },
           "source_kind": { "type": "string" },
           "status": { "type": "string" },
           "error": { "type": "string" }
+        }
+      },
+      "ImagePullPlan": {
+        "type": "object",
+        "required": ["name", "source", "installed", "available"],
+        "properties": {
+          "name": { "type": "string" },
+          "source": { "type": "string" },
+          "architecture": { "type": "string" },
+          "installed": { "type": "boolean" },
+          "available": { "type": "boolean" },
+          "bytes_total": { "type": "integer", "format": "int64" },
+          "bytes_cached": { "type": "integer", "format": "int64" },
+          "bytes_to_download": { "type": "integer", "format": "int64" },
+          "layers_total": { "type": "integer", "format": "int64" },
+          "layers_cached": { "type": "integer", "format": "int64" },
+          "resolved_source": { "type": "string" }
         }
       },
       "ImageMetadataState": {
@@ -986,7 +1032,8 @@
           "architecture": { "type": "string" },
           "cache_dir": { "type": "string" },
           "prefetch": { "type": "boolean" },
-          "prefetch_workers": { "type": "integer" }
+          "prefetch_workers": { "type": "integer" },
+          "refresh": { "type": "boolean" }
         }
       },
       "ImageSource": {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -1516,6 +1516,29 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 		})
 	})
 
+	mux.HandleFunc("POST /image/{image}/plan", func(w http.ResponseWriter, r *http.Request) {
+		imageName := r.PathValue("image")
+		var req client.PullImageRequest
+		if err := decodeRequiredJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		source, err := req.SourceString()
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		plan, err := srvState.images.PlanPull(r.Context(), imageName, source, oci.PullOptions{
+			Architecture: req.Architecture,
+			CVMFSMirrors: cvmfsSourceMirrors(req.SourceRef),
+		})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, plan)
+	})
+
 	mux.HandleFunc("POST /image/{image}/qemu/download", func(w http.ResponseWriter, r *http.Request) {
 		imageName := r.PathValue("image")
 		if isBuiltInBSDImage(imageName) {
@@ -1589,6 +1612,7 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 					Prefetch:        req.Prefetch,
 					PrefetchWorkers: req.PrefetchWorkers,
 					CVMFSMirrors:    cvmfsSourceMirrors(req.SourceRef),
+					Refresh:         req.Refresh,
 					Report: func(event client.ProgressEvent) {
 						if event.Artifact == "" {
 							event.Artifact = imageName
@@ -1621,6 +1645,7 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 			Prefetch:        req.Prefetch,
 			PrefetchWorkers: req.PrefetchWorkers,
 			CVMFSMirrors:    cvmfsSourceMirrors(req.SourceRef),
+			Refresh:         req.Refresh,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err)

--- a/internal/ccvmd/openapi_test.go
+++ b/internal/ccvmd/openapi_test.go
@@ -28,6 +28,7 @@ func TestOpenAPIContract(t *testing.T) {
 	}
 	for name, value := range map[string]any{
 		"ErrorResponse":           client.ErrorResponse{},
+		"ImagePullPlan":           client.ImagePullPlan{},
 		"CreateInstanceRequest":   client.CreateInstanceRequest{},
 		"StartInstanceRequest":    client.StartInstanceRequest{},
 		"RunRequest":              client.RunRequest{},

--- a/internal/oci/archive.go
+++ b/internal/oci/archive.go
@@ -78,7 +78,7 @@ func (s *Store) pullDockerArchiveDirect(ctx context.Context, name string, spec S
 			return fmt.Errorf("index docker archive layer %d %q: %w", i, layerMember, err)
 		}
 	}
-	return s.finalizeIndexedImage(name, spec, imageDir, tmpDir, cfg, build)
+	return s.finalizeIndexedImage(name, spec, "", imageDir, tmpDir, cfg, build)
 }
 
 type dockerArchiveLayerTarget struct {

--- a/internal/oci/indexedfs.go
+++ b/internal/oci/indexedfs.go
@@ -567,6 +567,74 @@ func writeLayerTarFromReaderWithProgress(dstPath, mediaType string, body io.Read
 	return os.Rename(tmpPath, dstPath)
 }
 
+func writeAndApplyIndexedLayer(
+	dstPath, mediaType string,
+	body io.Reader,
+	tarRef string,
+	merged map[string]*indexedNode,
+	entries map[string]fsmeta.Entry,
+	progress func(int64),
+) error {
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return err
+	}
+	tmpPath := dstPath + ".tmp"
+	dst, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = dst.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
+	tracked := &countingReader{r: body}
+	if progress != nil {
+		tracked.report = func(current, _ int64) {
+			progress(current)
+		}
+	}
+	buffered := bufio.NewReader(tracked)
+	var src io.Reader = buffered
+	var gzr *gzip.Reader
+	gzipLayer := strings.Contains(mediaType, "gzip")
+	if !gzipLayer {
+		if magic, peekErr := buffered.Peek(2); peekErr == nil {
+			gzipLayer = magic[0] == 0x1f && magic[1] == 0x8b
+		}
+	}
+	if gzipLayer {
+		gzr, err = gzip.NewReader(src)
+		if err != nil {
+			return fmt.Errorf("open gzip layer: %w", err)
+		}
+		defer gzr.Close()
+		src = gzr
+	}
+
+	maxBytes, err := download.FilesystemBudget(dstPath)
+	if err != nil {
+		return fmt.Errorf("determine expanded layer budget: %w", err)
+	}
+	budgetedDst, err := download.NewLimitWriter(dst, maxBytes)
+	if err != nil {
+		return err
+	}
+	expanded := &countingReader{r: io.TeeReader(src, budgetedDst)}
+	if err := applyIndexedLayerReader(tar.NewReader(expanded), expanded, tarRef, merged, entries, 0, nil); err != nil {
+		return err
+	}
+	// archive/tar stops at the end marker. Drain the decompressor so its
+	// checksum is verified and the final backing tar contains all padding.
+	if _, err := io.Copy(budgetedDst, src); err != nil {
+		return err
+	}
+	if err := dst.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, dstPath)
+}
+
 type countingReader struct {
 	r          io.Reader
 	n          uint64
@@ -609,13 +677,24 @@ func applyIndexedLayerWithProgress(
 		return err
 	}
 	cr := &countingReader{r: file, total: info.Size(), report: progress}
-	tr := tar.NewReader(cr)
+	return applyIndexedLayerReader(tar.NewReader(cr), cr, tarRef, merged, entries, info.Size(), progress)
+}
+
+func applyIndexedLayerReader(
+	tr *tar.Reader,
+	cr *countingReader,
+	tarRef string,
+	merged map[string]*indexedNode,
+	entries map[string]fsmeta.Entry,
+	total int64,
+	progress func(current, total int64),
+) error {
 	layerEntries := map[string]*indexedNode{}
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
 			if progress != nil {
-				progress(info.Size(), info.Size())
+				progress(total, total)
 			}
 			return nil
 		}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -70,6 +70,7 @@ type imageOpenCall struct {
 type metadata struct {
 	Name               string      `json:"name"`
 	Source             string      `json:"source"`
+	ResolvedSource     string      `json:"resolved_source,omitempty"`
 	SourceKind         string      `json:"source_kind,omitempty"`
 	CVMFSRootHash      string      `json:"cvmfs_root_hash,omitempty"`
 	CVMFSMirrors       []string    `json:"cvmfs_mirrors,omitempty"`
@@ -113,6 +114,7 @@ type PullOptions struct {
 	PrefetchWorkers int
 	CVMFSMirrors    []string
 	Report          func(client.ProgressEvent)
+	Refresh         bool
 }
 
 type SaveOptions struct {
@@ -487,25 +489,27 @@ func (s *Store) Pull(ctx context.Context, name, source string, options ...PullOp
 		reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
 		return s.Get(name)
 	}
-	if state, ok, err := s.existingState(ctx, name, spec, opts.Architecture); err != nil {
-		return client.ImageState{}, err
-	} else if ok {
-		reportPullProgress(opts.Report, client.ProgressEvent{Status: "available", Artifact: name})
-		if err := s.maybePrefetchCVMFSImage(ctx, name, spec, opts); err != nil {
+	if !opts.Refresh {
+		if state, ok, err := s.existingState(ctx, name, spec, opts.Architecture); err != nil {
 			return client.ImageState{}, err
+		} else if ok {
+			reportPullProgress(opts.Report, client.ProgressEvent{Status: "available", Artifact: name})
+			if err := s.maybePrefetchCVMFSImage(ctx, name, spec, opts); err != nil {
+				return client.ImageState{}, err
+			}
+			reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
+			return state, nil
 		}
-		reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
-		return state, nil
-	}
-	if state, ok, err := s.restoreFromSharedCache(ctx, name, spec, opts.Architecture); err != nil {
-		return client.ImageState{}, err
-	} else if ok {
-		reportPullProgress(opts.Report, client.ProgressEvent{Status: "restored", Artifact: name})
-		if err := s.maybePrefetchCVMFSImage(ctx, name, spec, opts); err != nil {
+		if state, ok, err := s.restoreFromSharedCache(ctx, name, spec, opts.Architecture); err != nil {
 			return client.ImageState{}, err
+		} else if ok {
+			reportPullProgress(opts.Report, client.ProgressEvent{Status: "restored", Artifact: name})
+			if err := s.maybePrefetchCVMFSImage(ctx, name, spec, opts); err != nil {
+				return client.ImageState{}, err
+			}
+			reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
+			return state, nil
 		}
-		reportPullProgress(opts.Report, client.ProgressEvent{Status: "downloaded", Artifact: name})
-		return state, nil
 	}
 
 	s.mu.Lock()
@@ -536,6 +540,103 @@ func (s *Store) Pull(ctx context.Context, name, source string, options ...PullOp
 	return state, nil
 }
 
+func (s *Store) PlanPull(ctx context.Context, name, source string, options ...PullOptions) (client.ImagePullPlan, error) {
+	if name == "" {
+		return client.ImagePullPlan{}, fmt.Errorf("image name is required")
+	}
+	if source == "" {
+		return client.ImagePullPlan{}, fmt.Errorf("image source is required")
+	}
+	spec, err := ParseSource(source)
+	if err != nil {
+		return client.ImagePullPlan{}, err
+	}
+	var opts PullOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	architecture := firstNonEmpty(normalizeArchitecture(opts.Architecture), nativeArch())
+	plan := client.ImagePullPlan{
+		Name:         name,
+		Source:       source,
+		Architecture: architecture,
+	}
+	sharedName := sharedImageKey(spec, opts.Architecture)
+	shared := NewStore(s.sharedRoot())
+	shared.httpClient = s.httpClient
+	plan.Installed = pullPlanImageInstalled(s, name, spec, architecture)
+	if spec.Kind != SourceKindOCI {
+		if _, ok, err := s.existingState(ctx, name, spec, opts.Architecture); err != nil {
+			return client.ImagePullPlan{}, err
+		} else if ok {
+			plan.Available = true
+			return plan, nil
+		}
+		if _, ok, err := shared.existingState(ctx, sharedName, spec, opts.Architecture); err != nil {
+			return client.ImagePullPlan{}, err
+		} else if ok {
+			plan.Available = true
+		}
+		return plan, nil
+	}
+
+	registry, imageName, tag, err := ParseImageRef(spec.Raw)
+	if err != nil {
+		return client.ImagePullPlan{}, err
+	}
+	reg := &registryContext{client: shared.httpClient, registry: registry}
+	mani, manifestDigest, err := shared.fetchManifest(ctx, reg, imageName, tag, preferredManifestArchitectures(opts.Architecture)...)
+	if err != nil {
+		return client.ImagePullPlan{}, err
+	}
+	if manifestDigest != "" {
+		plan.ResolvedSource = resolvedOCISource(registry, imageName, manifestDigest)
+	}
+	if pullPlanMetadataMatches(s, name, spec, architecture, plan.ResolvedSource) ||
+		pullPlanMetadataMatches(shared, sharedName, spec, architecture, plan.ResolvedSource) {
+		plan.Available = true
+		return plan, nil
+	}
+	seen := make(map[string]struct{}, len(mani.Layers))
+	for _, layer := range mani.Layers {
+		if layer.Size <= 0 {
+			return client.ImagePullPlan{}, fmt.Errorf("layer %s has invalid size %d", layer.Digest, layer.Size)
+		}
+		if _, duplicate := seen[layer.Digest]; duplicate {
+			continue
+		}
+		seen[layer.Digest] = struct{}{}
+		plan.LayersTotal++
+		plan.BytesTotal += layer.Size
+		blobPath := filepath.Join(shared.root, "_blobs", digestToFileName(layer.Digest))
+		if info, statErr := os.Stat(blobPath); statErr == nil && info.Mode().IsRegular() && info.Size() == layer.Size {
+			plan.LayersCached++
+			plan.BytesCached += layer.Size
+		}
+	}
+	plan.BytesToDownload = max(0, plan.BytesTotal-plan.BytesCached)
+	return plan, nil
+}
+
+func pullPlanImageInstalled(store *Store, name string, spec SourceSpec, architecture string) bool {
+	meta, err := store.readMetadata(name)
+	if err != nil || meta.Source != spec.Raw || meta.SourceKind != spec.Kind || !dirExists(meta.RootFSDir) {
+		return false
+	}
+	return architecture == "" || normalizeArchitecture(meta.Architecture) == normalizeArchitecture(architecture)
+}
+
+func pullPlanMetadataMatches(store *Store, name string, spec SourceSpec, architecture, resolvedSource string) bool {
+	if resolvedSource == "" {
+		return false
+	}
+	meta, err := store.readMetadata(name)
+	if err != nil || meta.ResolvedSource != resolvedSource {
+		return false
+	}
+	return pullPlanImageInstalled(store, name, spec, architecture)
+}
+
 func (s *Store) pull(ctx context.Context, name string, spec SourceSpec, options PullOptions) error {
 	if err := os.MkdirAll(s.root, 0o755); err != nil {
 		return fmt.Errorf("create image store: %w", err)
@@ -547,7 +648,11 @@ func (s *Store) pull(ctx context.Context, name string, spec SourceSpec, options 
 	sharedName := sharedImageKey(spec, options.Architecture)
 	shared := NewStore(s.sharedRoot())
 	shared.httpClient = s.httpClient
-	if _, ok, err := shared.existingState(ctx, sharedName, spec, options.Architecture); err != nil {
+	if options.Refresh {
+		if err := shared.pullDirect(ctx, sharedName, spec, options); err != nil {
+			return err
+		}
+	} else if _, ok, err := shared.existingState(ctx, sharedName, spec, options.Architecture); err != nil {
 		return err
 	} else if !ok {
 		if err := shared.pullDirect(ctx, sharedName, spec, options); err != nil {
@@ -603,7 +708,7 @@ func (s *Store) pullRootFSTarDirect(ctx context.Context, name string, spec Sourc
 	cfg := imageConfig{Architecture: firstNonEmpty(normalizeArchitecture(options.Architecture), nativeArch())}
 	cfg.Config.Env = []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 	cfg.Config.WorkingDir = "/"
-	if err := s.finalizeIndexedImage(name, spec, imageDir, tmpDir, cfg, build); err != nil {
+	if err := s.finalizeIndexedImage(name, spec, "", imageDir, tmpDir, cfg, build); err != nil {
 		return err
 	}
 	return nil
@@ -1036,78 +1141,126 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 		return fmt.Errorf("decode image config: %w", err)
 	}
 
-	downloads, err := s.startLayerBlobPull(ctx, reg, imageName, name, mani.Layers, report)
+	var totalLayerBytes int64
+	for _, layer := range mani.Layers {
+		totalLayerBytes += layer.Size
+	}
+	var pipelineMu sync.Mutex
+	var backgroundDownloadedBytes int64
+	var streamedDownloadedBytes int64
+	var downloadedLayerBytes int64
+	var preparedLayerWork int64
+	reportDownload := func(event client.ProgressEvent) {
+		pipelineMu.Lock()
+		if event.BytesTotal > 0 {
+			backgroundDownloadedBytes = max(backgroundDownloadedBytes, event.BytesDownloaded)
+			downloadedLayerBytes = min(totalLayerBytes, backgroundDownloadedBytes+streamedDownloadedBytes)
+			event.BytesDownloaded = downloadedLayerBytes
+			event.BytesTotal = totalLayerBytes
+			event.DownloadProgress = ratio(downloadedLayerBytes, totalLayerBytes)
+			event.IndexProgress = ratio(preparedLayerWork, totalLayerBytes)
+			event.Progress = ratio(downloadedLayerBytes+preparedLayerWork, totalLayerBytes*2)
+			if preparedLayerWork > 0 && event.Status == "downloading" {
+				event.Status = "processing"
+			}
+		}
+		pipelineMu.Unlock()
+		report(event)
+	}
+	streamFirstLayer := len(mani.Layers) != 0 && !s.cachedLayerBlobAvailable(mani.Layers[0])
+	downloadLayers := mani.Layers
+	if streamFirstLayer {
+		firstDigest := mani.Layers[0].Digest
+		downloadLayers = make([]descriptor, 0, len(mani.Layers)-1)
+		for _, layer := range mani.Layers[1:] {
+			if layer.Digest != firstDigest {
+				downloadLayers = append(downloadLayers, layer)
+			}
+		}
+	}
+	downloads, err := s.startLayerBlobPull(ctx, reg, imageName, name, downloadLayers, reportDownload)
 	if err != nil {
 		return err
 	}
 	defer downloads.cancel()
 
 	build := newIndexedBuildState()
-	var totalLayerBytes int64
-	for _, layer := range mani.Layers {
-		totalLayerBytes += layer.Size
-	}
 	var preparedLayerBytes int64
 	prepareStarted := time.Now()
 	for layerIndex, layer := range mani.Layers {
-		if err := downloads.waitLayer(ctx, layer.Digest); err != nil {
-			return fmt.Errorf("cache layer %s: %w", layer.Digest, err)
-		}
 		layerTarRel := filepath.Join("layers", digestToFileName(layer.Digest)+".tar")
 		layerTarPath := filepath.Join(tmpDir, layerTarRel)
-		reportPrepare := func(layerWork int64) {
-			if !downloads.finished() {
-				return
+		reportPrepare := func(layerWork int64, streaming bool) {
+			pipelineMu.Lock()
+			if streaming {
+				streamedDownloadedBytes = max(streamedDownloadedBytes, min(layer.Size, max(0, layerWork)))
+				downloadedLayerBytes = min(totalLayerBytes, backgroundDownloadedBytes+streamedDownloadedBytes)
 			}
-			workTotal := totalLayerBytes * 2
-			workDone := preparedLayerBytes*2 + min(layer.Size*2, max(0, layerWork))
-			progress := ratio(workDone, workTotal)
+			preparedLayerWork = preparedLayerBytes + min(layer.Size, max(0, layerWork))
+			downloadProgress := ratio(downloadedLayerBytes, totalLayerBytes)
+			indexProgress := ratio(preparedLayerWork, totalLayerBytes)
+			progress := ratio(downloadedLayerBytes+preparedLayerWork, totalLayerBytes*2)
+			bytesDownloaded := downloadedLayerBytes
+			pipelineMu.Unlock()
 			elapsed := time.Since(prepareStarted).Seconds()
 			var eta float64
 			if progress > 0 && progress < 1 && elapsed > 0 {
 				eta = elapsed * (1 - progress) / progress
 			}
 			report(client.ProgressEvent{
-				Status:          "indexing",
-				Artifact:        name,
-				Blob:            layer.Digest,
-				Progress:        progress,
-				FilesDownloaded: int64(layerIndex),
-				FilesTotal:      int64(len(mani.Layers)),
-				ETASeconds:      eta,
+				Status:           "processing",
+				Artifact:         name,
+				Blob:             layer.Digest,
+				Progress:         progress,
+				DownloadProgress: downloadProgress,
+				IndexProgress:    indexProgress,
+				BytesDownloaded:  bytesDownloaded,
+				BytesTotal:       totalLayerBytes,
+				FilesDownloaded:  int64(layerIndex),
+				FilesTotal:       int64(len(mani.Layers)),
+				ETASeconds:       eta,
 			})
 		}
-		reportPrepare(0)
-		if err := s.writeCachedLayerTar(layer, layerTarPath, func(compressedBytes int64) {
-			reportPrepare(min(layer.Size, compressedBytes))
-		}); err != nil {
-			return fmt.Errorf("expand layer %s: %w", layer.Digest, err)
-		}
-		if err := applyIndexedLayerWithProgress(layerTarPath, layerTarRel, build.merged, build.fsEntries, func(indexedBytes, expandedBytes int64) {
-			indexFraction := ratio(indexedBytes, expandedBytes)
-			reportPrepare(layer.Size + int64(float64(layer.Size)*indexFraction))
-		}); err != nil {
-			return fmt.Errorf("index layer %s: %w", layer.Digest, err)
+		reportPrepare(0, streamFirstLayer && layerIndex == 0)
+		if streamFirstLayer && layerIndex == 0 {
+			if err := s.downloadAndApplyLayer(ctx, reg, imageName, layer, layerTarPath, layerTarRel, build.merged, build.fsEntries, func(compressedBytes int64) {
+				reportPrepare(compressedBytes, true)
+			}); err != nil {
+				return fmt.Errorf("download and prepare layer %s: %w", layer.Digest, err)
+			}
+		} else {
+			if err := downloads.waitLayer(ctx, layer.Digest); err != nil {
+				return fmt.Errorf("cache layer %s: %w", layer.Digest, err)
+			}
+			if err := s.writeAndApplyCachedLayer(layer, layerTarPath, layerTarRel, build.merged, build.fsEntries, func(compressedBytes int64) {
+				reportPrepare(compressedBytes, false)
+			}); err != nil {
+				return fmt.Errorf("prepare layer %s: %w", layer.Digest, err)
+			}
 		}
 		preparedLayerBytes += layer.Size
-		reportPrepare(0)
+		reportPrepare(0, false)
 	}
 	if err := downloads.wait(ctx); err != nil {
 		return err
 	}
 	report(client.ProgressEvent{
-		Status:          "indexing",
-		Artifact:        name,
-		Blob:            "filesystem",
-		Progress:        1,
-		FilesDownloaded: int64(len(mani.Layers)),
-		FilesTotal:      int64(len(mani.Layers)),
+		Status:           "processing",
+		Artifact:         name,
+		Blob:             "filesystem",
+		Progress:         1,
+		DownloadProgress: 1,
+		IndexProgress:    1,
+		BytesDownloaded:  totalLayerBytes,
+		BytesTotal:       totalLayerBytes,
+		FilesDownloaded:  int64(len(mani.Layers)),
+		FilesTotal:       int64(len(mani.Layers)),
 	})
-	metaSpec := spec
+	resolvedSource := ""
 	if manifestDigest != "" {
-		metaSpec.Raw = resolvedOCISource(registry, imageName, manifestDigest)
+		resolvedSource = resolvedOCISource(registry, imageName, manifestDigest)
 	}
-	return s.finalizeIndexedImage(name, metaSpec, imageDir, tmpDir, cfg, build)
+	return s.finalizeIndexedImage(name, spec, resolvedSource, imageDir, tmpDir, cfg, build)
 }
 
 type indexedBuildState struct {
@@ -1133,7 +1286,7 @@ func newIndexedBuildState() indexedBuildState {
 	}
 }
 
-func (s *Store) finalizeIndexedImage(name string, spec SourceSpec, imageDir, tmpDir string, cfg imageConfig, build indexedBuildState) error {
+func (s *Store) finalizeIndexedImage(name string, spec SourceSpec, resolvedSource, imageDir, tmpDir string, cfg imageConfig, build indexedBuildState) error {
 	ensureIndexedParents(build.merged, build.fsEntries)
 	indexPath := filepath.Join(imageDir, "rootfs.index.json")
 	indexBuf, err := encodeFSIndex(build.merged)
@@ -1153,19 +1306,20 @@ func (s *Store) finalizeIndexedImage(name string, spec SourceSpec, imageDir, tmp
 	}
 
 	meta := metadata{
-		Name:         name,
-		Source:       spec.Raw,
-		SourceKind:   spec.Kind,
-		Architecture: cfg.Architecture,
-		RootFSDir:    imageDir,
-		MetadataPath: metadataPath,
-		IndexPath:    indexPath,
-		Env:          append([]string(nil), cfg.Config.Env...),
-		Entrypoint:   append([]string(nil), cfg.Config.Entrypoint...),
-		Cmd:          append([]string(nil), cfg.Config.Cmd...),
-		WorkingDir:   cfg.Config.WorkingDir,
-		User:         cfg.Config.User,
-		Labels:       labelPairsFromMap(cfg.Config.Labels),
+		Name:           name,
+		Source:         spec.Raw,
+		ResolvedSource: resolvedSource,
+		SourceKind:     spec.Kind,
+		Architecture:   cfg.Architecture,
+		RootFSDir:      imageDir,
+		MetadataPath:   metadataPath,
+		IndexPath:      indexPath,
+		Env:            append([]string(nil), cfg.Config.Env...),
+		Entrypoint:     append([]string(nil), cfg.Config.Entrypoint...),
+		Cmd:            append([]string(nil), cfg.Config.Cmd...),
+		WorkingDir:     cfg.Config.WorkingDir,
+		User:           cfg.Config.User,
+		Labels:         labelPairsFromMap(cfg.Config.Labels),
 	}
 
 	if err := os.RemoveAll(imageDir); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -1209,7 +1363,7 @@ func (s *Store) existingState(ctx context.Context, name string, spec SourceSpec,
 	if !dirExists(meta.RootFSDir) {
 		return client.ImageState{}, false, nil
 	}
-	return client.ImageState{Name: meta.Name, Source: meta.Source, SourceKind: meta.SourceKind, Status: "downloaded"}, true, nil
+	return client.ImageState{Name: meta.Name, Source: meta.Source, ResolvedSource: meta.ResolvedSource, SourceKind: meta.SourceKind, Status: "downloaded"}, true, nil
 }
 
 func (s *Store) restoreFromSharedCache(ctx context.Context, name string, spec SourceSpec, architecture string) (client.ImageState, bool, error) {
@@ -1246,7 +1400,7 @@ func (s *Store) restoreFromSharedCache(ctx context.Context, name string, spec So
 	if err := s.cloneFromStore(shared, sharedName, name, spec); err != nil {
 		return client.ImageState{}, false, err
 	}
-	return client.ImageState{Name: name, Source: spec.Raw, SourceKind: spec.Kind, Status: "downloaded"}, true, nil
+	return client.ImageState{Name: name, Source: spec.Raw, ResolvedSource: meta.ResolvedSource, SourceKind: spec.Kind, Status: "downloaded"}, true, nil
 }
 
 func (s *Store) currentCVMFSRootHash(ctx context.Context, spec SourceSpec, mirrors []string) (string, error) {
@@ -1299,6 +1453,12 @@ func (s *Store) cloneFromStore(src *Store, srcName, dstName string, spec SourceS
 	buf, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal image metadata: %w", err)
+	}
+	// copyTree hard-links immutable cache artifacts when possible. image.json
+	// belongs to the named image, so unlink it before writing the adjusted
+	// metadata rather than truncating the shared cache's copy.
+	if err := os.Remove(filepath.Join(tmpDir, "image.json")); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("replace cached image metadata: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpDir, "image.json"), buf, 0o644); err != nil {
 		return fmt.Errorf("write image metadata: %w", err)
@@ -1459,15 +1619,6 @@ func (p *layerBlobPull) wait(ctx context.Context) error {
 	}
 }
 
-func (p *layerBlobPull) finished() bool {
-	select {
-	case <-p.done:
-		return true
-	default:
-		return false
-	}
-}
-
 func (s *Store) startLayerBlobPull(
 	ctx context.Context,
 	reg *registryContext,
@@ -1570,8 +1721,13 @@ func (s *Store) cacheLayerBlob(
 ) error {
 	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
 	if info, err := os.Stat(blobPath); err == nil && info.Mode().IsRegular() {
-		progress.complete(layer.Digest, layer.Size)
-		return nil
+		if info.Size() == layer.Size {
+			progress.complete(layer.Digest, layer.Size)
+			return nil
+		}
+		if err := os.Remove(blobPath); err != nil {
+			return fmt.Errorf("remove invalid cached layer: %w", err)
+		}
 	}
 	resp, err := reg.do(ctx, "/"+imageName+"/blobs/"+layer.Digest, nil)
 	if err != nil {
@@ -1605,14 +1761,81 @@ func (s *Store) cacheLayerBlob(
 	return nil
 }
 
-func (s *Store) writeCachedLayerTar(layer descriptor, dstPath string, progress func(int64)) error {
+func (s *Store) cachedLayerBlobAvailable(layer descriptor) bool {
+	info, err := os.Stat(filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest)))
+	return err == nil && info.Mode().IsRegular() && info.Size() == layer.Size
+}
+
+func (s *Store) downloadAndApplyLayer(
+	ctx context.Context,
+	reg *registryContext,
+	imageName string,
+	layer descriptor,
+	dstPath, tarRef string,
+	merged map[string]*indexedNode,
+	entries map[string]fsmeta.Entry,
+	progress func(int64),
+) error {
+	resp, err := reg.do(ctx, "/"+imageName+"/blobs/"+layer.Digest, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if err := download.BoundResponse(resp, layer.Size); err != nil {
+		return err
+	}
+	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		return err
+	}
+	tmpBlobPath := blobPath + ".tmp"
+	blob, err := os.OpenFile(tmpBlobPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = blob.Close()
+		_ = os.Remove(tmpBlobPath)
+	}()
+	hash := sha256.New()
+	body := io.TeeReader(resp.Body, io.MultiWriter(blob, hash))
+	if err := writeAndApplyIndexedLayer(dstPath, layer.MediaType, body, tarRef, merged, entries, progress); err != nil {
+		return err
+	}
+	if err := blob.Close(); err != nil {
+		return err
+	}
+	info, err := os.Stat(tmpBlobPath)
+	if err != nil {
+		return err
+	}
+	if info.Size() != layer.Size {
+		return &download.LengthError{Expected: layer.Size, Actual: info.Size()}
+	}
+	actualDigest := "sha256:" + hex.EncodeToString(hash.Sum(nil))
+	if !strings.EqualFold(actualDigest, layer.Digest) {
+		return &download.DigestError{Expected: layer.Digest, Actual: actualDigest}
+	}
+	if err := os.Rename(tmpBlobPath, blobPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) writeAndApplyCachedLayer(
+	layer descriptor,
+	dstPath, tarRef string,
+	merged map[string]*indexedNode,
+	entries map[string]fsmeta.Entry,
+	progress func(int64),
+) error {
 	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
 	file, err := os.Open(blobPath)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
-	return writeLayerTarFromReaderWithProgress(dstPath, layer.MediaType, file, progress)
+	return writeAndApplyIndexedLayer(dstPath, layer.MediaType, file, tarRef, merged, entries, progress)
 }
 
 func (s *Store) getJSONBlob(ctx context.Context, reg *registryContext, path string, accept []string) ([]byte, string, error) {
@@ -1758,14 +1981,14 @@ func (s *Store) getLocked(name string) (client.ImageState, error) {
 	if s.downloading[name] {
 		meta, err := s.readMetadata(name)
 		if err == nil {
-			return client.ImageState{Name: name, Source: meta.Source, SourceKind: meta.SourceKind, Status: "downloading"}, nil
+			return client.ImageState{Name: name, Source: meta.Source, ResolvedSource: meta.ResolvedSource, SourceKind: meta.SourceKind, Status: "downloading"}, nil
 		}
 		return client.ImageState{Name: name, Status: "downloading"}, nil
 	}
 
 	meta, err := s.readMetadata(name)
 	if err == nil {
-		return client.ImageState{Name: meta.Name, Source: meta.Source, SourceKind: meta.SourceKind, Status: "downloaded"}, nil
+		return client.ImageState{Name: meta.Name, Source: meta.Source, ResolvedSource: meta.ResolvedSource, SourceKind: meta.SourceKind, Status: "downloaded"}, nil
 	}
 	if lastErr := s.lastErr[name]; lastErr != nil {
 		return client.ImageState{Name: name, Status: "error", Error: lastErr.Error()}, nil
@@ -2255,6 +2478,11 @@ func copyTree(srcDir, dstDir string) error {
 			}
 			return os.Symlink(link, target)
 		case mode.IsRegular():
+			if err := os.Link(current, target); err == nil {
+				return nil
+			}
+			// Custom image and shared-cache roots may live on different
+			// filesystems, where hard links are unavailable.
 			return copyFile(current, target, mode.Perm())
 		default:
 			return fmt.Errorf("unsupported file mode %v at %s", mode, current)

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -3,9 +3,11 @@ package oci
 import (
 	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +26,67 @@ import (
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/imagefs"
 )
+
+func TestWriteAndApplyIndexedLayerUsesOneStream(t *testing.T) {
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gzw)
+	body := []byte("hello from one pass")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "usr/share/message",
+		Mode:     0o644,
+		Size:     int64(len(body)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	build := newIndexedBuildState()
+	layerPath := filepath.Join(t.TempDir(), "layers", "test.tar")
+	var finalProgress int64
+	if err := writeAndApplyIndexedLayer(
+		layerPath,
+		"application/vnd.oci.image.layer.v1.tar+gzip",
+		bytes.NewReader(compressed.Bytes()),
+		"layers/test.tar",
+		build.merged,
+		build.fsEntries,
+		func(current int64) { finalProgress = current },
+	); err != nil {
+		t.Fatal(err)
+	}
+	node := build.merged["/usr/share/message"]
+	if node == nil || node.TarPath != "layers/test.tar" || node.Size != uint64(len(body)) {
+		t.Fatalf("indexed node = %+v", node)
+	}
+	file, err := os.Open(layerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	got := make([]byte, len(body))
+	if _, err := file.ReadAt(got, int64(node.TarOffset)); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("indexed contents = %q", got)
+	}
+	if finalProgress != int64(compressed.Len()) {
+		t.Fatalf("progress = %d, want %d", finalProgress, compressed.Len())
+	}
+	if _, err := os.Stat(layerPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temporary layer remains: %v", err)
+	}
+}
 
 func TestAggregateLayerProgressReportsWholeImageBytes(t *testing.T) {
 	var events []client.ProgressEvent
@@ -47,6 +110,100 @@ func TestAggregateLayerProgressReportsWholeImageBytes(t *testing.T) {
 	final := events[len(events)-1]
 	if final.BytesDownloaded != 150 || final.BytesTotal != 200 || final.Progress != 0.75 {
 		t.Fatalf("final aggregate progress = %+v", final)
+	}
+}
+
+func TestPlanPullReportsOnlyUncachedOCILayerBytes(t *testing.T) {
+	const (
+		firstDigest  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		secondDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	)
+	manifestData, err := json.Marshal(manifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.manifest.v1+json",
+		Config: descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Size:      32,
+		},
+		Layers: []descriptor{
+			{MediaType: "application/vnd.oci.image.layer.v1.tar+gzip", Digest: firstDigest, Size: 100},
+			{MediaType: "application/vnd.oci.image.layer.v1.tar+gzip", Digest: secondDigest, Size: 250},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/manifests/edge") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = w.Write(manifestData)
+	}))
+	defer server.Close()
+
+	shared := filepath.Join(t.TempDir(), "shared")
+	t.Setenv(sharedCacheEnv, shared)
+	if err := os.MkdirAll(filepath.Join(shared, "_blobs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shared, "_blobs", digestToFileName(firstDigest)), make([]byte, 100), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(filepath.Join(t.TempDir(), "store"))
+	store.httpClient = server.Client()
+	source := strings.TrimPrefix(server.URL, "https://") + "/team/squad:edge"
+	plan, err := store.PlanPull(t.Context(), "squadvm", source, PullOptions{Architecture: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Available || plan.BytesTotal != 350 || plan.BytesCached != 100 || plan.BytesToDownload != 250 {
+		t.Fatalf("pull plan = %+v", plan)
+	}
+	if plan.LayersTotal != 2 || plan.LayersCached != 1 {
+		t.Fatalf("pull plan layers = %+v", plan)
+	}
+
+	spec, err := ParseSource(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.writeMetadata("squadvm", metadata{
+		Name:           "squadvm",
+		Source:         spec.Raw,
+		SourceKind:     spec.Kind,
+		Architecture:   "amd64",
+		RootFSDir:      store.imageDir("squadvm"),
+		ResolvedSource: "oci:old",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	update, err := store.PlanPull(t.Context(), "squadvm", source, PullOptions{Architecture: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !update.Installed || update.Available || update.BytesToDownload != 250 {
+		t.Fatalf("update plan = %+v", update)
+	}
+
+	sum := sha256.Sum256(manifestData)
+	currentSource := resolvedOCISource(server.URL, "team/squad", "sha256:"+hex.EncodeToString(sum[:]))
+	meta, err := store.readMetadata("squadvm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.ResolvedSource = currentSource
+	if err := store.writeMetadata("squadvm", meta); err != nil {
+		t.Fatal(err)
+	}
+	current, err := store.PlanPull(t.Context(), "squadvm", source, PullOptions{Architecture: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !current.Installed || !current.Available || current.BytesToDownload != 0 {
+		t.Fatalf("current plan = %+v", current)
 	}
 }
 
@@ -173,12 +330,14 @@ func TestStorePullRestoresSIMGFromSharedCache(t *testing.T) {
 	t.Setenv(sharedCacheEnv, shared)
 	source := alpineFixture(t)
 
-	first := NewStore(filepath.Join(t.TempDir(), "first"))
+	firstRoot := filepath.Join(t.TempDir(), "first")
+	first := NewStore(firstRoot)
 	if _, err := first.Pull(context.Background(), "alpine", source, PullOptions{Architecture: "amd64"}); err != nil {
 		t.Fatalf("initial pull: %v", err)
 	}
 
-	second := NewStore(filepath.Join(t.TempDir(), "second"))
+	secondRoot := filepath.Join(t.TempDir(), "second")
+	second := NewStore(secondRoot)
 	state, err := second.Pull(context.Background(), "restored", source, PullOptions{Architecture: "amd64"})
 	if err != nil {
 		t.Fatalf("restore pull: %v", err)
@@ -188,6 +347,39 @@ func TestStorePullRestoresSIMGFromSharedCache(t *testing.T) {
 	}
 	if _, err := second.Open("restored"); err != nil {
 		t.Fatalf("open restored image: %v", err)
+	}
+
+	spec, err := ParseSource(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sharedImage := filepath.Join(shared, sharedImageKey(spec, "amd64"))
+	sharedRootFS, err := os.Stat(filepath.Join(sharedImage, "rootfs.simg"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(firstRoot, "alpine", "rootfs.simg"),
+		filepath.Join(secondRoot, "restored", "rootfs.simg"),
+	} {
+		localRootFS, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !os.SameFile(sharedRootFS, localRootFS) {
+			t.Fatalf("cached image artifact %q occupies a second copy", path)
+		}
+	}
+	sharedMetadata, err := os.Stat(filepath.Join(sharedImage, "image.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	localMetadata, err := os.Stat(filepath.Join(secondRoot, "restored", "image.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(sharedMetadata, localMetadata) {
+		t.Fatal("named image metadata aliases shared-cache metadata")
 	}
 }
 

--- a/internal/virtio/fs_backends.go
+++ b/internal/virtio/fs_backends.go
@@ -2953,6 +2953,20 @@ func (p *imageFS) imageNodeHasHandleLocked(nodeID uint64) bool {
 	return false
 }
 
+func (p *imageFS) imageNodeLinkedLocked(node *imageNode) bool {
+	if node == nil {
+		return false
+	}
+	if node.id == 1 {
+		return true
+	}
+	if !node.isDir() {
+		return node.nlink != 0
+	}
+	parent := p.imageNodeLocked(node.parent)
+	return parent != nil && parent.entries[node.name] == node.id
+}
+
 func (p *imageFS) touchImageDirectoryLocked(node *imageNode, now time.Time) {
 	if node == nil || !node.isDir() {
 		return
@@ -2975,12 +2989,8 @@ func (p *imageFS) collectImageNodeLocked(nodeID uint64) {
 	// Regular-file link counts are maintained when directory entries change.
 	// Most Release calls therefore prove the node is still linked in O(1),
 	// instead of rescanning every directory after every close. Directories are
-	// not hard-linkable and remain on the conservative reference scan.
-	linked := node.nlink != 0
-	if node.isDir() {
-		parent := p.imageNodeLocked(node.parent)
-		linked = parent != nil && parent.entries[node.name] == nodeID
-	}
+	// not hard-linkable and remain on the conservative parent-entry check.
+	linked := p.imageNodeLinkedLocked(node)
 	if !linked && p.persistent != nil {
 		// Once the namespace no longer reaches an inode, a crash cannot retain
 		// its open handles. Record that fact before reclaiming its data.

--- a/internal/virtio/fs_persistent_store.go
+++ b/internal/virtio/fs_persistent_store.go
@@ -1040,14 +1040,37 @@ func (p *imageFS) persistentStateLocked() *persistentImageState {
 	if p.persistent.lastErr != nil {
 		state.LastError = p.persistent.lastErr.Error()
 	}
-	ids := make([]uint64, 0, len(p.persistentNodes))
-	for id := range p.persistentNodes {
+	// Build the checkpoint from the namespace rooted at inode 1. Link counts
+	// and cached parent/name fields can briefly lag an atomic replacement, but
+	// the directory graph is the filesystem contract that survives restart.
+	reachable := make(map[uint64]struct{}, len(p.persistentNodes))
+	queue := []uint64{1}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if _, seen := reachable[id]; seen {
+			continue
+		}
+		node := p.nodes[id]
+		if node == nil {
+			continue
+		}
+		if _, persistent := p.persistentNodes[id]; id != 1 && !persistent {
+			continue
+		}
+		reachable[id] = struct{}{}
+		for _, childID := range node.entries {
+			queue = append(queue, childID)
+		}
+	}
+	ids := make([]uint64, 0, len(reachable))
+	for id := range reachable {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	for _, id := range ids {
 		if node := p.nodes[id]; node != nil {
-			state.Nodes = append(state.Nodes, persistentNodeFromImageNode(node, p.pathForNode(id), p.persistentNodes))
+			state.Nodes = append(state.Nodes, persistentNodeFromImageNode(node, p.pathForNode(id), reachable))
 		}
 	}
 	for id := range p.removedNodes {
@@ -1152,6 +1175,12 @@ func (p *imageFS) restorePersistentState(state *persistentImageState) error {
 	}
 	nodeSeen := make(map[uint64]struct{}, len(state.Nodes))
 	savedByPath := make(map[string]*imageNode, len(state.Nodes)+1)
+	linkedNodes := map[uint64]struct{}{1: {}}
+	for _, saved := range state.Nodes {
+		for _, entry := range saved.Entries {
+			linkedNodes[entry.Inode] = struct{}{}
+		}
+	}
 	for _, saved := range state.Nodes {
 		if saved.ID == 0 || saved.ID == ^uint64(0) {
 			return fmt.Errorf("invalid node ID %d", saved.ID)
@@ -1163,6 +1192,14 @@ func (p *imageFS) restorePersistentState(state *persistentImageState) error {
 		if _, removed := removedSeen[saved.ID]; removed {
 			return fmt.Errorf("node ID %d is both present and removed", saved.ID)
 		}
+		// Older writers could checkpoint an inode kept alive only by an open
+		// handle after it had been unlinked or atomically replaced. Handles
+		// cannot survive restart, so restore only nodes reached by the saved
+		// directory namespace (plus the root).
+		_, linked := linkedNodes[saved.ID]
+		if !linked && len(saved.LowerPath) == 0 {
+			continue
+		}
 		guestPath := string(saved.GuestPath)
 		if guestPath == "" && saved.ID == 1 {
 			guestPath = "/"
@@ -1171,7 +1208,18 @@ func (p *imageFS) restorePersistentState(state *persistentImageState) error {
 			return fmt.Errorf("node %d has invalid guest path %q", saved.ID, guestPath)
 		}
 		if existing := savedByPath[guestPath]; existing != nil && existing.id != saved.ID {
-			return fmt.Errorf("nodes %d and %d both use guest path %q", existing.id, saved.ID, guestPath)
+			switch {
+			case existing.nlink == 0 && saved.NLink != 0:
+				// Older checkpoints could include an open inode after an
+				// atomic replacement. Its handle cannot survive restart, so
+				// retain the linked replacement that owns the guest path.
+				delete(p.nodes, existing.id)
+				delete(p.persistentNodes, existing.id)
+			case saved.NLink == 0 && existing.nlink != 0:
+				continue
+			default:
+				return fmt.Errorf("nodes %d and %d both use guest path %q", existing.id, saved.ID, guestPath)
+			}
 		}
 		node := &imageNode{id: saved.ID}
 		if saved.ID == 1 {
@@ -1257,7 +1305,17 @@ func (p *imageFS) restorePersistentState(state *persistentImageState) error {
 				return fmt.Errorf("node %d has invalid directory entry %q", id, name)
 			}
 			if p.imageNodeLocked(childID) == nil {
-				return fmt.Errorf("node %d directory entry %q references missing inode %d", id, name, childID)
+				// A short-lived writer version could omit an open/replaced
+				// inode while leaving its directory entry in the checkpoint.
+				// The inode data is already absent, so retain the rest of the
+				// filesystem and hide the unrecoverable name.
+				delete(node.entries, name)
+				node.whiteouts[name] = true
+				recoveryErr := fmt.Errorf("discarded dangling directory entry %q from inode %d (missing inode %d)", name, id, childID)
+				p.persistent.lastErr = errors.Join(p.persistent.lastErr, recoveryErr)
+				if p.persistent.recovery.Status == "" {
+					p.persistent.recovery.Status = "recovered-dangling-directory-entry"
+				}
 			}
 		}
 	}

--- a/internal/virtio/fs_persistent_store_test.go
+++ b/internal/virtio/fs_persistent_store_test.go
@@ -555,6 +555,92 @@ func TestPersistentImageFSOpenUnlinkedFileSurvivesUntilRelease(t *testing.T) {
 	}
 }
 
+func TestPersistentImageFSCloseOmitsOpenReplacedFile(t *testing.T) {
+	storeDir := filepath.Join(t.TempDir(), "home")
+	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
+	replacedID, replacedFH, _, errno := backend.Create(1, "state", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+	if errno != 0 {
+		t.Fatalf("create state: errno %d", errno)
+	}
+	if written, errno := backend.Write(replacedID, replacedFH, 0, []byte("old"), 0); errno != 0 || written != 3 {
+		t.Fatalf("write old state = %d, errno %d", written, errno)
+	}
+	replacementID, replacementFH, _, errno := backend.Create(1, "state.tmp", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+	if errno != 0 {
+		t.Fatalf("create replacement: errno %d", errno)
+	}
+	if written, errno := backend.Write(replacementID, replacementFH, 0, []byte("new"), 0); errno != 0 || written != 3 {
+		t.Fatalf("write replacement = %d, errno %d", written, errno)
+	}
+	backend.Release(replacementID, replacementFH)
+	if errno := backend.Rename(1, "state.tmp", 1, "state", 0); errno != 0 {
+		t.Fatalf("replace state: errno %d", errno)
+	}
+	if got := readPersistentHandleTest(t, backend, replacedID, replacedFH, 0, 3); string(got) != "old" {
+		t.Fatalf("open replaced contents = %q", got)
+	}
+	// Deliberately close with the replaced inode still open. A clean checkpoint
+	// must preserve the namespace, not a handle that cannot survive restart.
+	if err := backend.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	backend = openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
+	defer backend.Close()
+	nodeID, _, errno := backend.Lookup(1, "state")
+	if errno != 0 {
+		t.Fatalf("lookup replacement: errno %d", errno)
+	}
+	if got := readPersistentTest(t, backend, nodeID, 0, 3); string(got) != "new" {
+		t.Fatalf("replacement contents = %q", got)
+	}
+}
+
+func TestPersistentImageFSRestoreRepairsDanglingDirectoryEntry(t *testing.T) {
+	storeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(storeDir, "data"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend := newImageFS(imagefs.NewOverlay(nil).Root(), storeDir, 0, 0, false).(*imageFS)
+	backend.persistent = &persistentImageStore{
+		dir:           storeDir,
+		dataUsage:     make(map[uint64]uint64),
+		dataPhysical:  make(map[uint64]uint64),
+		pendingTrim:   make(map[uint64]uint64),
+		pendingRemove: make(map[uint64]struct{}),
+	}
+	backend.persistentNodes = make(map[uint64]struct{})
+	err := backend.restorePersistentState(&persistentImageState{
+		NextNodeID: 3,
+		Nodes: []persistentImageNode{{
+			ID:          1,
+			Parent:      1,
+			Name:        []byte("/"),
+			Kind:        "dir",
+			Mode:        uint32(fs.ModeDir | 0o755),
+			NLink:       1,
+			EntriesDone: true,
+			Entries: []persistentImageDirent{{
+				Name:  []byte("missing"),
+				Inode: 2,
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("restore dangling checkpoint: %v", err)
+	}
+	root := backend.nodes[1]
+	if _, exists := root.entries["missing"]; exists {
+		t.Fatal("dangling directory entry survived recovery")
+	}
+	if !root.whiteouts["missing"] {
+		t.Fatal("recovered name was not hidden from the lower filesystem")
+	}
+	if backend.persistent.recovery.Status != "recovered-dangling-directory-entry" {
+		t.Fatalf("recovery status = %q", backend.persistent.recovery.Status)
+	}
+}
+
 func TestPersistentImageFSTornWALTailIsPreservedAndRemovedFromReplay(t *testing.T) {
 	storeDir := filepath.Join(t.TempDir(), "home")
 	lower := imagefs.NewOverlay(nil).Root()


### PR DESCRIPTION
## Summary

- add non-destructive OCI pull planning with resolved manifest digests and refresh support
- stream the first uncached layer into the filesystem index while remaining layers download in parallel
- expose separate download and indexing progress for desktop frontends
- deduplicate shared OCI cache state and preserve cached image metadata
- repair legacy persistent filesystem checkpoints with dangling directory entries
- build future persistent checkpoints from a consistent reachable namespace

## User impact

Mutable image tags can now offer accurate update sizes, skip or refresh safely, and show honest concurrent progress. Image preparation performs less temporary I/O. Persistent SquadVM homes affected by the missing-inode checkpoint bug recover instead of failing startup.

## Validation

- `go test ./client ./internal/oci ./internal/ccvmd`
- `go test ./internal/virtio`
- `go test -race ./internal/oci ./internal/virtio`
- full `go test ./...` passed all completed packages; `internal/vm` remains the repository's long-running suite