### PR TITLE
Stream OCI indexing and add high-resolution scrolling

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -29,3 +29,10 @@ type Session interface {
 	SetClipboard(text string)
 	GuestClipboard() (text string, generation uint64)
 }
+
+// HighResolutionScroller is implemented by display sessions that accept
+// horizontal and vertical wheel movement in v120 units, where 120 is one
+// conventional wheel detent.
+type HighResolutionScroller interface {
+	Scroll(deltaX120, deltaY120 int32) error
+}

--- a/internal/oci/fsindexbinary.go
+++ b/internal/oci/fsindexbinary.go
@@ -1,0 +1,198 @@
+package oci
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sort"
+)
+
+const fsIndexMagic = "CCFSIDX1"
+
+func encodeBinaryFSIndex(nodes []indexedNode) ([]byte, error) {
+	var out bytes.Buffer
+	writer := bufio.NewWriterSize(&out, 64<<10)
+	if _, err := writer.WriteString(fsIndexMagic); err != nil {
+		return nil, err
+	}
+	if err := writeLayerUvarint(writer, uint64(len(nodes))); err != nil {
+		return nil, err
+	}
+	for _, node := range nodes {
+		if err := writeBinaryIndexedNode(writer, node); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func encodeBinaryFSIndexMap(nodes map[string]*indexedNode) ([]byte, error) {
+	paths := make([]string, 0, len(nodes))
+	for path := range nodes {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	var out bytes.Buffer
+	writer := bufio.NewWriterSize(&out, 64<<10)
+	if _, err := writer.WriteString(fsIndexMagic); err != nil {
+		return nil, err
+	}
+	if err := writeLayerUvarint(writer, uint64(len(paths))); err != nil {
+		return nil, err
+	}
+	for _, path := range paths {
+		node := nodes[path]
+		if node == nil {
+			return nil, fmt.Errorf("filesystem index node %q is nil", path)
+		}
+		if err := writeBinaryIndexedNode(writer, *node); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func writeBinaryIndexedNode(w io.Writer, node indexedNode) error {
+	if err := writeLayerString(w, node.Path); err != nil {
+		return err
+	}
+	var kind byte
+	switch node.Kind {
+	case indexedKindDir:
+		kind = layerKindDirectory
+	case indexedKindFile:
+		kind = layerKindFile
+	case indexedKindSymlink:
+		kind = layerKindSymlink
+	default:
+		return fmt.Errorf("unsupported indexed kind %q", node.Kind)
+	}
+	if _, err := w.Write([]byte{kind}); err != nil {
+		return err
+	}
+	for _, value := range []uint64{
+		uint64(node.Mode),
+		uint64(node.UID),
+		uint64(node.GID),
+		uint64(node.RDev),
+		node.Size,
+		node.TarOffset,
+		node.PackedOffset,
+	} {
+		if err := writeLayerUvarint(w, value); err != nil {
+			return err
+		}
+	}
+	if err := writeLayerVarint(w, node.ModTimeNS); err != nil {
+		return err
+	}
+	for _, value := range []string{node.LinkTarget, node.TarPath, node.CVMFSTarget} {
+		if err := writeLayerString(w, value); err != nil {
+			return err
+		}
+	}
+	packed := byte(0)
+	if node.Packed {
+		packed = 1
+	}
+	_, err := w.Write([]byte{packed})
+	return err
+}
+
+func decodeBinaryFSIndex(data []byte) ([]indexedNode, error) {
+	reader := bufio.NewReaderSize(bytes.NewReader(data[len(fsIndexMagic):]), 64<<10)
+	count, err := binary.ReadUvarint(reader)
+	if err != nil {
+		return nil, err
+	}
+	// Each node requires at least a path length and kind byte. This bound also
+	// prevents a corrupt index from requesting an unreasonable allocation.
+	if count > uint64(len(data)) || count > uint64(^uint(0)>>1) {
+		return nil, fmt.Errorf("invalid filesystem index node count %d", count)
+	}
+	nodes := make([]indexedNode, 0, int(count))
+	for range count {
+		node, err := readBinaryIndexedNode(reader)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, node)
+	}
+	if _, err := reader.ReadByte(); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("filesystem index has trailing data")
+		}
+		return nil, err
+	}
+	return nodes, nil
+}
+
+func readBinaryIndexedNode(r *bufio.Reader) (indexedNode, error) {
+	var node indexedNode
+	var err error
+	node.Path, err = readLayerString(r)
+	if err != nil {
+		return indexedNode{}, err
+	}
+	kind, err := r.ReadByte()
+	if err != nil {
+		return indexedNode{}, err
+	}
+	switch kind {
+	case layerKindDirectory:
+		node.Kind = indexedKindDir
+	case layerKindFile:
+		node.Kind = indexedKindFile
+	case layerKindSymlink:
+		node.Kind = indexedKindSymlink
+	default:
+		return indexedNode{}, fmt.Errorf("unknown filesystem index kind %d", kind)
+	}
+	values := make([]uint64, 7)
+	for i := range values {
+		values[i], err = binary.ReadUvarint(r)
+		if err != nil {
+			return indexedNode{}, err
+		}
+	}
+	node.Mode = uint32(values[0])
+	node.UID = uint32(values[1])
+	node.GID = uint32(values[2])
+	node.RDev = uint32(values[3])
+	node.Size = values[4]
+	node.TarOffset = values[5]
+	node.PackedOffset = values[6]
+	node.ModTimeNS, err = binary.ReadVarint(r)
+	if err != nil {
+		return indexedNode{}, err
+	}
+	node.LinkTarget, err = readLayerString(r)
+	if err != nil {
+		return indexedNode{}, err
+	}
+	node.TarPath, err = readLayerString(r)
+	if err != nil {
+		return indexedNode{}, err
+	}
+	node.CVMFSTarget, err = readLayerString(r)
+	if err != nil {
+		return indexedNode{}, err
+	}
+	packed, err := r.ReadByte()
+	if err != nil {
+		return indexedNode{}, err
+	}
+	if packed > 1 {
+		return indexedNode{}, fmt.Errorf("invalid packed flag %d", packed)
+	}
+	node.Packed = packed == 1
+	return node, nil
+}

--- a/internal/oci/indexedfs.go
+++ b/internal/oci/indexedfs.go
@@ -52,12 +52,7 @@ type indexedNode struct {
 }
 
 func encodeFSIndex(nodes map[string]*indexedNode) ([]byte, error) {
-	out := make([]indexedNode, 0, len(nodes))
-	for _, node := range nodes {
-		out = append(out, *node)
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
-	return json.MarshalIndent(out, "", "  ")
+	return encodeBinaryFSIndexMap(nodes)
 }
 
 func encodeIndexedNodes(nodes []indexedNode) ([]byte, error) {
@@ -67,6 +62,9 @@ func encodeIndexedNodes(nodes []indexedNode) ([]byte, error) {
 }
 
 func decodeFSIndex(data []byte) ([]indexedNode, error) {
+	if len(data) >= len(fsIndexMagic) && string(data[:len(fsIndexMagic)]) == fsIndexMagic {
+		return decodeBinaryFSIndex(data)
+	}
 	var out []indexedNode
 	if err := json.Unmarshal(data, &out); err != nil {
 		return nil, err
@@ -789,7 +787,9 @@ func applyIndexedLayerReader(
 		if node.Kind == indexedKindSymlink {
 			meta.LinkTarget = node.LinkTarget
 		}
-		entries[node.Path] = meta
+		if entries != nil {
+			entries[node.Path] = meta
+		}
 	}
 }
 
@@ -814,10 +814,12 @@ func ensureIndexedParents(merged map[string]*indexedNode, entries map[string]fsm
 				GID:  0,
 				RDev: 0,
 			}
-			entries[parent] = fsmeta.Entry{
-				UID:  0,
-				GID:  0,
-				Mode: fsmeta.LinuxModeFromFileMode(fs.ModeDir | 0o755),
+			if entries != nil {
+				entries[parent] = fsmeta.Entry{
+					UID:  0,
+					GID:  0,
+					Mode: fsmeta.LinuxModeFromFileMode(fs.ModeDir | 0o755),
+				}
 			}
 			parent = path.Dir(parent)
 		}
@@ -835,7 +837,9 @@ func removeMergedPath(merged map[string]*indexedNode, entries map[string]fsmeta.
 	for key := range merged {
 		if key == target || strings.HasPrefix(key, target+"/") {
 			delete(merged, key)
-			delete(entries, key)
+			if entries != nil {
+				delete(entries, key)
+			}
 		}
 	}
 }

--- a/internal/oci/layerarchive.go
+++ b/internal/oci/layerarchive.go
@@ -1,0 +1,560 @@
+package oci
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	"j5.nz/cc/internal/download"
+	"j5.nz/cc/internal/fsmeta"
+)
+
+const (
+	layerArchiveMagic   = "CCLAYER1"
+	layerArchiveDirName = "_layers_v1"
+	layerIndexName      = "layer.index"
+	layerContentsName   = "layer.contents"
+
+	layerRecordAdd      = 1
+	layerRecordDelete   = 2
+	layerRecordOpaque   = 3
+	layerRecordHardlink = 4
+
+	layerKindDirectory = 1
+	layerKindFile      = 2
+	layerKindSymlink   = 3
+
+	maxLayerIndexString = 16 << 20
+)
+
+type layerRecord struct {
+	op             byte
+	node           indexedNode
+	hardlinkTarget string
+}
+
+func (s *Store) layerArchivePaths(digest string) (indexPath, contentsPath string) {
+	dir := filepath.Join(s.root, layerArchiveDirName, digestToFileName(digest))
+	return filepath.Join(dir, layerIndexName), filepath.Join(dir, layerContentsName)
+}
+
+func (s *Store) cachedLayerArchiveAvailable(layer descriptor) bool {
+	indexPath, contentsPath := s.layerArchivePaths(layer.Digest)
+	index, err := os.Open(indexPath)
+	if err != nil {
+		return false
+	}
+	defer index.Close()
+	magic := make([]byte, len(layerArchiveMagic))
+	if _, err := io.ReadFull(index, magic); err != nil || string(magic) != layerArchiveMagic {
+		return false
+	}
+	info, err := os.Stat(contentsPath)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func (s *Store) writeLayerArchiveAtomic(
+	layer descriptor,
+	body io.Reader,
+	progress func(int64),
+) (string, string, error) {
+	indexPath, contentsPath := s.layerArchivePaths(layer.Digest)
+	if s.cachedLayerArchiveAvailable(layer) {
+		return indexPath, contentsPath, nil
+	}
+	parent := filepath.Dir(filepath.Dir(indexPath))
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", "", err
+	}
+	tmpDir, err := os.MkdirTemp(parent, ".layer-")
+	if err != nil {
+		return "", "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpIndex := filepath.Join(tmpDir, layerIndexName)
+	tmpContents := filepath.Join(tmpDir, layerContentsName)
+	if err := writeLayerArchive(tmpIndex, tmpContents, layer.MediaType, body, progress); err != nil {
+		return "", "", err
+	}
+	finalDir := filepath.Dir(indexPath)
+	if err := os.Rename(tmpDir, finalDir); err != nil {
+		if !s.cachedLayerArchiveAvailable(layer) {
+			return "", "", err
+		}
+	}
+	return indexPath, contentsPath, nil
+}
+
+func (s *Store) prepareLayerArchiveFromBlob(layer descriptor, progress func(int64)) error {
+	if s.cachedLayerArchiveAvailable(layer) {
+		if progress != nil {
+			progress(layer.Size)
+		}
+		return nil
+	}
+	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
+	file, err := os.Open(blobPath)
+	if err != nil {
+		return err
+	}
+	_, _, writeErr := s.writeLayerArchiveAtomic(layer, file, progress)
+	closeErr := file.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	_ = os.Remove(blobPath)
+	return nil
+}
+
+func writeLayerArchive(indexPath, contentsPath, mediaType string, body io.Reader, progress func(int64)) error {
+	index, err := os.OpenFile(indexPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer index.Close()
+	contents, err := os.OpenFile(contentsPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer contents.Close()
+
+	indexWriter := bufio.NewWriterSize(index, 64<<10)
+	if _, err := indexWriter.WriteString(layerArchiveMagic); err != nil {
+		return err
+	}
+
+	tracked := &countingReader{r: body}
+	if progress != nil {
+		tracked.report = func(current, _ int64) {
+			progress(current)
+		}
+	}
+	buffered := bufio.NewReader(tracked)
+	var src io.Reader = buffered
+	var gzr *gzip.Reader
+	var zstdr *zstd.Decoder
+	gzipLayer := strings.Contains(mediaType, "gzip")
+	zstdLayer := strings.Contains(mediaType, "zstd")
+	if !gzipLayer && !zstdLayer {
+		if magic, peekErr := buffered.Peek(4); peekErr == nil {
+			gzipLayer = magic[0] == 0x1f && magic[1] == 0x8b
+			zstdLayer = magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd
+		}
+	}
+	switch {
+	case gzipLayer:
+		gzr, err = gzip.NewReader(src)
+		if err != nil {
+			return fmt.Errorf("open gzip layer: %w", err)
+		}
+		defer gzr.Close()
+		src = gzr
+	case zstdLayer:
+		zstdr, err = zstd.NewReader(src)
+		if err != nil {
+			return fmt.Errorf("open zstd layer: %w", err)
+		}
+		defer zstdr.Close()
+		src = zstdr
+	}
+
+	maxBytes, err := download.FilesystemBudget(contentsPath)
+	if err != nil {
+		return fmt.Errorf("determine layer contents budget: %w", err)
+	}
+	budgetedContents, err := download.NewLimitWriter(sparseFileWriter{file: contents}, maxBytes)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(src)
+	var contentsOffset uint64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read layer tar: %w", err)
+		}
+		if path.Clean(strings.TrimPrefix(hdr.Name, "/")) == "." {
+			continue
+		}
+		name, err := sanitizeArchivePath(hdr.Name)
+		if err != nil {
+			return err
+		}
+		base := path.Base(name)
+		dir := path.Dir(name)
+		if base == ".wh..wh..opq" {
+			if err := writeLayerRecord(indexWriter, layerRecord{
+				op:   layerRecordOpaque,
+				node: indexedNode{Path: fsmeta.Normalize(dir)},
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(base, ".wh.") {
+			if err := writeLayerRecord(indexWriter, layerRecord{
+				op: layerRecordDelete,
+				node: indexedNode{
+					Path: fsmeta.Normalize(path.Join(dir, strings.TrimPrefix(base, ".wh."))),
+				},
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		node := indexedNode{
+			Path:      fsmeta.Normalize(name),
+			UID:       uint32(hdr.Uid),
+			GID:       uint32(hdr.Gid),
+			Mode:      fsmeta.LinuxModeFromTarHeader(hdr),
+			Size:      uint64(hdr.Size),
+			ModTimeNS: hdr.ModTime.UnixNano(),
+			TarOffset: contentsOffset,
+			RDev:      uint32(hdr.Devmajor<<8 | hdr.Devminor),
+		}
+		record := layerRecord{op: layerRecordAdd, node: node}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			record.node.Kind = indexedKindDir
+			record.node.Size = 0
+			record.node.TarOffset = 0
+		case tar.TypeReg, tar.TypeRegA:
+			record.node.Kind = indexedKindFile
+			if _, err := io.CopyN(budgetedContents, tr, hdr.Size); err != nil {
+				return fmt.Errorf("write contents for %q: %w", name, err)
+			}
+			contentsOffset += uint64(hdr.Size)
+		case tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
+			record.node.Kind = indexedKindFile
+			record.node.Size = 0
+			record.node.TarOffset = 0
+		case tar.TypeSymlink:
+			record.node.Kind = indexedKindSymlink
+			record.node.LinkTarget = fsmeta.NormalizeSymlinkTarget(hdr.Linkname)
+			record.node.Size = uint64(len(hdr.Linkname))
+			record.node.TarOffset = 0
+		case tar.TypeLink:
+			target, err := sanitizeArchivePath(hdr.Linkname)
+			if err != nil {
+				return err
+			}
+			record.op = layerRecordHardlink
+			record.node.Kind = indexedKindFile
+			record.node.Size = 0
+			record.node.TarOffset = 0
+			record.hardlinkTarget = fsmeta.Normalize(target)
+		case tar.TypeXGlobalHeader:
+			continue
+		default:
+			return fmt.Errorf("unsupported layer entry type %d for %s", hdr.Typeflag, name)
+		}
+		if err := writeLayerRecord(indexWriter, record); err != nil {
+			return err
+		}
+	}
+	// archive/tar stops at the end marker. Drain the decompressor to validate
+	// the compressed stream checksum and account for all downloaded bytes.
+	if _, err := io.Copy(io.Discard, src); err != nil {
+		return err
+	}
+	if err := contents.Truncate(int64(contentsOffset)); err != nil {
+		return err
+	}
+	if err := indexWriter.Flush(); err != nil {
+		return err
+	}
+	if err := index.Sync(); err != nil {
+		return err
+	}
+	if err := contents.Sync(); err != nil {
+		return err
+	}
+	if progress != nil {
+		progress(int64(tracked.n))
+	}
+	return nil
+}
+
+type sparseFileWriter struct {
+	file *os.File
+}
+
+func (w sparseFileWriter) Write(p []byte) (int, error) {
+	allZero := true
+	for _, value := range p {
+		if value != 0 {
+			allZero = false
+			break
+		}
+	}
+	if !allZero {
+		return w.file.Write(p)
+	}
+	if _, err := w.file.Seek(int64(len(p)), io.SeekCurrent); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func writeLayerRecord(w io.Writer, record layerRecord) error {
+	if _, err := w.Write([]byte{record.op}); err != nil {
+		return err
+	}
+	if err := writeLayerString(w, record.node.Path); err != nil {
+		return err
+	}
+	if record.op == layerRecordDelete || record.op == layerRecordOpaque {
+		return nil
+	}
+	var kind byte
+	switch record.node.Kind {
+	case indexedKindDir:
+		kind = layerKindDirectory
+	case indexedKindFile:
+		kind = layerKindFile
+	case indexedKindSymlink:
+		kind = layerKindSymlink
+	default:
+		return fmt.Errorf("unsupported indexed kind %q", record.node.Kind)
+	}
+	if _, err := w.Write([]byte{kind}); err != nil {
+		return err
+	}
+	for _, value := range []uint64{
+		uint64(record.node.Mode),
+		uint64(record.node.UID),
+		uint64(record.node.GID),
+		uint64(record.node.RDev),
+		record.node.Size,
+		record.node.TarOffset,
+	} {
+		if err := writeLayerUvarint(w, value); err != nil {
+			return err
+		}
+	}
+	if err := writeLayerVarint(w, record.node.ModTimeNS); err != nil {
+		return err
+	}
+	if err := writeLayerString(w, record.node.LinkTarget); err != nil {
+		return err
+	}
+	if record.op == layerRecordHardlink {
+		return writeLayerString(w, record.hardlinkTarget)
+	}
+	return nil
+}
+
+func applyLayerArchive(
+	indexPath, contentsRef string,
+	merged map[string]*indexedNode,
+	entries map[string]fsmeta.Entry,
+) error {
+	file, err := os.Open(indexPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	reader := bufio.NewReaderSize(file, 64<<10)
+	magic := make([]byte, len(layerArchiveMagic))
+	if _, err := io.ReadFull(reader, magic); err != nil {
+		return err
+	}
+	if string(magic) != layerArchiveMagic {
+		return fmt.Errorf("unsupported layer index format")
+	}
+	layerEntries := make(map[string]*indexedNode)
+	for {
+		record, err := readLayerRecord(reader)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read layer index: %w", err)
+		}
+		switch record.op {
+		case layerRecordDelete:
+			removeMergedPath(merged, entries, record.node.Path)
+			continue
+		case layerRecordOpaque:
+			for key := range merged {
+				if key != record.node.Path &&
+					strings.HasPrefix(key, record.node.Path+"/") &&
+					layerEntries[key] == nil {
+					delete(merged, key)
+					if entries != nil {
+						delete(entries, key)
+					}
+				}
+			}
+			continue
+		case layerRecordHardlink:
+			target := layerEntries[record.hardlinkTarget]
+			if target == nil {
+				target = merged[record.hardlinkTarget]
+			}
+			if target == nil || target.Kind != indexedKindFile {
+				return fmt.Errorf("hardlink target %q for %q not found", record.hardlinkTarget, record.node.Path)
+			}
+			record.node.Size = target.Size
+			record.node.TarPath = target.TarPath
+			record.node.TarOffset = target.TarOffset
+		case layerRecordAdd:
+			if record.node.Kind == indexedKindFile && record.node.Size != 0 {
+				record.node.TarPath = contentsRef
+			}
+		default:
+			return fmt.Errorf("unknown layer operation %d", record.op)
+		}
+		node := record.node
+		// Descendants can only remain when this path previously represented a
+		// directory. Avoid scanning the complete merged namespace for ordinary
+		// file updates; large images contain hundreds of thousands of them.
+		existing := merged[node.Path]
+		if node.Kind != indexedKindDir && existing != nil && existing.Kind == indexedKindDir {
+			for key := range merged {
+				if strings.HasPrefix(key, node.Path+"/") {
+					delete(merged, key)
+					delete(layerEntries, key)
+					if entries != nil {
+						delete(entries, key)
+					}
+				}
+			}
+		}
+		merged[node.Path] = &node
+		layerEntries[node.Path] = &node
+		if entries != nil {
+			meta := fsmeta.Entry{UID: node.UID, GID: node.GID, Mode: node.Mode, RDev: node.RDev}
+			if node.Kind == indexedKindSymlink {
+				meta.LinkTarget = node.LinkTarget
+			}
+			entries[node.Path] = meta
+		}
+	}
+}
+
+func readLayerRecord(r *bufio.Reader) (layerRecord, error) {
+	op, err := r.ReadByte()
+	if err != nil {
+		return layerRecord{}, err
+	}
+	name, err := readLayerString(r)
+	if err != nil {
+		return layerRecord{}, err
+	}
+	record := layerRecord{op: op, node: indexedNode{Path: name}}
+	if op == layerRecordDelete || op == layerRecordOpaque {
+		return record, nil
+	}
+	kind, err := r.ReadByte()
+	if err != nil {
+		return layerRecord{}, err
+	}
+	switch kind {
+	case layerKindDirectory:
+		record.node.Kind = indexedKindDir
+	case layerKindFile:
+		record.node.Kind = indexedKindFile
+	case layerKindSymlink:
+		record.node.Kind = indexedKindSymlink
+	default:
+		return layerRecord{}, fmt.Errorf("unknown layer entry kind %d", kind)
+	}
+	values := make([]uint64, 6)
+	for i := range values {
+		values[i], err = binary.ReadUvarint(r)
+		if err != nil {
+			return layerRecord{}, err
+		}
+	}
+	record.node.Mode = uint32(values[0])
+	record.node.UID = uint32(values[1])
+	record.node.GID = uint32(values[2])
+	record.node.RDev = uint32(values[3])
+	record.node.Size = values[4]
+	record.node.TarOffset = values[5]
+	record.node.ModTimeNS, err = binary.ReadVarint(r)
+	if err != nil {
+		return layerRecord{}, err
+	}
+	record.node.LinkTarget, err = readLayerString(r)
+	if err != nil {
+		return layerRecord{}, err
+	}
+	if op == layerRecordHardlink {
+		record.hardlinkTarget, err = readLayerString(r)
+	}
+	return record, err
+}
+
+func writeLayerUvarint(w io.Writer, value uint64) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], value)
+	_, err := w.Write(buf[:n])
+	return err
+}
+
+func writeLayerVarint(w io.Writer, value int64) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutVarint(buf[:], value)
+	_, err := w.Write(buf[:n])
+	return err
+}
+
+func writeLayerString(w io.Writer, value string) error {
+	if len(value) > maxLayerIndexString {
+		return fmt.Errorf("layer index string is too large: %d bytes", len(value))
+	}
+	if err := writeLayerUvarint(w, uint64(len(value))); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, value)
+	return err
+}
+
+func readLayerString(r io.ByteReader) (string, error) {
+	size, err := binary.ReadUvarint(r)
+	if err != nil {
+		return "", err
+	}
+	if size > maxLayerIndexString {
+		return "", fmt.Errorf("layer index string is too large: %d bytes", size)
+	}
+	buf := make([]byte, int(size))
+	reader, ok := r.(io.Reader)
+	if !ok {
+		return "", fmt.Errorf("layer index reader cannot read strings")
+	}
+	if _, err := io.ReadFull(reader, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func linkOrCopyLayerContents(srcPath, dstPath string) error {
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.Link(srcPath, dstPath); err == nil {
+		return nil
+	}
+	return copyFile(srcPath, dstPath, fs.FileMode(0o644))
+}

--- a/internal/oci/layerarchive_test.go
+++ b/internal/oci/layerarchive_test.go
@@ -1,0 +1,478 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"j5.nz/cc/internal/download"
+	"j5.nz/cc/internal/fsmeta"
+	"j5.nz/cc/internal/imagefs"
+)
+
+type testLayerEntry struct {
+	header tar.Header
+	body   []byte
+}
+
+func compressedTestLayer(t *testing.T, entries ...testLayerEntry) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gzw)
+	for _, entry := range entries {
+		header := entry.header
+		if header.Typeflag == 0 {
+			header.Typeflag = tar.TypeReg
+		}
+		if header.Typeflag == tar.TypeReg || header.Typeflag == tar.TypeRegA {
+			header.Size = int64(len(entry.body))
+		}
+		if err := tw.WriteHeader(&header); err != nil {
+			t.Fatal(err)
+		}
+		if len(entry.body) != 0 {
+			if _, err := tw.Write(entry.body); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return compressed.Bytes()
+}
+
+func TestUncachedLayerIndexesWhileItDownloads(t *testing.T) {
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	body := bytes.Repeat([]byte("streamed layer contents\n"), 1<<16)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "payload",
+		Mode: 0o644,
+		Size: int64(len(body)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data := archive.Bytes()
+	sum := sha256.Sum256(data)
+	layer := descriptor{
+		Digest:    fmt.Sprintf("sha256:%x", sum),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Size:      int64(len(data)),
+	}
+
+	releaseDownload := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		split := min(len(data), 128<<10)
+		_, _ = w.Write(data[:split])
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-releaseDownload
+		_, _ = w.Write(data[split:])
+	}))
+	defer server.Close()
+
+	store := NewStore(t.TempDir())
+	reg := &registryContext{client: server.Client(), registry: server.URL}
+	indexStarted := make(chan struct{})
+	reported := false
+	done := make(chan error, 1)
+	go func() {
+		done <- store.ensureLayerArchive(
+			t.Context(),
+			reg,
+			"test/image",
+			"test",
+			layer,
+			func(int64) {},
+			func(current int64) {
+				if current > 0 && !reported {
+					reported = true
+					close(indexStarted)
+				}
+			},
+		)
+	}()
+
+	select {
+	case <-indexStarted:
+	case <-time.After(2 * time.Second):
+		close(releaseDownload)
+		t.Fatal("indexing did not begin before the layer download completed")
+	}
+	close(releaseDownload)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if !store.cachedLayerArchiveAvailable(layer) {
+		t.Fatal("streamed layer archive was not retained")
+	}
+}
+
+func TestLayerArchiveCachesPackedContentsAndPreservesOverlaySemantics(t *testing.T) {
+	firstData := []byte("lower contents")
+	first := compressedTestLayer(t,
+		testLayerEntry{header: tar.Header{Name: "etc/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		testLayerEntry{header: tar.Header{Name: "etc/old", Mode: 0o640, Uid: 10, Gid: 20}, body: []byte("remove me")},
+		testLayerEntry{header: tar.Header{Name: "opaque/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		testLayerEntry{header: tar.Header{Name: "opaque/lower", Mode: 0o644}, body: firstData},
+		testLayerEntry{header: tar.Header{Name: "replace/", Typeflag: tar.TypeDir, Mode: 0o755}},
+		testLayerEntry{header: tar.Header{Name: "replace/lower", Mode: 0o644}, body: []byte("hidden")},
+	)
+	secondData := []byte("upper contents")
+	second := compressedTestLayer(t,
+		testLayerEntry{header: tar.Header{Name: "etc/.wh.old", Mode: 0o000}},
+		testLayerEntry{header: tar.Header{Name: "opaque/new", Mode: 0o600, Uid: 30, Gid: 40}, body: secondData},
+		testLayerEntry{header: tar.Header{Name: "opaque/.wh..wh..opq", Mode: 0o000}},
+		testLayerEntry{header: tar.Header{Name: "opaque/hard", Typeflag: tar.TypeLink, Linkname: "opaque/new", Mode: 0o600}},
+		testLayerEntry{header: tar.Header{Name: "current", Typeflag: tar.TypeSymlink, Linkname: "opaque/new", Mode: 0o777}},
+		testLayerEntry{header: tar.Header{Name: "replace", Mode: 0o644}, body: []byte("now a file")},
+	)
+
+	store := NewStore(t.TempDir())
+	firstLayer := descriptor{
+		Digest:    "sha256:first",
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Size:      int64(len(first)),
+	}
+	secondLayer := descriptor{
+		Digest:    "sha256:second",
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Size:      int64(len(second)),
+	}
+	firstIndex, firstContents, err := store.writeLayerArchiveAtomic(firstLayer, bytes.NewReader(first), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondIndex, secondContents, err := store.writeLayerArchiveAtomic(secondLayer, bytes.NewReader(second), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstInfo, err := os.Stat(firstContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(len("remove me") + len(firstData) + len("hidden")); firstInfo.Size() != want {
+		t.Fatalf("first packed contents size = %d, want %d", firstInfo.Size(), want)
+	}
+	secondInfo, err := os.Stat(secondContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(len(secondData) + len("now a file")); secondInfo.Size() != want {
+		t.Fatalf("second packed contents size = %d, want %d", secondInfo.Size(), want)
+	}
+
+	build := newIndexedBuildState()
+	if err := applyLayerArchive(firstIndex, firstContents, build.merged, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyLayerArchive(secondIndex, secondContents, build.merged, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, removed := range []string{"/etc/old", "/opaque/lower", "/replace/lower"} {
+		if build.merged[removed] != nil {
+			t.Fatalf("%s survived its OCI whiteout", removed)
+		}
+	}
+	upper := build.merged["/opaque/new"]
+	hardlink := build.merged["/opaque/hard"]
+	if upper == nil || hardlink == nil {
+		t.Fatalf("upper entries missing: new=%+v hard=%+v", upper, hardlink)
+	}
+	if hardlink.TarPath != upper.TarPath || hardlink.TarOffset != upper.TarOffset || hardlink.Size != upper.Size {
+		t.Fatalf("hardlink does not share upper contents: new=%+v hard=%+v", upper, hardlink)
+	}
+	contents, err := os.Open(upper.TarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer contents.Close()
+	got := make([]byte, upper.Size)
+	if _, err := contents.ReadAt(got, int64(upper.TarOffset)); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, secondData) {
+		t.Fatalf("upper contents = %q, want %q", got, secondData)
+	}
+	link := build.merged["/current"]
+	if link == nil || link.LinkTarget != "opaque/new" {
+		t.Fatalf("symlink = %+v", link)
+	}
+}
+
+type failOnRead struct{}
+
+func (failOnRead) Read([]byte) (int, error) {
+	return 0, errors.New("cached layer was read again")
+}
+
+func TestLayerArchiveReusesCompletedLayerWithoutCompressedBlob(t *testing.T) {
+	data := compressedTestLayer(t, testLayerEntry{
+		header: tar.Header{Name: "bin/tool", Mode: 0o755},
+		body:   []byte("tool"),
+	})
+	store := NewStore(t.TempDir())
+	layer := descriptor{
+		Digest:    "sha256:reused",
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Size:      int64(len(data)),
+	}
+	blobPath := filepath.Join(store.root, "_blobs", digestToFileName(layer.Digest))
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blobPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.prepareLayerArchiveFromBlob(layer, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(blobPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("superseded compressed blob remains: %v", err)
+	}
+	firstIndex, firstContents := store.layerArchivePaths(layer.Digest)
+	secondIndex, secondContents, err := store.writeLayerArchiveAtomic(layer, failOnRead{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstIndex != secondIndex || firstContents != secondContents {
+		t.Fatalf("cached paths changed: (%q, %q) != (%q, %q)", firstIndex, firstContents, secondIndex, secondContents)
+	}
+
+	imageContents := filepath.Join(t.TempDir(), "layers", "reused.contents")
+	build := newIndexedBuildState()
+	if err := store.writeAndApplyCachedLayer(
+		layer,
+		imageContents,
+		"layers/reused.contents",
+		build.merged,
+		nil,
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if node := build.merged["/bin/tool"]; node == nil || node.TarPath != "layers/reused.contents" {
+		t.Fatalf("reused node = %+v", node)
+	}
+}
+
+func TestLayerArchiveReadsZstdOCILayer(t *testing.T) {
+	gzipped := compressedTestLayer(t, testLayerEntry{
+		header: tar.Header{Name: "zstd", Mode: 0o644},
+		body:   []byte("compressed with zstd"),
+	})
+	gzr, err := gzip.NewReader(bytes.NewReader(gzipped))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tarData, err := io.ReadAll(gzr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gzr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed := encoder.EncodeAll(tarData, nil)
+	encoder.Close()
+
+	store := NewStore(t.TempDir())
+	layer := descriptor{
+		Digest:    "sha256:zstd",
+		MediaType: "application/vnd.oci.image.layer.v1.tar+zstd",
+		Size:      int64(len(compressed)),
+	}
+	indexPath, contentsPath, err := store.writeLayerArchiveAtomic(layer, bytes.NewReader(compressed), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	build := newIndexedBuildState()
+	if err := applyLayerArchive(indexPath, contentsPath, build.merged, nil); err != nil {
+		t.Fatal(err)
+	}
+	node := build.merged["/zstd"]
+	if node == nil || node.Size != uint64(len("compressed with zstd")) {
+		t.Fatalf("zstd layer node = %+v", node)
+	}
+}
+
+func TestStreamedLayerDoesNotCacheUnverifiedArchive(t *testing.T) {
+	data := compressedTestLayer(t, testLayerEntry{
+		header: tar.Header{Name: "payload", Mode: 0o644},
+		body:   []byte("valid tar with the wrong descriptor digest"),
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		_, _ = w.Write(data)
+	}))
+	defer server.Close()
+
+	store := NewStore(t.TempDir())
+	layer := descriptor{
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Size:      int64(len(data)),
+	}
+	reg := &registryContext{client: server.Client(), registry: server.URL}
+	err := store.downloadAndApplyLayer(
+		t.Context(),
+		reg,
+		"test/image",
+		layer,
+		filepath.Join(t.TempDir(), "layer.contents"),
+		"layers/layer.contents",
+		newIndexedBuildState().merged,
+		nil,
+		nil,
+	)
+	var digestErr *download.DigestError
+	if !errors.As(err, &digestErr) {
+		t.Fatalf("streamed layer error = %v, want digest error", err)
+	}
+	if store.cachedLayerArchiveAvailable(layer) {
+		t.Fatal("unverified layer archive was retained")
+	}
+}
+
+func TestBinaryFilesystemIndexRoundTripAndLegacyJSONCompatibility(t *testing.T) {
+	nodes := map[string]*indexedNode{
+		"/": {
+			Path: "/", Kind: indexedKindDir,
+			Mode: fsmeta.LinuxModeFromFileMode(os.ModeDir | 0o755),
+		},
+		"/tool": {
+			Path: "/tool", Kind: indexedKindFile, Mode: 0o100755,
+			UID: 12, GID: 34, Size: 56, ModTimeNS: -78,
+			TarPath: "layers/tool.contents", TarOffset: 90,
+		},
+	}
+	encoded, err := encodeFSIndex(nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(encoded, []byte(fsIndexMagic)) {
+		t.Fatalf("binary filesystem index has no version magic")
+	}
+	decoded, err := decodeFSIndex(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []indexedNode{*nodes["/"], *nodes["/tool"]}
+	if !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("decoded index = %#v, want %#v", decoded, want)
+	}
+
+	legacy, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodedLegacy, err := decodeFSIndex(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decodedLegacy, want) {
+		t.Fatalf("decoded legacy index = %#v, want %#v", decodedLegacy, want)
+	}
+}
+
+func TestFinalizedBinaryIndexOpensWithoutDuplicateMetadata(t *testing.T) {
+	store := NewStore(t.TempDir())
+	imageDir := store.imageDir("indexed")
+	tmpDir := imageDir + ".tmp"
+	contentsRel := filepath.Join("layers", "base.contents")
+	contentsPath := filepath.Join(tmpDir, contentsRel)
+	if err := os.MkdirAll(filepath.Dir(contentsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("indexed contents")
+	if err := os.WriteFile(contentsPath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	build := newIndexedBuildState()
+	build.merged["/owned"] = &indexedNode{
+		Path: "/owned", Kind: indexedKindFile,
+		Mode: fsmeta.LinuxModeFromFileMode(0o640),
+		UID:  123, GID: 456, Size: uint64(len(body)),
+		TarPath: contentsRel,
+	}
+	spec := SourceSpec{Kind: SourceKindOCI, Raw: "example.invalid/indexed:latest"}
+	if err := store.finalizeIndexedImage("indexed", spec, "", imageDir, tmpDir, imageConfig{}, build); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(imageDir, "rootfs.metadata.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("duplicate metadata file exists: %v", err)
+	}
+
+	image, err := store.Open("indexed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := imagefs.LookupPath(image.RootFS, "/owned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid, gid := entry.File.Owner()
+	if uid != 123 || gid != 456 {
+		t.Fatalf("owner = %d:%d, want 123:456", uid, gid)
+	}
+	got, err := entry.File.ReadAt(0, uint32(len(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("contents = %q, want %q", got, body)
+	}
+
+	cloneStore := NewStore(t.TempDir())
+	if err := cloneStore.cloneFromStore(store, "indexed", "clone", spec); err != nil {
+		t.Fatal(err)
+	}
+	cloned, err := cloneStore.Open("clone")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clonedEntry, err := imagefs.LookupPath(cloned.RootFS, "/owned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clonedBody, err := clonedEntry.File.ReadAt(0, uint32(len(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(clonedBody, body) {
+		t.Fatalf("cloned contents = %q, want %q", clonedBody, body)
+	}
+}
+
+var _ io.Reader = failOnRead{}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -627,7 +627,10 @@ func (s *Store) PlanPull(ctx context.Context, name, source string, options ...Pu
 		plan.LayersTotal++
 		plan.BytesTotal += layer.Size
 		blobPath := filepath.Join(shared.root, "_blobs", digestToFileName(layer.Digest))
-		if info, statErr := os.Stat(blobPath); statErr == nil && info.Mode().IsRegular() && info.Size() == layer.Size {
+		if shared.cachedLayerArchiveAvailable(layer) {
+			plan.LayersCached++
+			plan.BytesCached += layer.Size
+		} else if info, statErr := os.Stat(blobPath); statErr == nil && info.Mode().IsRegular() && info.Size() == layer.Size {
 			plan.LayersCached++
 			plan.BytesCached += layer.Size
 		}
@@ -1163,142 +1166,135 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 		totalLayerBytes += layer.Size
 	}
 	var pipelineMu sync.Mutex
-	var backgroundDownloadedBytes int64
-	var streamedDownloadedBytes int64
-	var downloadedLayerBytes int64
-	var preparedLayerWork int64
-	reportDownload := func(event client.ProgressEvent) {
-		pipelineMu.Lock()
-		if event.BytesTotal > 0 {
-			backgroundDownloadedBytes = max(backgroundDownloadedBytes, event.BytesDownloaded)
-			downloadedLayerBytes = min(totalLayerBytes, backgroundDownloadedBytes+streamedDownloadedBytes)
-			event.BytesDownloaded = downloadedLayerBytes
-			event.BytesTotal = totalLayerBytes
-			event.DownloadProgress = ratio(downloadedLayerBytes, totalLayerBytes)
-			event.IndexProgress = ratio(preparedLayerWork, totalLayerBytes)
-			event.Progress = ratio(downloadedLayerBytes+preparedLayerWork, totalLayerBytes*2)
-			if preparedLayerWork > 0 && event.Status == "downloading" {
-				event.Status = "processing"
-			}
-		}
-		pipelineMu.Unlock()
-		report(event)
-	}
-	streamFirstLayer := len(mani.Layers) != 0 && !s.cachedLayerBlobAvailable(mani.Layers[0])
-	downloadLayers := mani.Layers
-	if streamFirstLayer {
-		firstDigest := mani.Layers[0].Digest
-		downloadLayers = make([]descriptor, 0, len(mani.Layers)-1)
-		for _, layer := range mani.Layers[1:] {
-			if layer.Digest != firstDigest {
-				downloadLayers = append(downloadLayers, layer)
-			}
-		}
-	}
-	downloads, err := s.startLayerBlobPull(ctx, reg, imageName, name, downloadLayers, reportDownload)
-	if err != nil {
-		return err
-	}
-	defer downloads.cancel()
-
 	build := newIndexedBuildState()
-	var preparedLayerBytes int64
 	prepareStarted := time.Now()
+	downloadedByLayer := make([]int64, len(mani.Layers))
+	indexedByLayer := make([]int64, len(mani.Layers))
 	for layerIndex, layer := range mani.Layers {
-		layerTarRel := filepath.Join("layers", digestToFileName(layer.Digest)+".tar")
-		layerTarPath := filepath.Join(tmpDir, layerTarRel)
-		reportPrepare := func(layerWork int64, streaming bool) {
-			pipelineMu.Lock()
-			if streaming {
-				streamedDownloadedBytes = max(streamedDownloadedBytes, min(layer.Size, max(0, layerWork)))
-				downloadedLayerBytes = min(totalLayerBytes, backgroundDownloadedBytes+streamedDownloadedBytes)
+		switch {
+		case s.cachedLayerArchiveAvailable(layer):
+			downloadedByLayer[layerIndex] = layer.Size
+			indexedByLayer[layerIndex] = layer.Size
+		case s.cachedLayerBlobAvailable(layer):
+			downloadedByLayer[layerIndex] = layer.Size
+		default:
+			partialPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest)) + ".partial"
+			if info, statErr := os.Stat(partialPath); statErr == nil {
+				downloadedByLayer[layerIndex] = min(layer.Size, max(0, info.Size()))
 			}
-			preparedLayerWork = preparedLayerBytes + min(layer.Size, max(0, layerWork))
-			downloadProgress := ratio(downloadedLayerBytes, totalLayerBytes)
-			indexProgress := ratio(preparedLayerWork, totalLayerBytes)
-			progress := ratio(downloadedLayerBytes+preparedLayerWork, totalLayerBytes*2)
-			bytesDownloaded := downloadedLayerBytes
-			pipelineMu.Unlock()
-			elapsed := time.Since(prepareStarted).Seconds()
-			var eta float64
-			if progress > 0 && progress < 1 && elapsed > 0 {
-				eta = elapsed * (1 - progress) / progress
-			}
-			report(client.ProgressEvent{
-				Status:           "processing",
-				Artifact:         name,
-				Blob:             layer.Digest,
-				Progress:         progress,
-				DownloadProgress: downloadProgress,
-				IndexProgress:    indexProgress,
-				BytesDownloaded:  bytesDownloaded,
-				BytesTotal:       totalLayerBytes,
-				FilesDownloaded:  int64(layerIndex),
-				FilesTotal:       int64(len(mani.Layers)),
-				ETASeconds:       eta,
-			})
 		}
-		reportFirstLayerDownload := func(downloaded int64) {
-			pipelineMu.Lock()
-			streamedDownloadedBytes = max(streamedDownloadedBytes, min(layer.Size, max(0, downloaded)))
-			downloadedLayerBytes = min(totalLayerBytes, backgroundDownloadedBytes+streamedDownloadedBytes)
-			downloadProgress := ratio(downloadedLayerBytes, totalLayerBytes)
-			indexProgress := ratio(preparedLayerWork, totalLayerBytes)
-			progress := ratio(downloadedLayerBytes+preparedLayerWork, totalLayerBytes*2)
-			bytesDownloaded := downloadedLayerBytes
-			pipelineMu.Unlock()
-			report(client.ProgressEvent{
-				Status:           "downloading",
-				Artifact:         name,
-				Blob:             layer.Digest,
-				Progress:         progress,
-				DownloadProgress: downloadProgress,
-				IndexProgress:    indexProgress,
-				BytesDownloaded:  bytesDownloaded,
-				BytesTotal:       totalLayerBytes,
-				FilesDownloaded:  int64(layerIndex),
-				FilesTotal:       int64(len(mani.Layers)),
-			})
+	}
+	reportPipeline := func(layerIndex int, layer descriptor, downloaded, indexed *int64) {
+		pipelineMu.Lock()
+		if downloaded != nil {
+			downloadedByLayer[layerIndex] = min(layer.Size, max(0, *downloaded))
 		}
-		reportPrepare(0, streamFirstLayer && layerIndex == 0)
-		if streamFirstLayer && layerIndex == 0 {
-			if err := s.downloadAndApplyLayer(ctx, reg, imageName, layer, layerTarPath, layerTarRel, build.merged, build.fsEntries, func(compressedBytes int64) {
-				reportPrepare(compressedBytes, true)
-			}); err != nil {
-				if !errors.Is(err, errStreamedLayerIncomplete) || ctx.Err() != nil {
-					return fmt.Errorf("download and prepare layer %s: %w", layer.Digest, err)
-				}
-				build = newIndexedBuildState()
-				pipelineMu.Lock()
-				preparedLayerWork = preparedLayerBytes
-				pipelineMu.Unlock()
-				resumeProgress := newParallelBlobProgress(name, layer.Size, func(event client.ProgressEvent) {
-					reportFirstLayerDownload(event.BytesDownloaded)
-				})
-				if err := s.cacheLayerBlob(ctx, reg, imageName, layer, resumeProgress); err != nil {
-					return fmt.Errorf("resume layer %s: %w", layer.Digest, err)
-				}
-				if err := s.writeAndApplyCachedLayer(layer, layerTarPath, layerTarRel, build.merged, build.fsEntries, func(compressedBytes int64) {
-					reportPrepare(compressedBytes, false)
-				}); err != nil {
-					return fmt.Errorf("prepare resumed layer %s: %w", layer.Digest, err)
-				}
+		if indexed != nil {
+			indexedByLayer[layerIndex] = min(layer.Size, max(0, *indexed))
+		}
+		var downloadedBytes, indexedBytes, indexedLayers int64
+		for index := range mani.Layers {
+			downloadedBytes += downloadedByLayer[index]
+			indexedBytes += indexedByLayer[index]
+			if indexedByLayer[index] >= mani.Layers[index].Size {
+				indexedLayers++
 			}
-		} else {
-			if err := downloads.waitLayer(ctx, layer.Digest); err != nil {
-				return fmt.Errorf("cache layer %s: %w", layer.Digest, err)
+		}
+		downloadProgress := ratio(downloadedBytes, totalLayerBytes)
+		indexProgress := ratio(indexedBytes, totalLayerBytes)
+		progress := ratio(downloadedBytes+indexedBytes, totalLayerBytes*2)
+		pipelineMu.Unlock()
+		elapsed := time.Since(prepareStarted).Seconds()
+		var eta float64
+		if progress > 0 && progress < 1 && elapsed > 0 {
+			eta = elapsed * (1 - progress) / progress
+		}
+		status := "processing"
+		if indexedBytes == 0 {
+			status = "downloading"
+		}
+		report(client.ProgressEvent{
+			Status:           status,
+			Artifact:         name,
+			Blob:             layer.Digest,
+			Progress:         progress,
+			DownloadProgress: downloadProgress,
+			IndexProgress:    indexProgress,
+			BytesDownloaded:  downloadedBytes,
+			BytesTotal:       totalLayerBytes,
+			FilesDownloaded:  indexedLayers,
+			FilesTotal:       int64(len(mani.Layers)),
+			ETASeconds:       eta,
+		})
+	}
+	prepareCtx, cancelPrepare := context.WithCancel(ctx)
+	defer cancelPrepare()
+	type layerPrepareResult struct {
+		done chan struct{}
+		err  error
+	}
+	prepareResults := make([]*layerPrepareResult, len(mani.Layers))
+	resultsByDigest := make(map[string]*layerPrepareResult, len(mani.Layers))
+	prepareJobs := make(chan int, len(mani.Layers))
+	missingLayers := 0
+	for layerIndex, layer := range mani.Layers {
+		if s.cachedLayerArchiveAvailable(layer) {
+			continue
+		}
+		if existing := resultsByDigest[layer.Digest]; existing != nil {
+			prepareResults[layerIndex] = existing
+			continue
+		}
+		result := &layerPrepareResult{done: make(chan struct{})}
+		resultsByDigest[layer.Digest] = result
+		prepareResults[layerIndex] = result
+		prepareJobs <- layerIndex
+		missingLayers++
+	}
+	close(prepareJobs)
+	// Downloading, decompressing, and writing layer contents all share the same
+	// stream. Bound that combined work so large images do not saturate host CPU,
+	// disk, or network.
+	for range min(2, missingLayers) {
+		go func() {
+			for layerIndex := range prepareJobs {
+				layer := mani.Layers[layerIndex]
+				err := s.ensureLayerArchive(
+					prepareCtx,
+					reg,
+					imageName,
+					name,
+					layer,
+					func(current int64) {
+						reportPipeline(layerIndex, layer, &current, nil)
+					},
+					func(current int64) {
+						reportPipeline(layerIndex, layer, nil, &current)
+					},
+				)
+				result := prepareResults[layerIndex]
+				result.err = err
+				close(result.done)
 			}
-			if err := s.writeAndApplyCachedLayer(layer, layerTarPath, layerTarRel, build.merged, build.fsEntries, func(compressedBytes int64) {
-				reportPrepare(compressedBytes, false)
-			}); err != nil {
+		}()
+	}
+
+	for layerIndex, layer := range mani.Layers {
+		layerContentsRel := filepath.Join("layers", digestToFileName(layer.Digest)+".contents")
+		layerContentsPath := filepath.Join(tmpDir, layerContentsRel)
+		if result := prepareResults[layerIndex]; result != nil {
+			<-result.done
+			if err := result.err; err != nil {
+				cancelPrepare()
 				return fmt.Errorf("prepare layer %s: %w", layer.Digest, err)
 			}
 		}
-		preparedLayerBytes += layer.Size
-		reportPrepare(0, false)
-	}
-	if err := downloads.wait(ctx); err != nil {
-		return err
+		if err := s.writeAndApplyCachedLayer(layer, layerContentsPath, layerContentsRel, build.merged, build.fsEntries, nil); err != nil {
+			cancelPrepare()
+			return fmt.Errorf("apply layer %s: %w", layer.Digest, err)
+		}
+		complete := layer.Size
+		reportPipeline(layerIndex, layer, &complete, &complete)
 	}
 	report(client.ProgressEvent{
 		Status:           "processing",
@@ -1325,16 +1321,13 @@ type indexedBuildState struct {
 }
 
 func newIndexedBuildState() indexedBuildState {
-	fsEntries := map[string]fsmeta.Entry{
-		"/": {UID: 0, GID: 0, Mode: fsmeta.LinuxModeFromFileMode(os.ModeDir | 0o755)},
-	}
+	rootMode := fsmeta.LinuxModeFromFileMode(os.ModeDir | 0o755)
 	return indexedBuildState{
-		fsEntries: fsEntries,
 		merged: map[string]*indexedNode{
 			"/": {
 				Path: "/",
 				Kind: indexedKindDir,
-				Mode: fsEntries["/"].Mode,
+				Mode: rootMode,
 				UID:  0,
 				GID:  0,
 			},
@@ -1344,21 +1337,13 @@ func newIndexedBuildState() indexedBuildState {
 
 func (s *Store) finalizeIndexedImage(name string, spec SourceSpec, resolvedSource, imageDir, tmpDir string, cfg imageConfig, build indexedBuildState) error {
 	ensureIndexedParents(build.merged, build.fsEntries)
-	indexPath := filepath.Join(imageDir, "rootfs.index.json")
+	indexPath := filepath.Join(imageDir, "rootfs.index")
 	indexBuf, err := encodeFSIndex(build.merged)
 	if err != nil {
 		return fmt.Errorf("marshal fs index: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "rootfs.index.json"), indexBuf, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "rootfs.index"), indexBuf, 0o644); err != nil {
 		return fmt.Errorf("write fs index: %w", err)
-	}
-	metadataPath := filepath.Join(imageDir, "rootfs.metadata.json")
-	fsMetaBuf, err := json.MarshalIndent(build.fsEntries, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal fs metadata: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "rootfs.metadata.json"), fsMetaBuf, 0o644); err != nil {
-		return fmt.Errorf("write fs metadata: %w", err)
 	}
 
 	meta := metadata{
@@ -1368,7 +1353,6 @@ func (s *Store) finalizeIndexedImage(name string, spec SourceSpec, resolvedSourc
 		SourceKind:     spec.Kind,
 		Architecture:   cfg.Architecture,
 		RootFSDir:      imageDir,
-		MetadataPath:   metadataPath,
 		IndexPath:      indexPath,
 		Env:            append([]string(nil), cfg.Config.Env...),
 		Entrypoint:     append([]string(nil), cfg.Config.Entrypoint...),
@@ -1501,10 +1485,10 @@ func (s *Store) cloneFromStore(src *Store, srcName, dstName string, spec SourceS
 		meta.RootFSDir = dstDir
 	}
 	if meta.MetadataPath != "" {
-		meta.MetadataPath = filepath.Join(dstDir, "rootfs.metadata.json")
+		meta.MetadataPath = filepath.Join(dstDir, filepath.Base(srcMeta.MetadataPath))
 	}
 	if meta.IndexPath != "" {
-		meta.IndexPath = filepath.Join(dstDir, "rootfs.index.json")
+		meta.IndexPath = filepath.Join(dstDir, filepath.Base(srcMeta.IndexPath))
 	}
 	buf, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
@@ -2081,14 +2065,11 @@ func (s *Store) cachedLayerBlobAvailable(layer descriptor) bool {
 	return err == nil && info.Mode().IsRegular() && info.Size() == layer.Size
 }
 
-func (s *Store) downloadAndApplyLayer(
+func (s *Store) downloadAndPrepareLayer(
 	ctx context.Context,
 	reg *registryContext,
 	imageName string,
 	layer descriptor,
-	dstPath, tarRef string,
-	merged map[string]*indexedNode,
-	entries map[string]fsmeta.Entry,
 	progress func(int64),
 ) error {
 	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
@@ -2132,7 +2113,8 @@ func (s *Store) downloadAndApplyLayer(
 	}()
 	hash := sha256.New()
 	body := io.TeeReader(resp.Body, &layerBlobWriter{dst: io.MultiWriter(blob, hash)})
-	if err := writeAndApplyIndexedLayer(dstPath, layer.MediaType, body, tarRef, merged, entries, progress); err != nil {
+	indexPath, _, err := s.writeLayerArchiveAtomic(layer, body, progress)
+	if err != nil {
 		attemptWatchdog.stop()
 		if timedOut() && ctx.Err() == nil {
 			return fmt.Errorf("%w: %v", errStreamedLayerIncomplete, errBlobDownloadInactive)
@@ -2143,6 +2125,12 @@ func (s *Store) downloadAndApplyLayer(
 		}
 		return err
 	}
+	archiveValidated := false
+	defer func() {
+		if !archiveValidated {
+			_ = os.RemoveAll(filepath.Dir(indexPath))
+		}
+	}()
 	attemptWatchdog.stop()
 	if err := blob.Close(); err != nil {
 		return err
@@ -2152,6 +2140,7 @@ func (s *Store) downloadAndApplyLayer(
 		return err
 	}
 	if info.Size() != layer.Size {
+		_ = os.RemoveAll(filepath.Dir(indexPath))
 		return fmt.Errorf("%w: %v", errStreamedLayerIncomplete, &download.LengthError{Expected: layer.Size, Actual: info.Size()})
 	}
 	actualDigest := "sha256:" + hex.EncodeToString(hash.Sum(nil))
@@ -2159,13 +2148,99 @@ func (s *Store) downloadAndApplyLayer(
 		_ = os.Remove(partialBlobPath)
 		return &download.DigestError{Expected: layer.Digest, Actual: actualDigest}
 	}
+	archiveValidated = true
 	if err := os.Rename(partialBlobPath, blobPath); err != nil {
 		return err
+	}
+	_ = os.Remove(blobPath)
+	return nil
+}
+
+func (s *Store) downloadAndApplyLayer(
+	ctx context.Context,
+	reg *registryContext,
+	imageName string,
+	layer descriptor,
+	dstPath, tarRef string,
+	merged map[string]*indexedNode,
+	entries map[string]fsmeta.Entry,
+	progress func(int64),
+) error {
+	if err := s.downloadAndPrepareLayer(ctx, reg, imageName, layer, progress); err != nil {
+		return err
+	}
+	indexPath, contentsPath := s.layerArchivePaths(layer.Digest)
+	if err := linkOrCopyLayerContents(contentsPath, dstPath); err != nil {
+		return fmt.Errorf("link layer contents: %w", err)
+	}
+	if err := applyLayerArchive(indexPath, tarRef, merged, entries); err != nil {
+		return fmt.Errorf("apply layer archive: %w", err)
 	}
 	return nil
 }
 
 var errStreamedLayerIncomplete = errors.New("streamed OCI layer download is incomplete")
+
+func (s *Store) ensureLayerArchive(
+	ctx context.Context,
+	reg *registryContext,
+	imageName string,
+	artifact string,
+	layer descriptor,
+	reportDownload func(int64),
+	reportIndex func(int64),
+) error {
+	if s.cachedLayerArchiveAvailable(layer) {
+		reportDownload(layer.Size)
+		reportIndex(layer.Size)
+		return nil
+	}
+	if s.cachedLayerBlobAvailable(layer) {
+		reportDownload(layer.Size)
+		return s.prepareLayerArchiveFromBlob(layer, reportIndex)
+	}
+
+	partialPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest)) + ".partial"
+	partial, partialErr := os.Stat(partialPath)
+	if partialErr != nil && !errors.Is(partialErr, os.ErrNotExist) {
+		return partialErr
+	}
+	if partialErr == nil && partial.Size() == 0 {
+		_ = os.Remove(partialPath)
+		partialErr = os.ErrNotExist
+	}
+	if errors.Is(partialErr, os.ErrNotExist) {
+		err := s.downloadAndPrepareLayer(ctx, reg, imageName, layer, func(current int64) {
+			reportDownload(current)
+			reportIndex(current)
+		})
+		if err == nil {
+			reportDownload(layer.Size)
+			reportIndex(layer.Size)
+			return nil
+		}
+		if !errors.Is(err, errStreamedLayerIncomplete) || ctx.Err() != nil {
+			return err
+		}
+		// The streamed archive is atomic and was discarded. Keep the partial
+		// compressed blob for a ranged retry, then rebuild the index from the
+		// completed blob.
+		reportIndex(0)
+	}
+
+	resumeProgress := newParallelBlobProgress(artifact, layer.Size, func(event client.ProgressEvent) {
+		reportDownload(event.BytesDownloaded)
+	})
+	if err := s.cacheLayerBlob(ctx, reg, imageName, layer, resumeProgress); err != nil {
+		return err
+	}
+	reportDownload(layer.Size)
+	if err := s.prepareLayerArchiveFromBlob(layer, reportIndex); err != nil {
+		return err
+	}
+	reportIndex(layer.Size)
+	return nil
+}
 
 func (s *Store) writeAndApplyCachedLayer(
 	layer descriptor,
@@ -2174,13 +2249,31 @@ func (s *Store) writeAndApplyCachedLayer(
 	entries map[string]fsmeta.Entry,
 	progress func(int64),
 ) error {
+	indexPath, contentsPath := s.layerArchivePaths(layer.Digest)
+	if s.cachedLayerArchiveAvailable(layer) {
+		if err := linkOrCopyLayerContents(contentsPath, dstPath); err != nil {
+			return fmt.Errorf("link cached layer contents: %w", err)
+		}
+		return applyLayerArchive(indexPath, tarRef, merged, entries)
+	}
 	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
 	file, err := os.Open(blobPath)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	return writeAndApplyIndexedLayer(dstPath, layer.MediaType, file, tarRef, merged, entries, progress)
+	indexPath, contentsPath, err = s.writeLayerArchiveAtomic(layer, file, progress)
+	closeErr := file.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	_ = os.Remove(blobPath)
+	if err := linkOrCopyLayerContents(contentsPath, dstPath); err != nil {
+		return fmt.Errorf("link layer contents: %w", err)
+	}
+	return applyLayerArchive(indexPath, tarRef, merged, entries)
 }
 
 func (s *Store) getJSONBlob(ctx context.Context, reg *registryContext, path string, accept []string) ([]byte, string, error) {

--- a/internal/virtio/display_test.go
+++ b/internal/virtio/display_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"image"
+	"reflect"
 	"testing"
 )
 
@@ -265,6 +266,61 @@ func TestAbsolutePointerReportsMouseWheel(t *testing.T) {
 	}
 	if len(wheelEvents) != 2 || wheelEvents[0] != 1 || wheelEvents[1] != -1 {
 		t.Fatalf("wheel events = %v, want [1 -1]", wheelEvents)
+	}
+}
+
+func TestAbsolutePointerReportsHighResolutionScroll(t *testing.T) {
+	mem := make(testGuestMemory, 64<<10)
+	input := NewAbsolutePointerInput(0x1000, 0x1000, 11, 800, 600)
+	input.Attach(mem, &testIRQ{})
+
+	relativeEvents := input.eventBitmapLocked(inputEventRel)
+	for _, code := range []uint16{inputRelHWheel, inputRelWheel, inputRelWheelHiRes, inputRelHWheelHiRes} {
+		if relativeEvents[code/8]&(1<<(code%8)) == 0 {
+			t.Fatalf("pointer does not advertise relative event %d", code)
+		}
+	}
+
+	q := &input.queues[inputQueueEvent]
+	q.size = 16
+	q.ready = true
+	q.descAddr = 0x2000
+	q.availAddr = 0x3000
+	q.usedAddr = 0x3800
+	for index := uint16(0); index < q.size; index++ {
+		writeDesc(mem, q.descAddr+uint64(index)*16, 0x4000+uint64(index)*8, 8, descFWrite, 0)
+		binary.LittleEndian.PutUint16(mem[q.availAddr+4+uint64(index)*2:], index)
+	}
+	binary.LittleEndian.PutUint16(mem[q.availAddr+2:], q.size)
+
+	if err := input.ScrollEvent(30, 40); err != nil {
+		t.Fatal(err)
+	}
+	if err := input.ScrollEvent(90, 80); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []InputEvent
+	for index := uint16(0); index < q.usedIdx; index++ {
+		raw := mem[0x4000+uint64(index)*8:]
+		events = append(events, InputEvent{
+			Type:  binary.LittleEndian.Uint16(raw),
+			Code:  binary.LittleEndian.Uint16(raw[2:]),
+			Value: int32(binary.LittleEndian.Uint32(raw[4:])),
+		})
+	}
+	want := []InputEvent{
+		{Type: inputEventRel, Code: inputRelHWheelHiRes, Value: 30},
+		{Type: inputEventRel, Code: inputRelWheelHiRes, Value: 40},
+		{Type: inputEventSyn, Code: inputSynReport},
+		{Type: inputEventRel, Code: inputRelHWheelHiRes, Value: 90},
+		{Type: inputEventRel, Code: inputRelHWheel, Value: 1},
+		{Type: inputEventRel, Code: inputRelWheelHiRes, Value: 80},
+		{Type: inputEventRel, Code: inputRelWheel, Value: 1},
+		{Type: inputEventSyn, Code: inputSynReport},
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
 	}
 }
 

--- a/internal/virtio/input.go
+++ b/internal/virtio/input.go
@@ -27,13 +27,16 @@ const (
 	inputEventRel = 0x02
 	inputEventAbs = 0x03
 
-	inputSynReport = 0
-	inputRelWheel  = 0x08
-	inputAbsX      = 0
-	inputAbsY      = 1
-	inputBtnLeft   = 0x110
-	inputBtnRight  = 0x111
-	inputBtnMiddle = 0x112
+	inputSynReport      = 0
+	inputRelHWheel      = 0x06
+	inputRelWheel       = 0x08
+	inputRelWheelHiRes  = 0x0b
+	inputRelHWheelHiRes = 0x0c
+	inputAbsX           = 0
+	inputAbsY           = 1
+	inputBtnLeft        = 0x110
+	inputBtnRight       = 0x111
+	inputBtnMiddle      = 0x112
 )
 
 type InputKind uint8
@@ -71,6 +74,8 @@ type Input struct {
 	width            uint32
 	height           uint32
 	pending          []InputEvent
+	scrollX120       int64
+	scrollY120       int64
 	queues           [2]queue
 }
 
@@ -336,6 +341,38 @@ func (i *Input) PointerEvent(x, y uint32, buttons uint8, previous uint8) error {
 	return i.flushEventsLocked()
 }
 
+// ScrollEvent reports high-resolution wheel movement in v120 units. Linux
+// expects the high-resolution events for every movement and a legacy wheel
+// event whenever the accumulated movement crosses a 120-unit detent.
+func (i *Input) ScrollEvent(deltaX120, deltaY120 int32) error {
+	if deltaX120 == 0 && deltaY120 == 0 {
+		return nil
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	events := make([]InputEvent, 0, 5)
+	if deltaX120 != 0 {
+		events = append(events, InputEvent{Type: inputEventRel, Code: inputRelHWheelHiRes, Value: deltaX120})
+		i.scrollX120 += int64(deltaX120)
+		if steps := i.scrollX120 / 120; steps != 0 {
+			events = append(events, InputEvent{Type: inputEventRel, Code: inputRelHWheel, Value: int32(steps)})
+			i.scrollX120 -= steps * 120
+		}
+	}
+	if deltaY120 != 0 {
+		events = append(events, InputEvent{Type: inputEventRel, Code: inputRelWheelHiRes, Value: deltaY120})
+		i.scrollY120 += int64(deltaY120)
+		if steps := i.scrollY120 / 120; steps != 0 {
+			events = append(events, InputEvent{Type: inputEventRel, Code: inputRelWheel, Value: int32(steps)})
+			i.scrollY120 -= steps * 120
+		}
+	}
+	events = append(events, InputEvent{Type: inputEventSyn, Code: inputSynReport})
+	i.pending = append(i.pending, events...)
+	return i.flushEventsLocked()
+}
+
 func scaleAbsolutePosition(position, extent uint32) uint32 {
 	if extent <= 1 {
 		return 0
@@ -493,8 +530,11 @@ func (i *Input) eventBitmapLocked(eventType byte) []byte {
 		return bitmap
 	case inputEventRel:
 		if i.Kind == InputAbsolutePointer {
-			bitmap := make([]byte, inputRelWheel/8+1)
+			bitmap := make([]byte, inputRelHWheelHiRes/8+1)
+			setInputBit(bitmap, inputRelHWheel)
 			setInputBit(bitmap, inputRelWheel)
+			setInputBit(bitmap, inputRelWheelHiRes)
+			setInputBit(bitmap, inputRelHWheelHiRes)
 			return bitmap
 		}
 	case inputEventAbs:

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -418,6 +418,13 @@ func (s desktopSession) Pointer(x, y uint32, buttons, previousButtons uint8) err
 	return s.desktop.Pointer.PointerEvent(x, y, buttons, previousButtons)
 }
 
+func (s desktopSession) Scroll(deltaX120, deltaY120 int32) error {
+	if s.desktop.Pointer == nil {
+		return nil
+	}
+	return s.desktop.Pointer.ScrollEvent(deltaX120, deltaY120)
+}
+
 func (s desktopSession) SetClipboard(text string) {
 	if s.desktop.Clipboard != nil {
 		s.desktop.Clipboard.SetFromFrontend(text)


### PR DESCRIPTION
## What changed

- stream OCI layer download and indexing together with bounded workers
- preserve ordered layer application while reporting independent progress
- add native high-resolution v120 scrolling through the display stack

## Why

This avoids duplicate temporary layer files and delivers trackpad scrolling without coarse wheel stepping.

## Validation

- `go test -race -short ./internal/oci ./internal/virtio ./internal/vm/... -count=1 -timeout 15m`