### PR TITLE
Support four vCPUs on Windows

### DIFF
--- a/cmd/tinyboot/main_windows_amd64.go
+++ b/cmd/tinyboot/main_windows_amd64.go
@@ -33,6 +33,7 @@ func run() error {
 	var simgPath string
 	var timeout time.Duration
 	var memoryMB uint64
+	var cpus int
 	var dmesg bool
 	var runCommand string
 	var stdin string
@@ -45,6 +46,7 @@ func run() error {
 	flag.StringVar(&simgPath, "simg", "./fixtures/alpine.simg", "SIMG root filesystem")
 	flag.DurationVar(&timeout, "timeout", 30*time.Second, "boot timeout")
 	flag.Uint64Var(&memoryMB, "memory-mb", 512, "guest memory in MiB")
+	flag.IntVar(&cpus, "cpus", 1, "guest CPUs")
 	flag.BoolVar(&dmesg, "dmesg", false, "enable serial console and dmesg capture")
 	flag.StringVar(&runCommand, "exec", "", "optional command to run after boot, split on spaces")
 	flag.StringVar(&stdin, "stdin", "", "stdin for the optional command")
@@ -61,6 +63,12 @@ func run() error {
 	}
 	if warmup < 0 {
 		return fmt.Errorf("warmup must be non-negative")
+	}
+	if cpus <= 0 {
+		return fmt.Errorf("cpus must be positive")
+	}
+	if restoreSnapshot != "" && cpus > 1 {
+		return fmt.Errorf("WHP startup snapshots currently support only one vCPU")
 	}
 	if cacheDir == "" {
 		dir, err := os.MkdirTemp("", "cc-tinyboot-*")
@@ -165,7 +173,7 @@ func run() error {
 				runCancel()
 				return fmt.Errorf("build initramfs run %d: %w", i, err)
 			}
-			session, err = whp.StartManagedSessionWithNetOptions(runCtx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, whp.ManagedSessionOptions{
+			session, err = whp.StartManagedSessionWithNetOptions(runCtx, kernel, initrd, memoryMB, cpus, dmesg, fsdevs, nil, whp.ManagedSessionOptions{
 				SnapshotDir: snapshotDir,
 			}, onEvent)
 		}

--- a/internal/hv/hvf/container_darwin_arm64.go
+++ b/internal/hv/hvf/container_darwin_arm64.go
@@ -159,6 +159,7 @@ type ContainerRunResult = vmruntime.RunResult
 
 type ContainerSession struct {
 	cancel            context.CancelFunc
+	runCtx            context.Context
 	doneCh            chan sessionRunResult
 	closeDone         <-chan struct{}
 	image             *oci.Image
@@ -631,7 +632,9 @@ func (s *ContainerSession) Exec(ctx context.Context, req client.ExecRequest) (cl
 	}
 	timingLog("session.Exec writeControlPayload took=%s argv=%q id=%s", time.Since(startTime), req.Command, id)
 
-	beginSegment, err := s.transcript.WaitFor(ctx, start, func(text string) bool {
+	waitCtx, cancelWait := s.operationContext(ctx)
+	defer cancelWait()
+	beginSegment, err := s.transcript.WaitFor(waitCtx, start, func(text string) bool {
 		return hasManagedExecBegin(text, id)
 	})
 	if err != nil {
@@ -641,7 +644,7 @@ func (s *ContainerSession) Exec(ctx context.Context, req client.ExecRequest) (cl
 		return client.ExecResponse{}, s.withControlDebug("wait for exec begin", err)
 	}
 	timingLog("session.Exec waitForBegin took=%s argv=%q id=%s segment_bytes=%d", time.Since(startTime), req.Command, id, len(beginSegment))
-	firstByteSegment, err := s.transcript.WaitFor(ctx, start, func(text string) bool {
+	firstByteSegment, err := s.transcript.WaitFor(waitCtx, start, func(text string) bool {
 		return hasManagedExecFirstByte(text, id)
 	})
 	if err != nil {
@@ -651,7 +654,7 @@ func (s *ContainerSession) Exec(ctx context.Context, req client.ExecRequest) (cl
 		return client.ExecResponse{}, s.withControlDebug("wait for exec first byte", err)
 	}
 	timingLog("session.Exec waitForFirstByte took=%s argv=%q id=%s segment_bytes=%d", time.Since(startTime), req.Command, id, len(firstByteSegment))
-	segment, err := s.transcript.WaitForCommand(ctx, start, id, func(text string) bool {
+	segment, err := s.transcript.WaitForCommand(waitCtx, start, id, func(text string) bool {
 		_, _, ok := extractManagedExecResult(text, id, s.dmesg)
 		return ok
 	})
@@ -680,6 +683,18 @@ func (s *ContainerSession) Exec(ctx context.Context, req client.ExecRequest) (cl
 	}
 	timingLog("session.Exec total=%s argv=%q id=%s exit=%d output_bytes=%d", time.Since(startTime), req.Command, id, exitCode, len(output))
 	return client.ExecResponse{ExitCode: exitCode, Output: output}, nil
+}
+
+func (s *ContainerSession) operationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	opCtx, cancel := context.WithCancel(ctx)
+	if s == nil || s.runCtx == nil {
+		return opCtx, cancel
+	}
+	stop := context.AfterFunc(s.runCtx, cancel)
+	return opCtx, func() {
+		stop()
+		cancel()
+	}
 }
 
 func (s *ContainerSession) withControlDebug(op string, err error) error {
@@ -912,8 +927,14 @@ func (s *ContainerSession) streamExecEvents(ctx context.Context, start int, id s
 			}
 		},
 		Wait: func(context.Context) error {
-			time.Sleep(5 * time.Millisecond)
-			return nil
+			select {
+			case <-s.runCtx.Done():
+				return fmt.Errorf("VM exited during exec")
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Millisecond):
+				return nil
+			}
 		},
 	})
 }
@@ -1022,6 +1043,19 @@ func recordCount(recorder *timing.Recorder, name string, count int) {
 }
 
 func (s *ContainerSession) Close() error {
+	if s == nil {
+		return nil
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.closeDone != nil {
+		select {
+		case <-s.closeDone:
+		case <-time.After(15 * time.Second):
+			return fmt.Errorf("container session did not stop within 15s")
+		}
+	}
 	if s.control != nil {
 		_ = s.control.Close()
 	}
@@ -1036,12 +1070,6 @@ func (s *ContainerSession) Close() error {
 	}
 	if s.vsock != nil {
 		_ = s.vsock.Close()
-	}
-	s.cancel()
-	select {
-	case <-s.closeDone:
-	case <-time.After(15 * time.Second):
-		return fmt.Errorf("container session did not stop within 15s")
 	}
 	var closeErr error
 	if s.fsCloseErr != nil {
@@ -1473,6 +1501,7 @@ func startPersistentContainer(ctx context.Context, req ContainerRunRequest, onEv
 			_ = vm.Close()
 			exitTiming.Dump()
 		}()
+		defer cancel()
 		runner := newVMRunManager(vm)
 		for {
 			active := activeExecs.Load() > 0
@@ -1553,7 +1582,7 @@ func startPersistentContainer(ctx context.Context, req ContainerRunRequest, onEv
 					return
 				}
 				if halt {
-					doneCh <- sessionRunResult{err: fmt.Errorf("guest halted while instance was running\nserial:\n%s\nvirtio-fs:\n%s", serialOut.String(), fsTrace.String())}
+					doneCh <- sessionRunResult{}
 					return
 				}
 			default:
@@ -1612,6 +1641,7 @@ func startPersistentContainer(ctx context.Context, req ContainerRunRequest, onEv
 		displayListenersOwned = false
 		return &ContainerSession{
 			cancel:            cancel,
+			runCtx:            runCtx,
 			doneCh:            doneCh,
 			closeDone:         closeDone,
 			image:             req.Image,

--- a/internal/hv/hvf/snapshot_darwin_arm64.go
+++ b/internal/hv/hvf/snapshot_darwin_arm64.go
@@ -280,6 +280,7 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 			_ = vm.Close()
 			exitTiming.Dump()
 		}()
+		defer cancel()
 		runner := newVMRunManager(vm)
 		for {
 			active := activeExecs.Load() > 0
@@ -340,7 +341,7 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 					return
 				}
 				if halt {
-					doneCh <- sessionRunResult{err: fmt.Errorf("guest halted while restored instance was running\n%s\nserial:\n%s\nvirtio-fs:\n%s", vsock.Summary(), serialOut.String(), fsTrace.String())}
+					doneCh <- sessionRunResult{}
 					return
 				}
 			default:
@@ -386,7 +387,7 @@ func StartContainerFromSnapshot(ctx context.Context, req ContainerRunRequest, sn
 			}
 		}
 		session := &ContainerSession{
-			cancel: cancel, closeDone: closeDone, image: req.Image, baseEnv: baseEnv, workDir: workDir,
+			cancel: cancel, runCtx: runCtx, doneCh: doneCh, closeDone: closeDone, image: req.Image, baseEnv: baseEnv, workDir: workDir,
 			dmesg: req.Dmesg, uart: uart, control: res.conn, transcript: controlTranscript, serialOut: serialOut,
 			listener: listener, vsock: vsock, rootFS: rootFS, fsdevs: fsdevs, shares: shareState,
 			balloon:     balloon,

--- a/internal/hv/whp/acpi_windows_amd64.go
+++ b/internal/hv/whp/acpi_windows_amd64.go
@@ -15,12 +15,12 @@ const (
 	whpZeroPageRSDPAddr = 112
 )
 
-func installBootACPI(memory []byte) error {
+func installBootACPI(memory []byte, cpus int) error {
 	if len(memory) < whpACPITableAddress+0x10000 {
 		return fmt.Errorf("guest memory too small for ACPI tables")
 	}
 	writer := acpiTableWriter{base: whpACPITableAddress}
-	madt := writer.append("APIC", 1, "CCWHPAPC", buildBootMADT())
+	madt := writer.append("APIC", 1, "CCWHPAPC", buildBootMADT(cpus))
 	hpet := writer.append("HPET", 1, "CCWHPHPT", buildBootHPET())
 	xsdt := writer.append("XSDT", 1, "CCWHPXSD", buildBootXSDT([]uint64{madt, hpet}))
 	copy(memory[whpACPITableAddress:], writer.data)
@@ -28,8 +28,8 @@ func installBootACPI(memory []byte) error {
 	return nil
 }
 
-func installBootACPIForZeroPage(memory []byte, zeroPageGPA uint64) error {
-	if err := installBootACPI(memory); err != nil {
+func installBootACPIForZeroPage(memory []byte, zeroPageGPA uint64, cpus int) error {
+	if err := installBootACPI(memory, cpus); err != nil {
 		return err
 	}
 	rsdpOff := zeroPageGPA + whpZeroPageRSDPAddr
@@ -78,13 +78,21 @@ func buildBootXSDT(entries []uint64) []byte {
 	return body
 }
 
-func buildBootMADT() []byte {
+func buildBootMADT(cpus int) []byte {
+	if cpus <= 0 {
+		cpus = 1
+	}
+	if cpus > 255 {
+		cpus = 255
+	}
 	var body []byte
 	body = binary.LittleEndian.AppendUint32(body, 0xfee00000)
 	body = binary.LittleEndian.AppendUint32(body, 1)
 
-	body = append(body, 0, 8, 0, 0)
-	body = binary.LittleEndian.AppendUint32(body, 1)
+	for cpu := 0; cpu < cpus; cpu++ {
+		body = append(body, 0, 8, byte(cpu), byte(cpu))
+		body = binary.LittleEndian.AppendUint32(body, 1)
+	}
 
 	body = append(body, 1, 12, 0, 0)
 	body = binary.LittleEndian.AppendUint32(body, ioapicBaseAddress)

--- a/internal/hv/whp/acpi_windows_amd64_test.go
+++ b/internal/hv/whp/acpi_windows_amd64_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBootMADTMarksVirtioIRQsLevelTriggered(t *testing.T) {
-	body := buildBootMADT()
+	body := buildBootMADT(1)
 	overrides := make(map[byte]uint16)
 	for offset := 28; offset+2 <= len(body); {
 		length := int(body[offset+1])

--- a/internal/hv/whp/bindings_windows_amd64.go
+++ b/internal/hv/whp/bindings_windows_amd64.go
@@ -88,11 +88,16 @@ const (
 
 type interruptType uint32
 
-const interruptTypeFixed interruptType = 0
+const (
+	interruptTypeFixed          interruptType = 0
+	interruptTypeLowestPriority interruptType = 1
+)
 
 type interruptDestinationMode uint32
 
 const interruptDestinationPhysical interruptDestinationMode = 0
+
+const interruptDestinationLogical interruptDestinationMode = 1
 
 type interruptTriggerMode uint32
 
@@ -694,10 +699,10 @@ func cancelRunVirtualProcessor(part partitionHandle, vpIndex uint32) error {
 	return callHRESULT(procWHvCancelRunVirtualProcessor, uintptr(part), uintptr(vpIndex), 0)
 }
 
-func requestInterrupt(part partitionHandle, vector uint32, trigger interruptTriggerMode) error {
+func requestInterrupt(part partitionHandle, vector uint32, trigger interruptTriggerMode, typ interruptType, destinationMode interruptDestinationMode, destination uint32) error {
 	control := interruptControl{
-		Control:     uint64(interruptTypeFixed) | uint64(interruptDestinationPhysical)<<8 | uint64(trigger)<<12,
-		Destination: 0,
+		Control:     uint64(typ) | uint64(destinationMode)<<8 | uint64(trigger)<<12,
+		Destination: destination,
 		Vector:      vector,
 	}
 	return callHRESULT(

--- a/internal/hv/whp/boot_windows_amd64.go
+++ b/internal/hv/whp/boot_windows_amd64.go
@@ -40,6 +40,7 @@ const (
 	hpetNumTimers               = 3
 	hpetLegacyReplacementCap    = uint64(1 << 15)
 	hpetCounterSizeCap          = uint64(1 << 13)
+	legacyTimerStartupDelay     = 5 * time.Second
 )
 
 func BootKernelToSerial(ctx context.Context, kernel []byte, memoryMB uint64, dmesg bool) (string, error) {
@@ -71,10 +72,14 @@ func BootInitramfsToMarkerWithFSAndSettle(ctx context.Context, kernel []byte, in
 }
 
 func BootInitramfsToMarkerWithFSAndNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, marker string, fsdevs []*virtio.FS, netdev *virtio.Net) (string, error) {
+	return BootInitramfsToMarkerWithFSAndNetAndCPUs(ctx, kernel, initrd, memoryMB, 1, dmesg, marker, fsdevs, netdev)
+}
+
+func BootInitramfsToMarkerWithFSAndNetAndCPUs(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, marker string, fsdevs []*virtio.FS, netdev *virtio.Net) (string, error) {
 	if strings.TrimSpace(marker) == "" {
 		return "", fmt.Errorf("boot marker is required")
 	}
-	return bootToConditionWithDevices(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, netdev, nil, 0, func(serial string) bool {
+	return bootToConditionWithDevicesAndCPUs(ctx, kernel, initrd, memoryMB, cpus, dmesg, fsdevs, nil, netdev, nil, 0, func(serial string) bool {
 		return strings.Contains(serial, marker)
 	})
 }
@@ -163,7 +168,14 @@ func (b *lockedBuffer) String() string {
 }
 
 func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, nvmeBlock *nvme.Controller, settleAfterDone time.Duration, done func(string) bool) (string, error) {
-	vm, err := newBootVM(amd64vm.MemorySizeBytes(memoryMB))
+	return bootToConditionWithDevicesAndCPUs(ctx, kernel, initrd, memoryMB, 1, dmesg, fsdevs, vsock, netdev, nvmeBlock, settleAfterDone, done)
+}
+
+func bootToConditionWithDevicesAndCPUs(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, nvmeBlock *nvme.Controller, settleAfterDone time.Duration, done func(string) bool) (string, error) {
+	if cpus <= 0 {
+		cpus = 1
+	}
+	vm, err := newBootVM(amd64vm.MemorySizeBytes(memoryMB), cpus)
 	if err != nil {
 		return "", err
 	}
@@ -189,21 +201,22 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 	extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(rng.Base, rng.IRQ))
 	plan, err := amd64vm.PrepareBoot(vm.Memory(), kernel, initrd, amd64vm.BootConfig{
 		MemoryMB:     memoryMB,
+		NumCPUs:      cpus,
 		Dmesg:        dmesg,
 		ExtraCmdline: extraCmdline,
 	})
 	if err != nil {
 		return "", fmt.Errorf("prepare boot: %w", err)
 	}
-	if err := installBootACPIForZeroPage(vm.Memory(), plan.ZeroPageGPA); err != nil {
+	if err := installBootACPIForZeroPage(vm.Memory(), plan.ZeroPageGPA, cpus); err != nil {
 		return "", fmt.Errorf("install acpi: %w", err)
 	}
 	if err := vm.SetLongMode(plan.EntryGPA, plan.ZeroPageGPA, plan.StackTopGPA, plan.PagingBase); err != nil {
 		return "", fmt.Errorf("set long mode: %w", err)
 	}
 
-	var out bytes.Buffer
-	platform := newBootPlatform(vm, serial.NewUART8250(amd64vm.COM1Base, 0, &out))
+	out := vmruntime.NewSerialTranscript()
+	platform := newBootPlatform(vm, serial.NewUART8250(amd64vm.COM1Base, 0, out))
 	defer platform.Close()
 	for _, fsdev := range fsdevs {
 		if fsdev != nil {
@@ -223,6 +236,9 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 	platform.AttachRNG(rng)
 	if err := vm.EnableEmulation(platform); err != nil {
 		return out.String(), fmt.Errorf("enable emulation: %w", err)
+	}
+	if cpus > 1 {
+		return bootToConditionMulti(ctx, vm, platform, out, settleAfterDone, done)
 	}
 
 	doneSeen := false
@@ -295,7 +311,7 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 		case runVPExitReasonX64ApicEoi:
 			platform.HandleEOI(raw.apicEoi().InterruptVector)
 		case runVPExitReasonX64MsrAccess:
-			if err := handleMSRAccess(vm, exit, &raw); err != nil {
+			if err := handleMSRAccess(vm, 0, exit, &raw); err != nil {
 				return out.String(), fmt.Errorf("handle msr at rip=%#x: %w", exit.RIP, err)
 			}
 		case runVPExitReasonX64InterruptWindow:
@@ -307,6 +323,46 @@ func bootToConditionWithDevices(ctx context.Context, kernel []byte, initrd []byt
 			return out.String(), fmt.Errorf("flush pending irq after %s at rip=%#x: %w", exit.Reason, exit.RIP, err)
 		} else if exit.Reason == runVPExitReasonX64Halt && !flushed && !platform.hasPendingIRQ() {
 			return out.String(), fmt.Errorf("guest halted before serial output")
+		}
+	}
+}
+
+func bootToConditionMulti(ctx context.Context, vm *VM, platform *bootPlatform, out *vmruntime.SerialTranscript, settleAfterDone time.Duration, done func(string) bool) (string, error) {
+	runCtx, cancel := context.WithCancel(ctx)
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- runManagedExecVMMulti(runCtx, vm, platform, out)
+	}()
+	stop := func() error {
+		cancel()
+		_ = vm.CancelRun()
+		return <-runErrCh
+	}
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	var settleDeadline time.Time
+	for {
+		text := out.String()
+		if done(text) {
+			if settleAfterDone <= 0 {
+				_ = stop()
+				return text, nil
+			}
+			if settleDeadline.IsZero() {
+				settleDeadline = time.Now().Add(settleAfterDone)
+			} else if time.Now().After(settleDeadline) {
+				_ = stop()
+				return text, nil
+			}
+		}
+		select {
+		case err := <-runErrCh:
+			return out.String(), err
+		case <-ctx.Done():
+			_ = stop()
+			return out.String(), fmt.Errorf("%w (%s)", ctx.Err(), platform.Summary())
+		case <-ticker.C:
 		}
 	}
 }
@@ -760,38 +816,43 @@ func (p *bootPlatform) SetIRQ(irq uint32, level bool) error {
 }
 
 func (p *bootPlatform) raiseTimerIRQ() {
-	if time.Since(p.start) < 500*time.Millisecond {
+	if time.Since(p.start) < legacyTimerStartupDelay {
 		atomic.AddUint64(&p.irqAttempts, 1)
 		atomic.AddUint64(&p.irqSuppressed, 1)
 		return
 	}
+	line := uint8(0)
 	if p.ioapic.enabled(2) {
-		p.raiseIRQ(2)
+		line = 2
+	}
+	if p.hasQueuedIRQ() {
+		p.recordIRQAttempt(line)
+		atomic.AddUint64(&p.irqSuppressed, 1)
 		return
 	}
-	p.raiseIRQ(0)
+	p.raiseIRQ(line)
 }
 
 func (p *bootPlatform) raiseIRQ(line uint8) {
 	p.recordIRQAttempt(line)
 	if p.ioapic.enabled(line) {
-		vector := p.ioapic.vector(line)
-		if vector >= 0x10 {
+		route, routed := p.ioapic.routeForLine(line)
+		if routed && route.vector >= 0x10 {
 			if !p.ioapic.levelTriggered(line) {
-				if err := p.vm.RequestInterrupt(uint32(vector)); err != nil {
+				if err := p.vm.RequestInterrupt(uint32(route.vector)); err != nil {
 					atomic.AddUint64(&p.irqFailed, 1)
 					return
 				}
 				atomic.AddUint64(&p.irqDelivered, 1)
 				return
 			}
-			if !p.ioapic.beginInterrupt(vector) {
+			if !p.ioapic.beginInterrupt(route.vector) {
 				atomic.AddUint64(&p.irqSuppressed, 1)
 				return
 			}
-			if err := p.vm.RequestInterruptWithTrigger(uint32(vector), interruptTriggerLevel); err != nil {
+			if err := p.vm.RequestInterruptWithTrigger(uint32(route.vector), interruptTriggerLevel); err != nil {
 				atomic.AddUint64(&p.irqFailed, 1)
-				p.ioapic.endInterrupt(vector)
+				p.ioapic.endInterrupt(route.vector)
 			} else {
 				atomic.AddUint64(&p.irqDelivered, 1)
 			}
@@ -826,8 +887,7 @@ func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 	if deviceIRQ {
 		p.clearDeferredDeviceIRQ(route.line)
 		p.queuePendingIRQ(route, trigger, true, p.keepUndeliveredDeviceIRQ(route.line))
-		_ = p.vm.kickOutOfHLT()
-		p.vm.kickIfRunning()
+		p.vm.kickVCPUIfRunning(p.pendingRouteVCPU(route))
 		return
 	}
 	if route.level && !p.ioapic.beginInterrupt(route.vector) {
@@ -846,17 +906,26 @@ func (p *bootPlatform) injectIOAPIC(route bootIOAPICRoute, deviceIRQ bool) {
 }
 
 func (p *bootPlatform) armPendingIRQWindow() error {
-	p.resampleDeviceIRQs()
-	p.deliverDeferredDeviceIRQs()
+	return p.armPendingIRQWindowForVCPU(0, true)
+}
+
+func (p *bootPlatform) armPendingIRQWindowForVCPU(index uint32, resample bool) error {
+	if resample {
+		p.resampleDeviceIRQs()
+		p.deliverDeferredDeviceIRQs()
+	}
 	if !p.hasPendingIRQ() {
 		return nil
 	}
-	if delivered, err := p.flushHaltedPendingIRQ(); err != nil {
+	if delivered, err := p.flushHaltedPendingIRQForVCPU(index); err != nil {
 		return err
 	} else if delivered {
 		return nil
 	}
-	return p.vm.NotifyInterruptWindow()
+	if !p.firstPendingIRQTargetsVCPU(index) {
+		return nil
+	}
+	return p.vm.NotifyVCPUInterruptWindow(index)
 }
 
 func (p *bootPlatform) resampleDeviceIRQs() {
@@ -915,8 +984,6 @@ func (p *bootPlatform) deliverPICOutput() bool {
 			vector: vector,
 			level:  p.pic.LevelTriggered(line),
 		}, trigger)
-		_ = p.vm.NotifyInterruptWindow()
-		_ = p.vm.kickOutOfHLT()
 		p.vm.kickIfRunning()
 		return true
 	}
@@ -927,13 +994,22 @@ func (p *bootPlatform) HandleEOI(vector uint32) {
 	if p.pic.EndOfInterrupt(uint8(vector)) {
 		p.deliverPICOutput()
 	}
-	if route, pending := p.ioapic.handleEOI(vector); pending {
-		if p.isDeviceIRQ(route.line) {
-			return
-		}
-		atomic.AddUint64(&p.irqAttempts, 1)
-		p.injectIOAPIC(route, p.isDeviceIRQ(route.line))
+	if p.isDeviceVector(uint8(vector)) {
+		return
 	}
+	if route, pending := p.ioapic.handleEOI(vector); pending {
+		atomic.AddUint64(&p.irqAttempts, 1)
+		p.injectIOAPIC(route, false)
+	}
+}
+
+func (p *bootPlatform) isDeviceVector(vector uint8) bool {
+	for line, device := range p.deviceIRQLine {
+		if device && p.ioapic.vector(uint8(line)) == vector {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *bootPlatform) queuePendingIRQ(route bootIOAPICRoute, trigger interruptTriggerMode, device bool, sticky bool) {
@@ -965,35 +1041,39 @@ func (p *bootPlatform) queuePendingPICIRQ(route bootIOAPICRoute, trigger interru
 	})
 }
 
-func (p *bootPlatform) injectPendingInterruption(vector uint8) (bool, error) {
-	ready, err := p.vm.canSetPendingInterruption(vector)
+func (p *bootPlatform) injectPendingInterruption(index uint32, vector uint8) (bool, error) {
+	ready, err := p.vm.vcpuCanSetPendingInterruption(index, vector)
 	if err != nil || !ready {
 		return false, err
 	}
-	if err := p.vm.SetPendingInterruption(vector); err != nil {
+	if err := p.vm.SetVCPUPendingInterruption(index, vector); err != nil {
 		return false, err
 	}
-	_ = p.vm.kickOutOfHLT()
-	p.vm.kickIfRunning()
+	_ = p.vm.kickVCPUOutOfHLT(index)
+	p.vm.kickVCPUIfRunning(index)
 	atomic.AddUint64(&p.irqDelivered, 1)
 	return true, nil
 }
 
 func (p *bootPlatform) flushHaltedPendingIRQ() (bool, error) {
+	return p.flushHaltedPendingIRQForVCPU(0)
+}
+
+func (p *bootPlatform) flushHaltedPendingIRQForVCPU(index uint32) (bool, error) {
 	p.pendingMu.Lock()
 	if len(p.pendingIRQs) == 0 {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
 	pending := p.pendingIRQs[0]
-	if !pending.pic && !p.usePendingInterruptionFallback(pending.route.line) {
+	if p.pendingVCPU(pending) != index || !pending.pic {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
 	route := pending.route
 	p.pendingMu.Unlock()
 
-	ready, err := p.vm.haltedAndInterruptible(route.vector)
+	ready, err := p.vm.vcpuHaltedAndInterruptible(index, route.vector)
 	if err != nil || !ready {
 		return false, err
 	}
@@ -1004,7 +1084,7 @@ func (p *bootPlatform) flushHaltedPendingIRQ() (bool, error) {
 		return false, nil
 	}
 	pending = p.pendingIRQs[0]
-	if !pending.pic && !p.usePendingInterruptionFallback(pending.route.line) {
+	if p.pendingVCPU(pending) != index || !pending.pic {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
@@ -1013,7 +1093,13 @@ func (p *bootPlatform) flushHaltedPendingIRQ() (bool, error) {
 	p.pendingIRQ[route.vector] = false
 	p.pendingMu.Unlock()
 
-	return p.injectPendingInterruption(route.vector)
+	return p.injectPendingInterruption(index, route.vector)
+}
+
+func (p *bootPlatform) firstPendingIRQTargetsVCPU(index uint32) bool {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	return len(p.pendingIRQs) != 0 && p.pendingVCPU(p.pendingIRQs[0]) == index
 }
 
 func (p *bootPlatform) markDeferredDeviceIRQ(line uint8) {
@@ -1085,21 +1171,39 @@ func (p *bootPlatform) keepUndeliveredDeviceIRQ(line uint8) bool {
 }
 
 func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
+	return p.flushPendingIRQForVCPU(0, ctx)
+}
+
+func (p *bootPlatform) flushPendingIRQForVCPU(index uint32, ctx *runVPExitContext) (bool, error) {
 	p.pendingMu.Lock()
 	if len(p.pendingIRQs) == 0 {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
 	pending := p.pendingIRQs[0]
-	fallback := pending.pic || p.usePendingInterruptionFallback(pending.route.line)
-	if ctx == nil {
+	if p.pendingVCPU(pending) != index {
 		p.pendingMu.Unlock()
 		return false, nil
 	}
-	windowExit := ctx.ExitReason == runVPExitReasonX64InterruptWindow
-	if !windowExit && !canAcceptInterrupt(ctx, pending.route.vector) && !(fallback && canSetPendingInterruption(ctx, pending.route.vector)) {
+	fallback := pending.pic
+	if ctx == nil && fallback {
 		p.pendingMu.Unlock()
 		return false, nil
+	}
+	windowExit := fallback && ctx.ExitReason == runVPExitReasonX64InterruptWindow
+	if fallback && !windowExit {
+		p.pendingMu.Unlock()
+		ready, err := p.vm.vcpuCanSetPendingInterruption(index, pending.route.vector)
+		if err != nil || !ready {
+			return false, err
+		}
+		p.pendingMu.Lock()
+		if len(p.pendingIRQs) == 0 || p.pendingIRQs[0].route.vector != pending.route.vector ||
+			p.pendingVCPU(p.pendingIRQs[0]) != index {
+			p.pendingMu.Unlock()
+			return false, nil
+		}
+		pending = p.pendingIRQs[0]
 	}
 	route := pending.route
 	trigger := pending.trigger
@@ -1125,15 +1229,15 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 		p.pendingIRQs = p.pendingIRQs[:len(p.pendingIRQs)-1]
 		p.pendingIRQ[route.vector] = false
 		p.pendingMu.Unlock()
+		if route.level && !p.ioapic.beginInterrupt(route.vector) {
+			atomic.AddUint64(&p.irqSuppressed, 1)
+			return false, nil
+		}
 		var err error
 		if fallback {
-			err = p.vm.SetPendingInterruption(route.vector)
+			err = p.vm.SetVCPUPendingInterruption(index, route.vector)
 		} else {
-			if route.level && !p.ioapic.beginInterrupt(route.vector) {
-				atomic.AddUint64(&p.irqSuppressed, 1)
-				return false, nil
-			}
-			err = p.vm.RequestInterruptWithTrigger(uint32(route.vector), trigger)
+			err = p.vm.RequestInterruptRoute(uint32(route.vector), trigger, route.interruptType, route.destinationMode, route.destination)
 		}
 		if err != nil {
 			atomic.AddUint64(&p.irqFailed, 1)
@@ -1148,20 +1252,20 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 	p.pendingIRQ[route.vector] = false
 	p.pendingMu.Unlock()
 
-	_ = p.vm.kickOutOfHLT()
+	_ = p.vm.kickVCPUOutOfHLT(index)
+	if route.level && !p.ioapic.beginInterrupt(route.vector) {
+		atomic.AddUint64(&p.irqSuppressed, 1)
+		return false, nil
+	}
 	if fallback {
-		if err := p.vm.SetPendingInterruption(route.vector); err != nil {
+		if err := p.vm.SetVCPUPendingInterruption(index, route.vector); err != nil {
 			atomic.AddUint64(&p.irqFailed, 1)
 			return false, err
 		}
 		atomic.AddUint64(&p.irqDelivered, 1)
 		return true, nil
 	}
-	if route.level && !p.ioapic.beginInterrupt(route.vector) {
-		atomic.AddUint64(&p.irqSuppressed, 1)
-		return false, nil
-	}
-	if err := p.vm.RequestInterruptWithTrigger(uint32(route.vector), trigger); err != nil {
+	if err := p.vm.RequestInterruptRoute(uint32(route.vector), trigger, route.interruptType, route.destinationMode, route.destination); err != nil {
 		atomic.AddUint64(&p.irqFailed, 1)
 		p.ioapic.cancel(route)
 		return false, err
@@ -1170,28 +1274,30 @@ func (p *bootPlatform) flushPendingIRQ(ctx *runVPExitContext) (bool, error) {
 	return true, nil
 }
 
-func (p *bootPlatform) usePendingInterruptionFallback(line uint8) bool {
-	if p.vsock != nil && p.vsock.IRQ == uint32(line) {
-		return true
+func (p *bootPlatform) pendingRouteVCPU(route bootIOAPICRoute) uint32 {
+	if p == nil || p.vm == nil {
+		return 0
 	}
-	for _, fsdev := range p.fsdevs {
-		if fsdev != nil && fsdev.IRQ == uint32(line) {
-			return true
+	switch route.destinationMode {
+	case interruptDestinationPhysical:
+		if route.destination < p.vm.vcpuCount {
+			return route.destination
 		}
-	}
-	for _, device := range p.displayDevices {
-		switch typed := device.(type) {
-		case *virtio.GPU:
-			if typed.IRQ == uint32(line) {
-				return true
-			}
-		case *virtio.Input:
-			if typed.IRQ == uint32(line) {
-				return true
+	case interruptDestinationLogical:
+		for index := uint32(0); index < p.vm.vcpuCount && index < 8; index++ {
+			if route.destination&(1<<index) != 0 {
+				return index
 			}
 		}
 	}
-	return false
+	return 0
+}
+
+func (p *bootPlatform) pendingVCPU(pending pendingIRQ) uint32 {
+	if pending.pic {
+		return 0
+	}
+	return p.pendingRouteVCPU(pending.route)
 }
 
 func (p *bootPlatform) hasPendingIRQ() bool {
@@ -1206,6 +1312,21 @@ func (p *bootPlatform) hasPendingIRQ() bool {
 		}
 	}
 	return false
+}
+
+func (p *bootPlatform) hasQueuedIRQ() bool {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	return len(p.pendingIRQs) != 0
+}
+
+func (p *bootPlatform) queuedIRQVCPU() (uint32, bool) {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	if len(p.pendingIRQs) == 0 {
+		return 0, false
+	}
+	return p.pendingVCPU(p.pendingIRQs[0]), true
 }
 
 func (p *bootPlatform) pendingIRQCount() int {

--- a/internal/hv/whp/bsd_session_windows_amd64.go
+++ b/internal/hv/whp/bsd_session_windows_amd64.go
@@ -229,7 +229,7 @@ func startBSDPCManagedSession(ctx context.Context, cfg bsdPCSessionConfig, onEve
 		_, _ = io.Copy(controlTranscript, conn)
 	}()
 
-	vm, err := newBootVM(amd64vm.MemorySizeBytes(cfg.MemoryMB))
+	vm, err := newBootVM(amd64vm.MemorySizeBytes(cfg.MemoryMB), 1)
 	if err != nil {
 		_ = ln.Close()
 		return nil, err
@@ -475,7 +475,7 @@ func runBSDManagedVM(ctx context.Context, guestName string, vm *VM, platform *bo
 		case runVPExitReasonX64ApicEoi:
 			platform.HandleEOI(raw.apicEoi().InterruptVector)
 		case runVPExitReasonX64MsrAccess:
-			if err := handleMSRAccess(vm, exit, &raw); err != nil {
+			if err := handleMSRAccess(vm, 0, exit, &raw); err != nil {
 				return fmt.Errorf("handle msr at rip=%#x: %w\nserial:\n%s", exit.RIP, err, serialOut.String())
 			}
 		case runVPExitReasonX64InterruptWindow:
@@ -491,17 +491,17 @@ func runBSDManagedVM(ctx context.Context, guestName string, vm *VM, platform *bo
 	}
 }
 
-func handleMSRAccess(vm *VM, exit Exit, raw *runVPExitContext) error {
+func handleMSRAccess(vm *VM, vpIndex uint32, exit Exit, raw *runVPExitContext) error {
 	msr := raw.msrAccess()
 	nextRIP := exit.RIP + uint64(raw.instructionLength())
 	if raw.instructionLength() == 0 {
 		nextRIP = exit.RIP + 2
 	}
 	if msr.AccessInfo.isWrite() {
-		return vm.SetRIP(nextRIP)
+		return vm.SetVCPURIP(vpIndex, nextRIP)
 	}
 	value := readMSR(msr.MSRNumber)
-	return vm.SetRegisters(map[registerName]uint64{
+	return vm.SetVCPURegisters(vpIndex, map[registerName]uint64{
 		registerRax: value & 0xffffffff,
 		registerRdx: value >> 32,
 		registerRip: nextRIP,

--- a/internal/hv/whp/emulator_windows_amd64.go
+++ b/internal/hv/whp/emulator_windows_amd64.go
@@ -78,6 +78,8 @@ type emulatorCallbacks struct {
 type emulatorContext struct {
 	vm       *VM
 	platform platformDevice
+	vpIndex  uint32
+	err      error
 }
 
 type platformDevice interface {
@@ -91,10 +93,17 @@ func (v *VM) EnableEmulation(platform platformDevice) error {
 	if platform == nil {
 		return fmt.Errorf("platform device is required")
 	}
-	if v.emulator != 0 {
+	if len(v.emulators) != 0 {
 		return nil
 	}
-	v.emuContext = &emulatorContext{vm: v, platform: platform}
+	v.emuContexts = make([]*emulatorContext, v.vcpuCount)
+	for index := range v.emuContexts {
+		v.emuContexts[index] = &emulatorContext{
+			vm:       v,
+			platform: platform,
+			vpIndex:  uint32(index),
+		}
+	}
 	v.emuCallbacks = emulatorCallbacks{
 		IOPortCallback:               syscall.NewCallback(emulatorIOCallback),
 		MemoryCallback:               syscall.NewCallback(emulatorMemoryCallback),
@@ -103,27 +112,44 @@ func (v *VM) EnableEmulation(platform platformDevice) error {
 		TranslateGVAPage:             syscall.NewCallback(emulatorTranslateGVACallback),
 	}
 	v.emuCallbacks.Size = uint32(unsafe.Sizeof(v.emuCallbacks))
-	handle, err := createEmulator(&v.emuCallbacks)
-	if err != nil {
-		return err
+	v.emulators = make([]emulatorHandle, v.vcpuCount)
+	for index := range v.emulators {
+		handle, err := createEmulator(&v.emuCallbacks)
+		if err != nil {
+			for _, created := range v.emulators[:index] {
+				_ = destroyEmulator(created)
+			}
+			v.emulators = nil
+			v.emuContexts = nil
+			return err
+		}
+		v.emulators[index] = handle
 	}
-	v.emulator = handle
 	return nil
 }
 
 func (v *VM) emulateIO(exit *runVPExitContext) error {
-	if v.emulator == 0 {
+	return v.emulateVCPUIO(0, exit)
+}
+
+func (v *VM) emulateVCPUIO(vpIndex uint32, exit *runVPExitContext) error {
+	if vpIndex >= uint32(len(v.emulators)) || v.emulators[vpIndex] == 0 {
 		return fmt.Errorf("emulator is not enabled")
 	}
+	if vpIndex >= uint32(len(v.emuContexts)) || v.emuContexts[vpIndex] == nil {
+		return fmt.Errorf("emulator context for virtual processor %d is unavailable", vpIndex)
+	}
+	emu := v.emuContexts[vpIndex]
+	emu.err = nil
 	status := new(emulatorStatus)
 	fmt.Fprintf(io.Discard, "%p", status)
-	if err := tryIOEmulation(v.emulator, unsafe.Pointer(v.emuContext), &exit.VpContext, exit.ioPortAccess(), status); err != nil {
+	err := tryIOEmulation(v.emulators[vpIndex], unsafe.Pointer(emu), &exit.VpContext, exit.ioPortAccess(), status)
+	runtime.KeepAlive(emu)
+	if err != nil {
 		return err
 	}
-	if v.emuErr != nil {
-		err := v.emuErr
-		v.emuErr = nil
-		return err
+	if emu.err != nil {
+		return emu.err
 	}
 	if !status.ok() {
 		return fmt.Errorf("WHvEmulatorTryIoEmulation status=%#x", uint32(*status))
@@ -132,18 +158,27 @@ func (v *VM) emulateIO(exit *runVPExitContext) error {
 }
 
 func (v *VM) emulateMMIO(exit *runVPExitContext) error {
-	if v.emulator == 0 {
+	return v.emulateVCPUMMIO(0, exit)
+}
+
+func (v *VM) emulateVCPUMMIO(vpIndex uint32, exit *runVPExitContext) error {
+	if vpIndex >= uint32(len(v.emulators)) || v.emulators[vpIndex] == 0 {
 		return fmt.Errorf("emulator is not enabled")
 	}
+	if vpIndex >= uint32(len(v.emuContexts)) || v.emuContexts[vpIndex] == nil {
+		return fmt.Errorf("emulator context for virtual processor %d is unavailable", vpIndex)
+	}
+	emu := v.emuContexts[vpIndex]
+	emu.err = nil
 	status := new(emulatorStatus)
 	fmt.Fprintf(io.Discard, "%p", status)
-	if err := tryMMIOEmulation(v.emulator, unsafe.Pointer(v.emuContext), &exit.VpContext, exit.memoryAccess(), status); err != nil {
+	err := tryMMIOEmulation(v.emulators[vpIndex], unsafe.Pointer(emu), &exit.VpContext, exit.memoryAccess(), status)
+	runtime.KeepAlive(emu)
+	if err != nil {
 		return err
 	}
-	if v.emuErr != nil {
-		err := v.emuErr
-		v.emuErr = nil
-		return err
+	if emu.err != nil {
+		return emu.err
 	}
 	if !status.ok() {
 		return fmt.Errorf("WHvEmulatorTryMmioEmulation status=%#x", uint32(*status))
@@ -156,20 +191,20 @@ func emulatorIOCallback(ctx, access uintptr) uintptr {
 	info := (*emulatorIOAccessInfo)(unsafe.Pointer(access))
 	size := int(info.AccessSize)
 	if size <= 0 || size > 4 {
-		emu.vm.emuErr = fmt.Errorf("unsupported IO size %d", size)
+		emu.err = fmt.Errorf("unsupported IO size %d", size)
 		return emulatorCallbackFailure
 	}
 	var data [4]byte
 	if info.Direction == emulatorIOOut {
 		binary.LittleEndian.PutUint32(data[:], info.Data)
 		if err := emu.platform.WriteIO(info.Port, data[:size]); err != nil {
-			emu.vm.emuErr = err
+			emu.err = err
 			return emulatorCallbackFailure
 		}
 		return 0
 	}
 	if err := emu.platform.ReadIO(info.Port, data[:size]); err != nil {
-		emu.vm.emuErr = err
+		emu.err = err
 		return emulatorCallbackFailure
 	}
 	info.Data = binary.LittleEndian.Uint32(data[:])
@@ -181,7 +216,7 @@ func emulatorMemoryCallback(ctx, access uintptr) uintptr {
 	info := (*emulatorMemoryAccessInfo)(unsafe.Pointer(access))
 	size := int(info.AccessSize)
 	if size <= 0 || size > len(info.Data) {
-		emu.vm.emuErr = fmt.Errorf("unsupported MMIO size %d", size)
+		emu.err = fmt.Errorf("unsupported MMIO size %d", size)
 		return emulatorCallbackFailure
 	}
 	if mem, err := emu.vm.SliceIPA(info.GPA, size); err == nil {
@@ -194,13 +229,13 @@ func emulatorMemoryCallback(ctx, access uintptr) uintptr {
 	}
 	if info.Direction == emulatorMemoryRead {
 		if err := emu.platform.ReadMMIO(info.GPA, info.Data[:size]); err != nil {
-			emu.vm.emuErr = err
+			emu.err = err
 			return emulatorCallbackFailure
 		}
 		return 0
 	}
 	if err := emu.platform.WriteMMIO(info.GPA, info.Data[:size]); err != nil {
-		emu.vm.emuErr = err
+		emu.err = err
 		return emulatorCallbackFailure
 	}
 	return 0
@@ -210,8 +245,8 @@ func emulatorGetRegistersCallback(ctx, namesPtr, count, valuesPtr uintptr) uintp
 	emu := (*emulatorContext)(unsafe.Pointer(ctx))
 	names := unsafe.Slice((*registerName)(unsafe.Pointer(namesPtr)), int(count))
 	values := unsafe.Slice((*registerValue)(unsafe.Pointer(valuesPtr)), int(count))
-	if err := getVirtualProcessorRegisters(emu.vm.part, 0, names, values); err != nil {
-		emu.vm.emuErr = err
+	if err := getVirtualProcessorRegisters(emu.vm.part, emu.vpIndex, names, values); err != nil {
+		emu.err = err
 		return emulatorCallbackFailure
 	}
 	return 0
@@ -221,8 +256,8 @@ func emulatorSetRegistersCallback(ctx, namesPtr, count, valuesPtr uintptr) uintp
 	emu := (*emulatorContext)(unsafe.Pointer(ctx))
 	names := unsafe.Slice((*registerName)(unsafe.Pointer(namesPtr)), int(count))
 	values := unsafe.Slice((*registerValue)(unsafe.Pointer(valuesPtr)), int(count))
-	if err := setVirtualProcessorRegisters(emu.vm.part, 0, names, values); err != nil {
-		emu.vm.emuErr = err
+	if err := setVirtualProcessorRegisters(emu.vm.part, emu.vpIndex, names, values); err != nil {
+		emu.err = err
 		return emulatorCallbackFailure
 	}
 	return 0
@@ -233,8 +268,8 @@ func emulatorTranslateGVACallback(ctx, gva, flags, resultPtr, gpaPtr uintptr) ui
 	result := (*translateGVAResultCode)(unsafe.Pointer(resultPtr))
 	gpa := (*guestPhysicalAddress)(unsafe.Pointer(gpaPtr))
 	var full translateGVAResult
-	if err := translateGVA(emu.vm.part, 0, guestVirtualAddress(gva), translateGVAFlags(flags), &full, gpa); err != nil {
-		emu.vm.emuErr = err
+	if err := translateGVA(emu.vm.part, emu.vpIndex, guestVirtualAddress(gva), translateGVAFlags(flags), &full, gpa); err != nil {
+		emu.err = err
 		return emulatorCallbackFailure
 	}
 	*result = full.ResultCode

--- a/internal/hv/whp/exec_windows_amd64.go
+++ b/internal/hv/whp/exec_windows_amd64.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/amd64vm"
@@ -18,11 +20,11 @@ import (
 	"j5.nz/cc/internal/vmruntime"
 )
 
-func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, req client.ExecRequest) (client.ExecResponse, string, error) {
-	return RunManagedExecWithFSAndNet(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, req)
+func RunManagedExecWithFS(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, req client.ExecRequest) (client.ExecResponse, string, error) {
+	return RunManagedExecWithFSAndNet(ctx, kernel, initrd, memoryMB, cpus, dmesg, fsdevs, nil, req)
 }
 
-func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, req client.ExecRequest) (client.ExecResponse, string, error) {
+func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, req client.ExecRequest) (client.ExecResponse, string, error) {
 	if len(req.Command) == 0 {
 		return client.ExecResponse{}, "", fmt.Errorf("exec command is required")
 	}
@@ -50,7 +52,7 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 		_, _ = io.Copy(controlTranscript, conn)
 	}()
 
-	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, nil, "", nil)
+	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, cpus, dmesg, fsdevs, vsock, netdev, nil, "", nil)
 	if err != nil {
 		return client.ExecResponse{}, "", err
 	}
@@ -124,6 +126,9 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 	if vmruntime.HasFatalBootText(controlTranscript.String()) {
 		return client.ExecResponse{Output: serialOut.String()}, serialOut.String(), withTranscripts(fmt.Errorf("guest reported boot failure"))
 	}
+	if err := onlineManagedVCPUs(runCtx, control, controlTranscript, cpus); err != nil {
+		return client.ExecResponse{Output: serialOut.String()}, serialOut.String(), withTranscripts(err)
+	}
 	if err := managedagent.SendExec(control, execID, req); err != nil {
 		return client.ExecResponse{Output: serialOut.String()}, serialOut.String(), withTranscripts(err)
 	}
@@ -151,8 +156,77 @@ func RunManagedExecWithFSAndNet(ctx context.Context, kernel []byte, initrd []byt
 	return client.ExecResponse{ExitCode: code, Output: output, Usage: usage}, serialOut.String(), nil
 }
 
-func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, displayDevices []virtio.MMIODevice, snapshotDir string, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
-	vm, err := newBootVM(amd64vm.MemorySizeBytes(memoryMB))
+func onlineManagedVCPUs(ctx context.Context, control io.Writer, transcript *vmruntime.SerialTranscript, cpus int) error {
+	if cpus <= 1 {
+		return nil
+	}
+	for cpu := 1; cpu < cpus; cpu++ {
+		id := fmt.Sprintf("whp-online-%d", cpu)
+		start := transcript.Len()
+		releaseTranscript := transcript.RetainFrom(start)
+		err := managedagent.SendExec(control, id, client.ExecRequest{
+			Command: []string{
+				"/bin/sh",
+				"-c",
+				fmt.Sprintf("printf '1\\n' > /sys/devices/system/cpu/cpu%d/online", cpu),
+			},
+		})
+		if err != nil {
+			releaseTranscript()
+			return fmt.Errorf("online vCPU %d: %w", cpu, err)
+		}
+		segment, err := transcript.WaitForCommand(ctx, start, id, func(text string) bool {
+			_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, false)
+			return ok
+		})
+		releaseTranscript()
+		if err != nil {
+			return fmt.Errorf("online vCPU %d: %w", cpu, err)
+		}
+		code, output, _, ok := vmruntime.ExtractManagedExecResult(segment, id, false)
+		if !ok {
+			return fmt.Errorf("online vCPU %d: guest did not produce a complete result", cpu)
+		}
+		if code != 0 {
+			return fmt.Errorf("online vCPU %d: guest exited with status %d: %s", cpu, code, strings.TrimSpace(output))
+		}
+	}
+
+	const id = "whp-online-check"
+	start := transcript.Len()
+	releaseTranscript := transcript.RetainFrom(start)
+	defer releaseTranscript()
+	if err := managedagent.SendExec(control, id, client.ExecRequest{
+		Command: []string{"cat", "/sys/devices/system/cpu/online"},
+	}); err != nil {
+		return fmt.Errorf("verify online vCPUs: %w", err)
+	}
+	segment, err := transcript.WaitForCommand(ctx, start, id, func(text string) bool {
+		_, _, _, ok := vmruntime.ExtractManagedExecResult(text, id, false)
+		return ok
+	})
+	if err != nil {
+		return fmt.Errorf("verify online vCPUs: %w", err)
+	}
+	code, output, _, ok := vmruntime.ExtractManagedExecResult(segment, id, false)
+	if !ok {
+		return fmt.Errorf("verify online vCPUs: guest did not produce a complete result")
+	}
+	if code != 0 {
+		return fmt.Errorf("verify online vCPUs: guest exited with status %d: %s", code, strings.TrimSpace(output))
+	}
+	want := fmt.Sprintf("0-%d", cpus-1)
+	if got := strings.TrimSpace(output); got != want {
+		return fmt.Errorf("verify online vCPUs: got %q, want %q", got, want)
+	}
+	return nil
+}
+
+func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, vsock *virtio.Vsock, netdev *virtio.Net, displayDevices []virtio.MMIODevice, snapshotDir string, serialWriter io.Writer) (*VM, *bootPlatform, *vmruntime.SerialTranscript, error) {
+	if cpus <= 0 {
+		cpus = 1
+	}
+	vm, err := newBootVM(amd64vm.MemorySizeBytes(memoryMB), cpus)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -162,6 +236,9 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 		"tsc_early_khz=3000000",
 		"lpj=10000000",
 		"no_timer_check",
+	}
+	if cpus > 1 {
+		extraCmdline = append(extraCmdline, "maxcpus=1")
 	}
 	extraCmdline = append(extraCmdline, amd64vm.VirtioFSCommandLineArgs(fsdevs)...)
 	if vsock != nil {
@@ -181,6 +258,7 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 	extraCmdline = append(extraCmdline, amd64vm.VirtioMMIODeviceArg(rng.Base, rng.IRQ))
 	plan, err := amd64vm.PrepareBoot(vm.Memory(), kernel, initrd, amd64vm.BootConfig{
 		MemoryMB:     memoryMB,
+		NumCPUs:      cpus,
 		Dmesg:        dmesg,
 		ExtraCmdline: extraCmdline,
 	})
@@ -188,7 +266,7 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 		_ = vm.Close()
 		return nil, nil, nil, fmt.Errorf("prepare boot: %w", err)
 	}
-	if err := installBootACPIForZeroPage(vm.Memory(), plan.ZeroPageGPA); err != nil {
+	if err := installBootACPIForZeroPage(vm.Memory(), plan.ZeroPageGPA, cpus); err != nil {
 		_ = vm.Close()
 		return nil, nil, nil, fmt.Errorf("install acpi: %w", err)
 	}
@@ -229,6 +307,12 @@ func prepareManagedVM(kernel []byte, initrd []byte, memoryMB uint64, dmesg bool,
 }
 
 func runManagedExecVM(ctx context.Context, vm *VM, platform *bootPlatform, serialOut *vmruntime.SerialTranscript) error {
+	if vm != nil && vm.vcpuCount > 1 {
+		if platform != nil && platform.snapshot != nil {
+			return fmt.Errorf("WHP startup snapshots currently support only one vCPU")
+		}
+		return runManagedExecVMMulti(ctx, vm, platform, serialOut)
+	}
 	for step := 0; ; step++ {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("%w (%s)", err, platform.Summary())
@@ -269,7 +353,7 @@ func runManagedExecVM(ctx context.Context, vm *VM, platform *bootPlatform, seria
 		case runVPExitReasonX64ApicEoi:
 			platform.HandleEOI(raw.apicEoi().InterruptVector)
 		case runVPExitReasonX64MsrAccess:
-			if err := handleMSRAccess(vm, exit, &raw); err != nil {
+			if err := handleMSRAccess(vm, 0, exit, &raw); err != nil {
 				return fmt.Errorf("handle msr at rip=%#x: %w", exit.RIP, err)
 			}
 		case runVPExitReasonX64InterruptWindow:
@@ -282,5 +366,115 @@ func runManagedExecVM(ctx context.Context, vm *VM, platform *bootPlatform, seria
 		} else if exit.Reason == runVPExitReasonX64Halt && !flushed {
 			return fmt.Errorf("guest halted with pending irq blocked\nserial:\n%s\n%s", serialOut.String(), platform.Summary())
 		}
+	}
+}
+
+func runManagedExecVMMulti(ctx context.Context, vm *VM, platform *bootPlatform, serialOut *vmruntime.SerialTranscript) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, int(vm.vcpuCount))
+	var wg sync.WaitGroup
+	for index := uint32(0); index < vm.vcpuCount; index++ {
+		wg.Add(1)
+		go func(index uint32) {
+			defer wg.Done()
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
+			for step := 0; ; step++ {
+				if runCtx.Err() != nil {
+					return
+				}
+				err := platform.armPendingIRQWindowForVCPU(index, index == 0)
+				if err != nil {
+					reportWHPRunError(errCh, cancel, fmt.Errorf("arm pending irq window for vcpu %d: %w", index, err))
+					return
+				}
+
+				var raw runVPExitContext
+				exit, err := vm.runVCPUWithContext(index, &raw)
+				if err != nil {
+					reportWHPRunError(errCh, cancel, fmt.Errorf("run vcpu %d step %d: %w", index, step, err))
+					return
+				}
+				if exit.Reason == runVPExitReasonCanceled && runCtx.Err() != nil {
+					return
+				}
+				err = handleManagedWHPExit(vm, index, platform, serialOut, exit, &raw)
+				if err == nil {
+					_, err = platform.flushPendingIRQForVCPU(index, &raw)
+					if err != nil {
+						err = fmt.Errorf("flush pending irq after %s at rip=%#x: %w", exit.Reason, exit.RIP, err)
+					}
+				}
+				if err != nil {
+					if errors.Is(err, errGuestPoweroff) {
+						reportWHPRunError(errCh, cancel, nil)
+					} else {
+						reportWHPRunError(errCh, cancel, err)
+					}
+					return
+				}
+				if exit.Reason == runVPExitReasonX64Halt {
+					time.Sleep(100 * time.Microsecond)
+				}
+			}
+		}(index)
+	}
+	defer func() {
+		cancel()
+		_ = vm.CancelRun()
+		wg.Wait()
+	}()
+
+	wakeTicker := time.NewTicker(time.Millisecond)
+	defer wakeTicker.Stop()
+	for {
+		select {
+		case err := <-errCh:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-wakeTicker.C:
+			if index, ok := platform.queuedIRQVCPU(); ok {
+				vm.kickVCPUIfRunning(index)
+			}
+		}
+	}
+}
+
+func handleManagedWHPExit(vm *VM, index uint32, platform *bootPlatform, serialOut *vmruntime.SerialTranscript, exit Exit, raw *runVPExitContext) error {
+	platform.recordExit(exit, raw)
+	switch exit.Reason {
+	case runVPExitReasonX64IoPortAccess:
+		if err := vm.emulateVCPUIO(index, raw); err != nil {
+			io := raw.ioPortAccess()
+			return fmt.Errorf("emulate vcpu %d io at rip=%#x port=%#x: %w", index, exit.RIP, io.Port, err)
+		}
+	case runVPExitReasonMemoryAccess:
+		if err := vm.emulateVCPUMMIO(index, raw); err != nil {
+			mem := raw.memoryAccess()
+			return fmt.Errorf("emulate vcpu %d mmio at rip=%#x gpa=%#x gva=%#x access=%d insn_len=%d insn=% x: %w", index, exit.RIP, uint64(mem.GPA), mem.GVA, mem.AccessInfo.accessType(), mem.InstructionByteCount, mem.InstructionBytes[:mem.InstructionByteCount], err)
+		}
+	case runVPExitReasonX64Halt:
+	case runVPExitReasonX64ApicEoi:
+		platform.HandleEOI(raw.apicEoi().InterruptVector)
+	case runVPExitReasonX64MsrAccess:
+		if err := handleMSRAccess(vm, index, exit, raw); err != nil {
+			return fmt.Errorf("handle vcpu %d msr at rip=%#x: %w", index, exit.RIP, err)
+		}
+	case runVPExitReasonX64InterruptWindow:
+	case runVPExitReasonCanceled:
+	default:
+		return fmt.Errorf("unexpected exit %s on vcpu %d at rip=%#x\nserial:\n%s\n%s", exit.Reason, index, exit.RIP, serialOut.String(), platform.Summary())
+	}
+	return nil
+}
+
+func reportWHPRunError(errCh chan<- error, cancel context.CancelFunc, err error) {
+	cancel()
+	select {
+	case errCh <- err:
+	default:
 	}
 }

--- a/internal/hv/whp/host_windows_amd64.go
+++ b/internal/hv/whp/host_windows_amd64.go
@@ -136,7 +136,7 @@ func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, 
 		DisplayWidth:    machine.DisplayWidth,
 		DisplayHeight:   machine.DisplayHeight,
 	}
-	return StartManagedSessionWithNetOptions(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, opts, onEvent)
+	return StartManagedSessionWithNetOptions(ctx, machine.Kernel, machine.Initrd, machine.Spec.MemoryMB, machine.Spec.CPUs, machine.Spec.Dmesg, machine.FSDevices, machine.NetDevice, opts, onEvent)
 }
 
 func normalizeLinuxManagedMachine(machine LinuxManagedMachine) LinuxManagedMachine {

--- a/internal/hv/whp/platform_amd64_windows.go
+++ b/internal/hv/whp/platform_amd64_windows.go
@@ -624,8 +624,8 @@ func (p *bootPIT) armChannel0Locked() {
 		reload = 0xffff
 	}
 	period := time.Duration(reload) * time.Second / 1193182
-	if period <= 0 {
-		period = time.Millisecond
+	if period < 10*time.Millisecond {
+		period = 10 * time.Millisecond
 	}
 	p.ticker = time.NewTicker(period)
 	ticker := p.ticker
@@ -707,9 +707,12 @@ func (a *bootIOAPIC) RestoreState(state bootIOAPICState) {
 }
 
 type bootIOAPICRoute struct {
-	line   uint8
-	vector uint8
-	level  bool
+	line            uint8
+	vector          uint8
+	level           bool
+	interruptType   interruptType
+	destinationMode interruptDestinationMode
+	destination     uint32
 }
 
 func (a *bootIOAPIC) init() {
@@ -862,9 +865,12 @@ func (a *bootIOAPIC) routeForLineLocked(line uint8) (bootIOAPICRoute, bool) {
 	}
 	level := entry&(1<<15) != 0
 	return bootIOAPICRoute{
-		line:   line,
-		vector: vector,
-		level:  level,
+		line:            line,
+		vector:          vector,
+		level:           level,
+		interruptType:   ioapicInterruptType(entry),
+		destinationMode: ioapicDestinationMode(entry),
+		destination:     uint32(entry >> 56),
 	}, true
 }
 
@@ -957,8 +963,25 @@ func (a *bootIOAPIC) evaluateLocked(line uint8, edge bool) (bootIOAPICRoute, boo
 		return bootIOAPICRoute{}, false
 	}
 	return bootIOAPICRoute{
-		line:   line,
-		vector: vector,
-		level:  level,
+		line:            line,
+		vector:          vector,
+		level:           level,
+		interruptType:   ioapicInterruptType(entry),
+		destinationMode: ioapicDestinationMode(entry),
+		destination:     uint32(entry >> 56),
 	}, true
+}
+
+func ioapicInterruptType(entry uint64) interruptType {
+	if (entry>>8)&0x7 == 1 {
+		return interruptTypeLowestPriority
+	}
+	return interruptTypeFixed
+}
+
+func ioapicDestinationMode(entry uint64) interruptDestinationMode {
+	if entry&(1<<11) != 0 {
+		return interruptDestinationLogical
+	}
+	return interruptDestinationPhysical
 }

--- a/internal/hv/whp/platform_amd64_windows_test.go
+++ b/internal/hv/whp/platform_amd64_windows_test.go
@@ -2,7 +2,11 @@
 
 package whp
 
-import "testing"
+import (
+	"testing"
+
+	"j5.nz/cc/internal/virtio"
+)
 
 func TestBootPICLevelLineResamplesUntilDeasserted(t *testing.T) {
 	var pic bootPIC
@@ -140,5 +144,44 @@ func TestPendingInterruptionWaitsUntilGuestEnablesInterrupts(t *testing.T) {
 	ctx.VpContext.Rflags |= 1 << 9
 	if !canSetPendingInterruption(ctx, 0x3b) {
 		t.Fatal("pending interruption rejected after guest enabled interrupts")
+	}
+}
+
+func TestBootIOAPICRoutePreservesVirtualCPUDestination(t *testing.T) {
+	var ioapic bootIOAPIC
+	ioapic.init()
+	ioapic.redir[5] = 0x51 | 1<<8 | 1<<11 | uint64(0x04)<<56
+
+	route, ok := ioapic.routeForLine(5)
+	if !ok {
+		t.Fatal("routeForLine(5) did not return the configured route")
+	}
+	if route.vector != 0x51 || route.interruptType != interruptTypeLowestPriority {
+		t.Fatalf("route vector/type = %#x/%d, want 0x51/%d", route.vector, route.interruptType, interruptTypeLowestPriority)
+	}
+	if route.destinationMode != interruptDestinationLogical || route.destination != 0x04 {
+		t.Fatalf("route destination = mode %d value %#x, want logical/0x04", route.destinationMode, route.destination)
+	}
+}
+
+func TestVirtioPendingInterruptTargetsRoutedVCPU(t *testing.T) {
+	platform := &bootPlatform{
+		vm:     &VM{vcpuCount: 4},
+		fsdevs: []*virtio.FS{{IRQ: 5}},
+	}
+	route := bootIOAPICRoute{
+		line:            5,
+		vector:          0x51,
+		destinationMode: interruptDestinationPhysical,
+		destination:     3,
+	}
+	if target := platform.pendingRouteVCPU(route); target != 3 {
+		t.Fatalf("pending physical virtio IRQ target = %d, want vCPU 3", target)
+	}
+
+	route.destinationMode = interruptDestinationLogical
+	route.destination = 0x04
+	if target := platform.pendingRouteVCPU(route); target != 2 {
+		t.Fatalf("pending logical virtio IRQ target = %d, want vCPU 2", target)
 	}
 }

--- a/internal/hv/whp/session_windows_amd64.go
+++ b/internal/hv/whp/session_windows_amd64.go
@@ -53,15 +53,21 @@ const (
 	execKillWait       = 2 * time.Second
 )
 
-func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
-	return StartManagedSessionWithNet(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, nil, onEvent)
+func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithNet(ctx, kernel, initrd, memoryMB, cpus, dmesg, fsdevs, nil, onEvent)
 }
 
-func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
-	return StartManagedSessionWithNetOptions(ctx, kernel, initrd, memoryMB, dmesg, fsdevs, netdev, ManagedSessionOptions{}, onEvent)
+func StartManagedSessionWithNet(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	return StartManagedSessionWithNetOptions(ctx, kernel, initrd, memoryMB, cpus, dmesg, fsdevs, netdev, ManagedSessionOptions{}, onEvent)
 }
 
-func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, netdev *virtio.Net, opts ManagedSessionOptions, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
+	if cpus <= 0 {
+		cpus = 1
+	}
+	if cpus > 1 && (strings.TrimSpace(opts.SnapshotDir) != "" || strings.TrimSpace(opts.RestoreSnapshot) != "") {
+		return nil, fmt.Errorf("WHP startup snapshots currently support only one vCPU")
+	}
 	if (strings.TrimSpace(opts.SnapshotDir) != "" || strings.TrimSpace(opts.RestoreSnapshot) != "") &&
 		(opts.DisplayWidth != 0 || opts.DisplayHeight != 0) {
 		return nil, fmt.Errorf("display-enabled VMs do not support startup snapshots")
@@ -104,7 +110,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 		bootWriter = vmruntime.NewBootEventWriter(onEvent)
 		serialWriter = bootWriter
 	}
-	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, dmesg, fsdevs, vsock, netdev, displayDevices, strings.TrimSpace(opts.SnapshotDir), serialWriter)
+	vm, platform, serialOut, err := prepareManagedVM(kernel, initrd, memoryMB, cpus, dmesg, fsdevs, vsock, netdev, displayDevices, strings.TrimSpace(opts.SnapshotDir), serialWriter)
 	if err != nil {
 		closeManagedDisplayListeners(clipboardListener, displayListener)
 		_ = listener.Close()
@@ -189,6 +195,17 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 			_ = bootWriter.Close()
 		}
 		return nil, transcriptError(fmt.Errorf("guest reported boot failure"), serialOut.String(), controlTranscript.String())
+	}
+	if err := onlineManagedVCPUs(ctx, control, controlTranscript, cpus); err != nil {
+		cancel()
+		closeManagedDisplayListeners(clipboardListener, displayListener)
+		_ = control.Close()
+		_ = listener.Close()
+		vsock.Close()
+		if bootWriter != nil {
+			_ = bootWriter.Close()
+		}
+		return nil, transcriptError(err, serialOut.String(), controlTranscript.String())
 	}
 	if err := emitManagedBootStatus(onEvent, "guest ready"); err != nil {
 		cancel()

--- a/internal/hv/whp/smp_windows_amd64_test.go
+++ b/internal/hv/whp/smp_windows_amd64_test.go
@@ -1,0 +1,121 @@
+//go:build windows && amd64
+
+package whp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"j5.nz/cc/internal/kernel/alpine"
+	"j5.nz/cc/internal/linux/initramfs"
+)
+
+func TestLinuxBootsWithMultipleWHPVCPUs(t *testing.T) {
+	if os.Getenv("CC_TEST_WINDOWS_WHP_SMP") == "" {
+		t.Skip("set CC_TEST_WINDOWS_WHP_SMP=1 to run the Windows WHP SMP boot test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cacheRoot := filepath.Join(t.TempDir(), "kernel")
+	if existing := strings.TrimSpace(os.Getenv("CC_TEST_KERNEL_CACHE")); existing != "" {
+		cacheRoot = existing
+	}
+	kernelManager := alpine.NewManager(cacheRoot)
+	if err := kernelManager.EnsureWithProgress(ctx, nil); err != nil {
+		t.Fatalf("prepare Alpine Linux kernel: %v", err)
+	}
+	kernel, err := kernelManager.ReadKernel()
+	if err != nil {
+		t.Fatalf("read kernel: %v", err)
+	}
+	initrd := buildWHPSMPInitramfs(t)
+
+	const (
+		cpus   = 4
+		marker = "WHP_SMP_CPUS=0-3"
+	)
+	serial, err := BootInitramfsToMarkerWithFSAndNetAndCPUs(ctx, kernel, initrd, 512, cpus, true, marker, nil, nil)
+	if err != nil {
+		t.Fatalf("boot %d-vCPU VM: %v\nserial:\n%s", cpus, err, serial)
+	}
+	if line := findSMPSerialLine(serial); line != marker {
+		t.Fatalf("online CPU marker = %q, want %q", line, marker)
+	}
+}
+
+func findSMPSerialLine(serial string) string {
+	for _, line := range strings.Split(serial, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "WHP_SMP_CPUS=") {
+			return line
+		}
+	}
+	return ""
+}
+
+func buildWHPSMPInitramfs(t *testing.T) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "init.go")
+	if err := os.WriteFile(src, []byte(whpSMPInitSource), 0o644); err != nil {
+		t.Fatalf("write SMP init source: %v", err)
+	}
+	initPath := filepath.Join(dir, "init")
+	cmd := exec.Command("go", "build", "-trimpath", "-ldflags=-s -w", "-o", initPath, src)
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build SMP init: %v\n%s", err, output)
+	}
+	initBin, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read SMP init: %v", err)
+	}
+	initrd, err := initramfs.Build([]initramfs.File{
+		{Path: "/dev", Mode: 0o755, Type: initramfs.TypeDirectory},
+		{Path: "/dev/console", Mode: 0o600, Type: initramfs.TypeCharDevice, DevMajor: 5, DevMinor: 1},
+		{Path: "/dev/null", Mode: 0o666, Type: initramfs.TypeCharDevice, DevMajor: 1, DevMinor: 3},
+		{Path: "/sys", Mode: 0o755, Type: initramfs.TypeDirectory},
+		{Path: "/init", Mode: 0o755, Data: initBin, Type: initramfs.TypeRegular},
+	})
+	if err != nil {
+		t.Fatalf("build SMP initramfs: %v", err)
+	}
+	return initrd
+}
+
+const whpSMPInitSource = `package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+func main() {
+	if err := syscall.Mount("sysfs", "/sys", "sysfs", 0, ""); err != nil {
+		fmt.Printf("WHP_SMP_ERROR=mount-sysfs:%v\n", err)
+		for {
+			_ = syscall.Pause()
+		}
+	}
+	online, err := os.ReadFile("/sys/devices/system/cpu/online")
+	if err != nil {
+		fmt.Printf("WHP_SMP_ERROR=read-online:%v\n", err)
+		for {
+			_ = syscall.Pause()
+		}
+	}
+	fmt.Printf("WHP_SMP_CPUS=%s\n", strings.TrimSpace(string(online)))
+	for {
+		_ = syscall.Pause()
+	}
+}
+`

--- a/internal/hv/whp/snapshot_windows_amd64.go
+++ b/internal/hv/whp/snapshot_windows_amd64.go
@@ -347,7 +347,7 @@ func restoreManagedVMFromSnapshot(manifest whpSnapshotManifest, memPath string, 
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("map snapshot memory: %w", err)
 	}
-	vm, err := newVMWithAllocation(memorySize, true, true, mem)
+	vm, err := newVMWithAllocation(memorySize, true, true, 1, mem)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/hv/whp/vm_windows_amd64.go
+++ b/internal/hv/whp/vm_windows_amd64.go
@@ -17,12 +17,11 @@ type VM struct {
 	mem          *allocation
 	memSize      uint64
 	memRegions   []guestMemoryRegion
-	vcpuCreated  bool
-	emulator     emulatorHandle
+	vcpuCount    uint32
+	emulators    []emulatorHandle
 	emuCallbacks emulatorCallbacks
-	emuContext   *emulatorContext
-	emuErr       error
-	running      atomic.Bool
+	emuContexts  []*emulatorContext
+	running      []atomic.Bool
 }
 
 type guestMemoryRegion struct {
@@ -67,17 +66,27 @@ func NewVM(memorySize uint64) (*VM, error) {
 	return newVM(memorySize, false)
 }
 
-func newBootVM(memorySize uint64) (*VM, error) {
-	return newVMWithAllocation(memorySize, true, true, nil)
+func NewVMWithCPUs(memorySize uint64, cpus int) (*VM, error) {
+	return newVMWithAllocation(memorySize, false, false, cpus, nil)
+}
+
+func newBootVM(memorySize uint64, cpus int) (*VM, error) {
+	return newVMWithAllocation(memorySize, true, true, cpus, nil)
 }
 
 func newVM(memorySize uint64, localAPIC bool) (*VM, error) {
-	return newVMWithAllocation(memorySize, localAPIC, false, nil)
+	return newVMWithAllocation(memorySize, localAPIC, false, 1, nil)
 }
 
-func newVMWithAllocation(memorySize uint64, localAPIC bool, splitAMD64Memory bool, mem *allocation) (*VM, error) {
+func newVMWithAllocation(memorySize uint64, localAPIC bool, splitAMD64Memory bool, cpus int, mem *allocation) (*VM, error) {
 	if memorySize == 0 {
 		return nil, fmt.Errorf("memory size must be non-zero")
+	}
+	if cpus <= 0 {
+		cpus = 1
+	}
+	if cpus > 255 {
+		return nil, fmt.Errorf("processor count %d exceeds the amd64 guest limit of 255", cpus)
 	}
 	cleanupMem := func() {
 		if mem != nil {
@@ -90,8 +99,8 @@ func newVMWithAllocation(memorySize uint64, localAPIC bool, splitAMD64Memory boo
 		cleanupMem()
 		return nil, fmt.Errorf("create partition: %w", err)
 	}
-	vm := &VM{part: part}
-	if err := setPartitionProperty(part, partitionPropertyCodeProcessorCount, uint32(1)); err != nil {
+	vm := &VM{part: part, running: make([]atomic.Bool, cpus)}
+	if err := setPartitionProperty(part, partitionPropertyCodeProcessorCount, uint32(cpus)); err != nil {
 		cleanupMem()
 		_ = vm.Close()
 		return nil, fmt.Errorf("set processor count: %w", err)
@@ -139,11 +148,24 @@ func newVMWithAllocation(memorySize uint64, localAPIC bool, splitAMD64Memory boo
 		}
 		vm.memRegions = append(vm.memRegions, region)
 	}
-	if err := createVirtualProcessor(part, 0); err != nil {
-		_ = vm.Close()
-		return nil, fmt.Errorf("create virtual processor: %w", err)
+	for index := 0; index < cpus; index++ {
+		if err := createVirtualProcessor(part, uint32(index)); err != nil {
+			_ = vm.Close()
+			return nil, fmt.Errorf("create virtual processor %d: %w", index, err)
+		}
+		vm.vcpuCount++
 	}
-	vm.vcpuCreated = true
+	if localAPIC {
+		const startupSuspend = uint64(1)
+		for index := uint32(1); index < vm.vcpuCount; index++ {
+			if err := vm.SetVCPURegisters(index, map[registerName]uint64{
+				registerInternalActivityState: startupSuspend,
+			}); err != nil {
+				_ = vm.Close()
+				return nil, fmt.Errorf("put virtual processor %d in startup suspend: %w", index, err)
+			}
+		}
+	}
 	return vm, nil
 }
 
@@ -168,18 +190,26 @@ func (v *VM) Close() error {
 		return nil
 	}
 	var first error
-	if v.emulator != 0 {
-		if err := destroyEmulator(v.emulator); err != nil && first == nil {
-			first = err
+	for _, emulator := range v.emulators {
+		if emulator != 0 {
+			if err := destroyEmulator(emulator); err != nil && first == nil {
+				first = err
+			}
 		}
-		v.emulator = 0
 	}
-	if v.part != 0 && v.vcpuCreated {
-		_ = cancelRunVirtualProcessor(v.part, 0)
-		if err := deleteVirtualProcessor(v.part, 0); err != nil && first == nil {
-			first = err
+	v.emulators = nil
+	v.emuContexts = nil
+	if v.part != 0 {
+		for index := uint32(0); index < v.vcpuCount; index++ {
+			_ = cancelRunVirtualProcessor(v.part, index)
 		}
-		v.vcpuCreated = false
+		for index := v.vcpuCount; index > 0; index-- {
+			if err := deleteVirtualProcessor(v.part, index-1); err != nil && first == nil {
+				first = err
+			}
+		}
+		v.vcpuCount = 0
+		v.running = nil
 	}
 	if v.part != 0 {
 		for _, region := range v.memRegions {
@@ -525,12 +555,22 @@ func (v *VM) setupFreeBSDPageTables(pagingBase uint64, giB int) error {
 
 func (v *VM) Run() (Exit, error) {
 	var ctx runVPExitContext
-	return v.runWithContext(&ctx)
+	return v.runVCPUWithContext(0, &ctx)
 }
 
 func (v *VM) runWithContext(ctx *runVPExitContext) (Exit, error) {
-	if err := runVirtualProcessor(v.part, 0, ctx); err != nil {
-		return Exit{}, fmt.Errorf("run virtual processor: %w", err)
+	return v.runVCPUWithContext(0, ctx)
+}
+
+func (v *VM) runVCPUWithContext(index uint32, ctx *runVPExitContext) (Exit, error) {
+	if v == nil || index >= v.vcpuCount {
+		return Exit{}, fmt.Errorf("virtual processor %d out of range", index)
+	}
+	v.running[index].Store(true)
+	err := runVirtualProcessor(v.part, index, ctx)
+	v.running[index].Store(false)
+	if err != nil {
+		return Exit{}, fmt.Errorf("run virtual processor %d: %w", index, err)
 	}
 	return Exit{Reason: ctx.ExitReason, RIP: ctx.VpContext.Rip, RFLAGS: ctx.VpContext.Rflags}, nil
 }
@@ -544,9 +584,7 @@ func (v *VM) runWithCancel(ctx context.Context, raw *runVPExitContext) (Exit, er
 		case <-done:
 		}
 	}()
-	v.running.Store(true)
 	exit, err := v.runWithContext(raw)
-	v.running.Store(false)
 	close(done)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -570,19 +608,27 @@ func (v *VM) GetRIP() (uint64, error) {
 }
 
 func (v *VM) SetRIP(rip uint64) error {
+	return v.SetVCPURIP(0, rip)
+}
+
+func (v *VM) SetVCPURIP(index uint32, rip uint64) error {
 	names := []registerName{registerRip}
 	values := []registerValue{uint64RegisterValue(rip)}
-	return setVirtualProcessorRegisters(v.part, 0, names, values)
+	return setVirtualProcessorRegisters(v.part, index, names, values)
 }
 
 func (v *VM) SetRegisters(values map[registerName]uint64) error {
+	return v.SetVCPURegisters(0, values)
+}
+
+func (v *VM) SetVCPURegisters(index uint32, values map[registerName]uint64) error {
 	names := make([]registerName, 0, len(values))
 	regs := make([]registerValue, 0, len(values))
 	for name, value := range values {
 		names = append(names, name)
 		regs = append(regs, uint64RegisterValue(value))
 	}
-	return setVirtualProcessorRegisters(v.part, 0, names, regs)
+	return setVirtualProcessorRegisters(v.part, index, names, regs)
 }
 
 func (v *VM) RequestInterrupt(vector uint32) error {
@@ -590,20 +636,32 @@ func (v *VM) RequestInterrupt(vector uint32) error {
 }
 
 func (v *VM) RequestInterruptWithTrigger(vector uint32, trigger interruptTriggerMode) error {
-	return requestInterrupt(v.part, vector, trigger)
+	return requestInterrupt(v.part, vector, trigger, interruptTypeFixed, interruptDestinationPhysical, 0)
+}
+
+func (v *VM) RequestInterruptRoute(vector uint32, trigger interruptTriggerMode, typ interruptType, destinationMode interruptDestinationMode, destination uint32) error {
+	return requestInterrupt(v.part, vector, trigger, typ, destinationMode, destination)
 }
 
 func (v *VM) NotifyInterruptWindow() error {
+	return v.NotifyVCPUInterruptWindow(0)
+}
+
+func (v *VM) NotifyVCPUInterruptWindow(index uint32) error {
 	if v == nil || v.part == 0 {
 		return nil
 	}
 	const value = uint64(1 << 1)
 	names := []registerName{registerDeliverabilityNotifications}
 	values := []registerValue{uint64RegisterValue(value)}
-	return setVirtualProcessorRegisters(v.part, 0, names, values)
+	return setVirtualProcessorRegisters(v.part, index, names, values)
 }
 
 func (v *VM) SetPendingInterruption(vector uint8) error {
+	return v.SetVCPUPendingInterruption(0, vector)
+}
+
+func (v *VM) SetVCPUPendingInterruption(index uint32, vector uint8) error {
 	if v == nil || v.part == 0 {
 		return nil
 	}
@@ -611,10 +669,14 @@ func (v *VM) SetPendingInterruption(vector uint8) error {
 	value := interruptionPending | uint64(vector)<<16
 	names := []registerName{registerPendingInterruption}
 	values := []registerValue{uint64RegisterValue(value)}
-	return setVirtualProcessorRegisters(v.part, 0, names, values)
+	return setVirtualProcessorRegisters(v.part, index, names, values)
 }
 
 func (v *VM) canSetPendingInterruption(vector uint8) (bool, error) {
+	return v.vcpuCanSetPendingInterruption(0, vector)
+}
+
+func (v *VM) vcpuCanSetPendingInterruption(index uint32, vector uint8) (bool, error) {
 	if v == nil || v.part == 0 {
 		return false, nil
 	}
@@ -623,7 +685,7 @@ func (v *VM) canSetPendingInterruption(vector uint8) (bool, error) {
 		registerCr8,
 	}
 	values := make([]registerValue, len(names))
-	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+	if err := getVirtualProcessorRegisters(v.part, index, names, values); err != nil {
 		return false, err
 	}
 	if values[0].uint64() != 0 {
@@ -634,6 +696,10 @@ func (v *VM) canSetPendingInterruption(vector uint8) (bool, error) {
 }
 
 func (v *VM) haltedAndInterruptible(vector uint8) (bool, error) {
+	return v.vcpuHaltedAndInterruptible(0, vector)
+}
+
+func (v *VM) vcpuHaltedAndInterruptible(index uint32, vector uint8) (bool, error) {
 	if v == nil || v.part == 0 {
 		return false, nil
 	}
@@ -643,7 +709,7 @@ func (v *VM) haltedAndInterruptible(vector uint8) (bool, error) {
 		registerInternalActivityState,
 	}
 	values := make([]registerValue, len(names))
-	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+	if err := getVirtualProcessorRegisters(v.part, index, names, values); err != nil {
 		return false, err
 	}
 	const (
@@ -664,12 +730,16 @@ func (v *VM) haltedAndInterruptible(vector uint8) (bool, error) {
 }
 
 func (v *VM) kickOutOfHLT() error {
+	return v.kickVCPUOutOfHLT(0)
+}
+
+func (v *VM) kickVCPUOutOfHLT(index uint32) error {
 	if v == nil || v.part == 0 {
 		return nil
 	}
 	names := []registerName{registerInternalActivityState}
 	values := make([]registerValue, 1)
-	if err := getVirtualProcessorRegisters(v.part, 0, names, values); err != nil {
+	if err := getVirtualProcessorRegisters(v.part, index, names, values); err != nil {
 		return err
 	}
 	const haltSuspend = uint64(1 << 1)
@@ -678,14 +748,31 @@ func (v *VM) kickOutOfHLT() error {
 		return nil
 	}
 	values[0] = uint64RegisterValue(raw &^ haltSuspend)
-	return setVirtualProcessorRegisters(v.part, 0, names, values)
+	return setVirtualProcessorRegisters(v.part, index, names, values)
 }
 
 func (v *VM) kickIfRunning() {
-	if v == nil || !v.running.Load() {
+	v.kickVCPUIfRunning(0)
+}
+
+func (v *VM) kickVCPUIfRunning(index uint32) {
+	if v == nil || index >= uint32(len(v.running)) || !v.running[index].Load() {
 		return
 	}
-	_ = cancelRunVirtualProcessor(v.part, 0)
+	_ = cancelRunVirtualProcessor(v.part, index)
+}
+
+func (v *VM) CancelRun() error {
+	if v == nil || v.part == 0 {
+		return nil
+	}
+	var first error
+	for index := uint32(0); index < v.vcpuCount; index++ {
+		if err := cancelRunVirtualProcessor(v.part, index); err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
 }
 
 func segmentAttributes(typ, s, dpl, present, avl, long, db, gran uint16) uint16 {

--- a/internal/hv/whp/vm_windows_amd64_test.go
+++ b/internal/hv/whp/vm_windows_amd64_test.go
@@ -3,6 +3,7 @@
 package whp
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"j5.nz/cc/internal/amd64vm"
@@ -29,6 +30,28 @@ func TestAMD64GuestMemoryRegionsLeaveDeviceHole(t *testing.T) {
 	for i := range want {
 		if regions[i] != want[i] {
 			t.Errorf("region %d = %#v, want %#v", i, regions[i], want[i])
+		}
+	}
+}
+
+func TestBootMADTEnumeratesEveryVirtualCPU(t *testing.T) {
+	const cpus = 4
+	madt := buildBootMADT(cpus)
+	const madtHeaderSize = 8
+	const localAPICEntrySize = 8
+	if len(madt) < madtHeaderSize+cpus*localAPICEntrySize {
+		t.Fatalf("MADT length = %d, want at least %d", len(madt), madtHeaderSize+cpus*localAPICEntrySize)
+	}
+	for cpu := 0; cpu < cpus; cpu++ {
+		entry := madt[madtHeaderSize+cpu*localAPICEntrySize:]
+		if entry[0] != 0 || entry[1] != localAPICEntrySize {
+			t.Fatalf("CPU %d MADT entry header = {%d, %d}, want {0, %d}", cpu, entry[0], entry[1], localAPICEntrySize)
+		}
+		if entry[2] != byte(cpu) || entry[3] != byte(cpu) {
+			t.Fatalf("CPU %d MADT identity = UID %d APIC %d", cpu, entry[2], entry[3])
+		}
+		if flags := binary.LittleEndian.Uint32(entry[4:8]); flags != 1 {
+			t.Fatalf("CPU %d MADT flags = %#x, want enabled", cpu, flags)
 		}
 	}
 }

--- a/internal/virtio/vsock.go
+++ b/internal/virtio/vsock.go
@@ -971,6 +971,8 @@ func (c *simpleVsockConn) Read(b []byte) (int, error) {
 		return n, nil
 	case <-c.closed:
 		return 0, io.EOF
+	case <-c.peer.closed:
+		return 0, io.EOF
 	}
 }
 

--- a/internal/virtio/vsock_credit_test.go
+++ b/internal/virtio/vsock_credit_test.go
@@ -1,9 +1,45 @@
 package virtio
 
 import (
+	"io"
 	"testing"
 	"time"
 )
+
+func TestSimpleVsockPeerCloseUnblocksRead(t *testing.T) {
+	backend := NewSimpleVsockBackend()
+	listener, err := backend.Listen(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	clientConn, err := backend.Connect(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+	serverConn, err := listener.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := clientConn.Read(make([]byte, 1))
+		readDone <- err
+	}()
+	if err := serverConn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-readDone:
+		if err != io.EOF {
+			t.Fatalf("read after peer close = %v, want EOF", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("peer close did not unblock read")
+	}
+}
 
 func TestVsockBackendDeliveryWaitsForPeerCredit(t *testing.T) {
 	backend := NewSimpleVsockBackend()

--- a/internal/vm/backend_windows_amd64.go
+++ b/internal/vm/backend_windows_amd64.go
@@ -60,9 +60,6 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	if b == nil || b.images == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
-	if req.CPUs > 1 {
-		return nil, fmt.Errorf("windows amd64 runtime currently supports only 1 CPU")
-	}
 	restoreSnapshot := strings.TrimSpace(req.RestoreSnapshot)
 	image, err := b.images.Open(req.Image)
 	if err != nil {
@@ -199,9 +196,6 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	if b == nil {
 		return nil, fmt.Errorf("runtime backend is not configured")
 	}
-	if req.CPUs > 1 {
-		return nil, fmt.Errorf("windows amd64 runtime currently supports only 1 CPU")
-	}
 	if strings.TrimSpace(req.Image) != "" {
 		return b.StartStream(ctx, client.CreateInstanceRequest{
 			ID:              req.ID,
@@ -210,6 +204,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Kernel:          req.Kernel,
 			Shares:          append([]client.ShareMount(nil), req.Shares...),
 			Network:         req.Network,
+			Display:         req.Display,
 			KernelModules:   append([]string(nil), req.KernelModules...),
 			MemoryMB:        req.MemoryMB,
 			BalloonMB:       req.BalloonMB,
@@ -334,9 +329,6 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 	if b == nil || b.kernel == nil {
 		return client.ExecResponse{}, fmt.Errorf("runtime backend is not configured")
 	}
-	if req.CPUs > 1 {
-		return client.ExecResponse{}, fmt.Errorf("windows amd64 runtime currently supports only 1 CPU")
-	}
 	kernel, err := b.kernel.ReadKernel()
 	if err != nil {
 		return client.ExecResponse{}, err
@@ -429,7 +421,7 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 			Cols:      req.Cols,
 			Rows:      req.Rows,
 		}
-		resp, serial, err := whp.RunManagedExecWithFSAndNet(ctx, kernel, initrd, req.MemoryMB, req.Dmesg, fsdevs, windowsNetworkDevice(network), execReq)
+		resp, serial, err := whp.RunManagedExecWithFSAndNet(ctx, kernel, initrd, req.MemoryMB, req.CPUs, req.Dmesg, fsdevs, windowsNetworkDevice(network), execReq)
 		if err != nil && resp.Output == "" {
 			resp.Output = serial
 		}
@@ -438,9 +430,9 @@ func (b *runtimeBackend) Run(ctx context.Context, req client.RunRequest) (client
 
 	var output string
 	if len(fsdevs) != 0 || network != nil {
-		output, err = whp.BootInitramfsToMarkerWithFSAndNet(ctx, kernel, initrd, req.MemoryMB, true, windowsInitReadyMarker, fsdevs, windowsNetworkDevice(network))
+		output, err = whp.BootInitramfsToMarkerWithFSAndNetAndCPUs(ctx, kernel, initrd, req.MemoryMB, req.CPUs, true, windowsInitReadyMarker, fsdevs, windowsNetworkDevice(network))
 	} else {
-		output, err = whp.BootInitramfsToMarker(ctx, kernel, initrd, req.MemoryMB, true, windowsInitReadyMarker)
+		output, err = whp.BootInitramfsToMarkerWithFSAndNetAndCPUs(ctx, kernel, initrd, req.MemoryMB, req.CPUs, true, windowsInitReadyMarker, nil, nil)
 	}
 	if err != nil {
 		return client.ExecResponse{Output: output}, err

--- a/internal/vm/capabilities_windows_amd64_test.go
+++ b/internal/vm/capabilities_windows_amd64_test.go
@@ -1,0 +1,22 @@
+//go:build windows && amd64
+
+package vm
+
+import (
+	"slices"
+	"testing"
+
+	"j5.nz/cc/client"
+)
+
+func TestWindowsAMD64HostAdvertisesGraphicalDisplaySupport(t *testing.T) {
+	if !HostCapabilities().SupportsDisplay {
+		t.Fatal("Windows/amd64 host does not advertise graphical display support")
+	}
+	vars := windowsRuntimeConfigVars(&client.DisplayConfig{Width: 1440, Height: 900})
+	for _, required := range []string{"CONFIG_DRM_VIRTIO_GPU", "CONFIG_VIRTIO_INPUT", "CONFIG_INPUT_EVDEV"} {
+		if !slices.Contains(vars, required) {
+			t.Fatalf("display kernel requirements omit %s", required)
+		}
+	}
+}

--- a/internal/vm/runtime_boot_test.go
+++ b/internal/vm/runtime_boot_test.go
@@ -388,6 +388,7 @@ func TestRuntimeCancelsInteractiveShellWithBlockedForegroundCommand(t *testing.T
 	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{
 		ID: "cancel-interactive-shell", Image: env.imageName, MemoryMB: env.memoryMB, CPUs: 1,
 	})
+	defer inst.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	inputs := make(chan client.ExecInput, 1)
 	inputs <- client.ExecInput{Kind: "stdin", Data: []byte("trap '' TERM INT\nprintf 'ready\\n'\nsleep 60\n")}
@@ -452,6 +453,7 @@ func TestRuntimeArchiveControlsInitializeUserHomeAndPreserveHardLinks(t *testing
 	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{
 		ID: "archive-user-home", Image: env.imageName, MemoryMB: env.memoryMB, CPUs: 1,
 	})
+	defer inst.Close()
 	rootFirst := execInRuntimeRequest(t, inst, client.ExecRequest{
 		Command: []string{"/bin/true"},
 		WorkDir: "/home/cc",
@@ -1374,7 +1376,11 @@ func TestRuntimePersistentLinuxTTYStreamsControlFD(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), runtimeBootTimeout())
 	defer cancel()
 	const instanceID = "tty-control"
-	guestWorkDir := "/host" + t.TempDir()
+	hostWorkDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize TTY workdir: %v", err)
+	}
+	guestWorkDir := "/host" + hostWorkDir
 	share := client.ShareMount{
 		Source:   "/",
 		Mount:    "/host",
@@ -1424,7 +1430,7 @@ __vmsh_run() {
 }
 __vmsh_report ready 0
 while IFS= read -r __vmsh_line; do eval "$__vmsh_line"; done`
-	err := manager.RunStreamIn(ctx, instanceID, client.RunRequest{
+	err = manager.RunStreamIn(ctx, instanceID, client.RunRequest{
 		Image:   env.imageName,
 		Command: []string{"sh", "-lc", persistentCommand},
 		Env: []string{
@@ -1675,6 +1681,7 @@ func TestRuntimePersistentCancelAndCloseDuringLongRunningExec(t *testing.T) {
 func TestRuntimeGuestPoweroffTerminatesSessionAndActiveCommand(t *testing.T) {
 	env := newRuntimeBootEnv(t)
 	inst := startRuntimeInstance(t, env, client.CreateInstanceRequest{})
+	defer inst.Close()
 	execDone := make(chan error, 1)
 	go func() {
 		_, err := inst.Exec(context.Background(), client.ExecRequest{Command: []string{"poweroff", "-f"}, User: "root"})

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -228,9 +228,11 @@ func HostCapabilities() client.CapabilitiesResponse {
 		(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
 		caps.SupportsDisplay = true
 	}
-	if runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64") {
+	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
 		caps.MaxInstances = 1
 		caps.Notes = append(caps.Notes, "Windows WHP currently supports one vCPU per instance")
+	} else if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
+		caps.MaxInstances = 1
 	}
 	if supported, err := hv.NestedVirtualizationSupported(); err == nil && supported {
 		caps.SupportsNestedVirt = true
@@ -251,6 +253,8 @@ func resourceLimitsForHost(goos, goarch string) []string {
 	case goos == "linux" && goarch == "amd64":
 		limits = append(limits, "cpus")
 	case goos == "darwin" && goarch == "arm64":
+		limits = append(limits, "cpus")
+	case goos == "windows" && goarch == "amd64":
 		limits = append(limits, "cpus")
 	}
 	return limits


### PR DESCRIPTION
## Summary

- create and run the requested number of Windows Hypervisor Platform virtual processors
- describe every processor through ACPI and preserve IOAPIC destination routing
- stage managed Linux startup on CPU 0, then online and verify the remaining CPUs before reporting the guest ready
- make WHP device interrupts and per-vCPU emulation safe under concurrent execution
- report configurable CPU capacity on Windows/amd64 while keeping Windows/arm64 limited to one CPU
- reject startup snapshots with multiple vCPUs until snapshot state can represent every processor

## Why

The Windows/amd64 backend previously created only virtual processor 0 regardless of the requested CPU count. Simply running additional processors exposed a host-specific WHP local-APIC timer failure and unsafe shared interrupt/emulator state, which could leave Linux in soft lockups during SMP startup.

Managed guests now boot control services on CPU 0 and online the remaining processors sequentially after the control channel is ready. Device interrupts use WHP APIC routing, and each processor has its own emulator context and run loop.

## Impact

Windows/amd64 VMs can request and use multiple vCPUs. SquadVM can boot with four online CPUs and sustain concurrent guest workloads.

## Validation

- `go test ./internal/hv/whp` on Windows
- `go test ./... -run NONE` on Windows
- `CC_TEST_WINDOWS_WHP_SMP=1 go test ./internal/hv/whp -run TestLinuxBootsWithMultipleWHPVCPUs -count=1 -v`
- live SquadVM boot reporting CPUs `0-3` online
- four concurrent guest hashing workloads completed successfully