### PR TITLE
Add shared memory domains

### DIFF
--- a/client/protocol.go
+++ b/client/protocol.go
@@ -419,50 +419,57 @@ type DisplayState struct {
 	VNCAddress string `json:"vnc_address,omitempty"`
 }
 
+type SharedMemoryConfig struct {
+	Domain   string `json:"domain"`
+	PhysAddr uint64 `json:"phys_addr"`
+}
+
 type CreateInstanceRequest struct {
-	ID               string            `json:"id,omitempty"`
-	Image            string            `json:"image"`
-	DefaultUser      string            `json:"default_user,omitempty"`
-	InitSystem       string            `json:"init,omitempty"`
-	Kernel           string            `json:"kernel,omitempty"`
-	Shares           []ShareMount      `json:"shares,omitempty"`
-	PersistentMounts []PersistentMount `json:"persistent_mounts,omitempty"`
-	Network          *NetworkConfig    `json:"network,omitempty"`
-	Display          *DisplayConfig    `json:"display,omitempty"`
-	KernelModules    []string          `json:"kernel_modules,omitempty"`
-	MemoryMB         uint64            `json:"memory_mb,omitempty"`
-	BalloonMB        uint64            `json:"balloon_mb,omitempty"`
-	CPUs             int               `json:"cpus,omitempty"`
-	NestedVirt       bool              `json:"nested_virtualization,omitempty"`
-	AMD64Emulation   bool              `json:"amd64_emulation,omitempty"`
-	Dmesg            bool              `json:"dmesg,omitempty"`
-	SnapshotDir      string            `json:"snapshot_dir,omitempty"`
-	RestoreSnapshot  string            `json:"restore_snapshot,omitempty"`
-	TimeoutSeconds   float64           `json:"timeout_seconds,omitempty"`
-	PolicyToken      uint64            `json:"-"`
+	ID               string              `json:"id,omitempty"`
+	Image            string              `json:"image"`
+	DefaultUser      string              `json:"default_user,omitempty"`
+	InitSystem       string              `json:"init,omitempty"`
+	Kernel           string              `json:"kernel,omitempty"`
+	Shares           []ShareMount        `json:"shares,omitempty"`
+	PersistentMounts []PersistentMount   `json:"persistent_mounts,omitempty"`
+	Network          *NetworkConfig      `json:"network,omitempty"`
+	Display          *DisplayConfig      `json:"display,omitempty"`
+	SharedMemory     *SharedMemoryConfig `json:"shared_memory,omitempty"`
+	KernelModules    []string            `json:"kernel_modules,omitempty"`
+	MemoryMB         uint64              `json:"memory_mb,omitempty"`
+	BalloonMB        uint64              `json:"balloon_mb,omitempty"`
+	CPUs             int                 `json:"cpus,omitempty"`
+	NestedVirt       bool                `json:"nested_virtualization,omitempty"`
+	AMD64Emulation   bool                `json:"amd64_emulation,omitempty"`
+	Dmesg            bool                `json:"dmesg,omitempty"`
+	SnapshotDir      string              `json:"snapshot_dir,omitempty"`
+	RestoreSnapshot  string              `json:"restore_snapshot,omitempty"`
+	TimeoutSeconds   float64             `json:"timeout_seconds,omitempty"`
+	PolicyToken      uint64              `json:"-"`
 }
 
 type StartInstanceRequest struct {
-	ID               string            `json:"id,omitempty"`
-	Image            string            `json:"image,omitempty"`
-	DefaultUser      string            `json:"default_user,omitempty"`
-	InitSystem       string            `json:"init,omitempty"`
-	Kernel           string            `json:"kernel,omitempty"`
-	Shares           []ShareMount      `json:"shares,omitempty"`
-	PersistentMounts []PersistentMount `json:"persistent_mounts,omitempty"`
-	Network          *NetworkConfig    `json:"network,omitempty"`
-	Display          *DisplayConfig    `json:"display,omitempty"`
-	KernelModules    []string          `json:"kernel_modules,omitempty"`
-	MemoryMB         uint64            `json:"memory_mb,omitempty"`
-	BalloonMB        uint64            `json:"balloon_mb,omitempty"`
-	CPUs             int               `json:"cpus,omitempty"`
-	NestedVirt       bool              `json:"nested_virtualization,omitempty"`
-	AMD64Emulation   bool              `json:"amd64_emulation,omitempty"`
-	Dmesg            bool              `json:"dmesg,omitempty"`
-	SnapshotDir      string            `json:"snapshot_dir,omitempty"`
-	RestoreSnapshot  string            `json:"restore_snapshot,omitempty"`
-	TimeoutSeconds   float64           `json:"timeout_seconds,omitempty"`
-	PolicyToken      uint64            `json:"-"`
+	ID               string              `json:"id,omitempty"`
+	Image            string              `json:"image,omitempty"`
+	DefaultUser      string              `json:"default_user,omitempty"`
+	InitSystem       string              `json:"init,omitempty"`
+	Kernel           string              `json:"kernel,omitempty"`
+	Shares           []ShareMount        `json:"shares,omitempty"`
+	PersistentMounts []PersistentMount   `json:"persistent_mounts,omitempty"`
+	Network          *NetworkConfig      `json:"network,omitempty"`
+	Display          *DisplayConfig      `json:"display,omitempty"`
+	SharedMemory     *SharedMemoryConfig `json:"shared_memory,omitempty"`
+	KernelModules    []string            `json:"kernel_modules,omitempty"`
+	MemoryMB         uint64              `json:"memory_mb,omitempty"`
+	BalloonMB        uint64              `json:"balloon_mb,omitempty"`
+	CPUs             int                 `json:"cpus,omitempty"`
+	NestedVirt       bool                `json:"nested_virtualization,omitempty"`
+	AMD64Emulation   bool                `json:"amd64_emulation,omitempty"`
+	Dmesg            bool                `json:"dmesg,omitempty"`
+	SnapshotDir      string              `json:"snapshot_dir,omitempty"`
+	RestoreSnapshot  string              `json:"restore_snapshot,omitempty"`
+	TimeoutSeconds   float64             `json:"timeout_seconds,omitempty"`
+	PolicyToken      uint64              `json:"-"`
 }
 
 type InstanceState struct {
@@ -477,6 +484,7 @@ type InstanceState struct {
 	BalloonStatus                 string                 `json:"balloon_status,omitempty"`
 	CPUs                          int                    `json:"cpus,omitempty"`
 	NestedVirt                    bool                   `json:"nested_virtualization,omitempty"`
+	SharedMemory                  *SharedMemoryConfig    `json:"shared_memory,omitempty"`
 	StartedAt                     string                 `json:"started_at,omitempty"`
 	NetworkIPv4                   string                 `json:"network_ipv4,omitempty"`
 	Display                       *DisplayState          `json:"display,omitempty"`

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1197,6 +1197,14 @@
           "vnc_address": { "type": "string" }
         }
       },
+      "SharedMemoryConfig": {
+        "type": "object",
+        "required": ["domain", "phys_addr"],
+        "properties": {
+          "domain": { "type": "string" },
+          "phys_addr": { "type": "integer", "format": "uint64" }
+        }
+      },
       "PortForward": {
         "type": "object",
         "properties": {
@@ -1227,11 +1235,13 @@
           "persistent_mounts": { "type": "array", "items": { "$ref": "#/components/schemas/PersistentMount" } },
           "network": { "$ref": "#/components/schemas/NetworkConfig" },
           "display": { "$ref": "#/components/schemas/DisplayConfig" },
+          "shared_memory": { "$ref": "#/components/schemas/SharedMemoryConfig" },
           "kernel_modules": { "type": "array", "items": { "type": "string" } },
           "memory_mb": { "type": "integer", "format": "uint64" },
           "balloon_mb": { "type": "integer", "format": "uint64" },
           "cpus": { "type": "integer" },
           "nested_virtualization": { "type": "boolean" },
+          "shared_memory": { "$ref": "#/components/schemas/SharedMemoryConfig" },
           "amd64_emulation": { "type": "boolean", "description": "Install the amd64 binfmt emulator even when the guest image is arm64." },
           "dmesg": { "type": "boolean" },
           "snapshot_dir": { "type": "string", "description": "Directory where the runtime may write a startup snapshot during this boot." },

--- a/internal/hv/kvm/host_linux_amd64.go
+++ b/internal/hv/kvm/host_linux_amd64.go
@@ -13,6 +13,7 @@ import (
 	"j5.nz/cc/internal/managed/machine"
 	managedsession "j5.nz/cc/internal/managed/session"
 	"j5.nz/cc/internal/netstack"
+	"j5.nz/cc/internal/shmem"
 	"j5.nz/cc/internal/virtio"
 )
 
@@ -29,6 +30,7 @@ type LinuxManagedMachine struct {
 	DisplayHeight   uint32
 	SnapshotDir     string
 	RestoreSnapshot string
+	SharedMemory    *shmem.Attachment
 }
 
 type LinuxManagedAttachments struct {
@@ -39,6 +41,7 @@ type LinuxManagedAttachments struct {
 	DisplayHeight   uint32
 	SnapshotDir     string
 	RestoreSnapshot string
+	SharedMemory    *shmem.Attachment
 }
 
 type BSDManagedAttachments struct {
@@ -87,6 +90,7 @@ func (Host) startLinux(ctx context.Context, req managedhost.StartRequest, onEven
 		DisplayHeight:   attachments.DisplayHeight,
 		SnapshotDir:     strings.TrimSpace(attachments.SnapshotDir),
 		RestoreSnapshot: strings.TrimSpace(attachments.RestoreSnapshot),
+		SharedMemory:    attachments.SharedMemory,
 	}, onEvent)
 }
 
@@ -176,6 +180,7 @@ func (Host) StartLinuxManaged(ctx context.Context, machine LinuxManagedMachine, 
 			BalloonMB:       machine.BalloonMB,
 			DisplayWidth:    machine.DisplayWidth,
 			DisplayHeight:   machine.DisplayHeight,
+			SharedMemory:    machine.SharedMemory,
 		},
 		onEvent,
 	)

--- a/internal/hv/kvm/session_linux_amd64.go
+++ b/internal/hv/kvm/session_linux_amd64.go
@@ -15,6 +15,7 @@ import (
 	"j5.nz/cc/client"
 	"j5.nz/cc/internal/amd64vm"
 	managedagent "j5.nz/cc/internal/managed/agent"
+	"j5.nz/cc/internal/shmem"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
 )
@@ -47,6 +48,7 @@ type ManagedSessionOptions struct {
 	BalloonMB       uint64
 	DisplayWidth    uint32
 	DisplayHeight   uint32
+	SharedMemory    *shmem.Attachment
 }
 
 func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, cpus int, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
@@ -145,6 +147,18 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 		vsock.Close()
 		return nil, fmt.Errorf("map guest memory: %w", err)
 	}
+	runtimeDevices := append([]virtio.MMIODevice(nil), displayDevices...)
+	if opts.SharedMemory != nil {
+		device, err := shmem.NewDevice(opts.SharedMemory.Config().PhysAddr, opts.SharedMemory, vm)
+		if err != nil {
+			closeVMWithFS(vm, fsdevs)
+			_ = listener.Close()
+			vsock.Close()
+			return nil, err
+		}
+		opts.SharedMemory.Claim()
+		runtimeDevices = append(runtimeDevices, device)
+	}
 
 	serialOut := vmruntime.NewSerialTranscript()
 	var serialWriter io.Writer = serialOut
@@ -226,7 +240,7 @@ func StartManagedSessionWithNetOptions(ctx context.Context, kernel []byte, initr
 	done := newSessionDone()
 	var fsCloseErr error
 	go func() {
-		err := runManagedExecVMWithSnapshot(runCtx, vm, uart, fsdevs, vsock, rng, balloon, netdev, displayDevices, serialOut, snapshot)
+		err := runManagedExecVMWithSnapshot(runCtx, vm, uart, fsdevs, vsock, rng, balloon, netdev, runtimeDevices, serialOut, snapshot)
 		fsCloseErr = closeVMWithFS(vm, fsdevs)
 		done.finish(err)
 	}()

--- a/internal/hv/kvm/session_linux_arm64.go
+++ b/internal/hv/kvm/session_linux_arm64.go
@@ -18,6 +18,7 @@ import (
 	"j5.nz/cc/internal/fdt"
 	managedagent "j5.nz/cc/internal/managed/agent"
 	"j5.nz/cc/internal/serial"
+	"j5.nz/cc/internal/shmem"
 	"j5.nz/cc/internal/timing"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vmruntime"
@@ -49,6 +50,7 @@ type ManagedSessionOptions struct {
 	DisplayWidth    uint32
 	DisplayHeight   uint32
 	NetDevice       *virtio.Net
+	SharedMemory    *shmem.Attachment
 }
 
 func StartManagedSession(ctx context.Context, kernel []byte, initrd []byte, memoryMB uint64, dmesg bool, fsdevs []*virtio.FS, onEvent func(client.BootEvent) error) (*ManagedSession, error) {
@@ -166,6 +168,17 @@ func StartManagedSessionWithOptions(ctx context.Context, kernel []byte, initrd [
 		vsock.Close()
 		return nil, fmt.Errorf("map guest memory: %w", err)
 	}
+	var sharedMemoryDevice *shmem.Device
+	if opts.SharedMemory != nil {
+		sharedMemoryDevice, err = shmem.NewDevice(opts.SharedMemory.Config().PhysAddr, opts.SharedMemory, vm)
+		if err != nil {
+			closeVMWithFS(vm, fsdevs)
+			_ = listener.Close()
+			vsock.Close()
+			return nil, err
+		}
+		opts.SharedMemory.Claim()
+	}
 	if snapshot != nil {
 		snapshot.mem = mem
 	}
@@ -192,6 +205,9 @@ func StartManagedSessionWithOptions(ctx context.Context, kernel []byte, initrd [
 		opts.NetDevice.Attach(vm, vm)
 	}
 	runtimeDevices := append([]virtio.MMIODevice(nil), displayDevices...)
+	if sharedMemoryDevice != nil {
+		runtimeDevices = append(runtimeDevices, sharedMemoryDevice)
+	}
 	if opts.NetDevice != nil {
 		runtimeDevices = append(runtimeDevices, opts.NetDevice)
 	}

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -235,6 +235,49 @@ func (v *VM) MapAnonymousMemorySlot(slot uint32, size uint64, guestPhysAddr uint
 	return mem, nil
 }
 
+func (v *VM) MapSharedMemory(mem []byte, guestPhysAddr uint64) error {
+	if len(mem) == 0 || guestPhysAddr%4096 != 0 || uint64(len(mem))%4096 != 0 {
+		return fmt.Errorf("shared memory mapping must be non-empty and page-aligned")
+	}
+	size := uint64(len(mem))
+	if guestPhysAddr > ^uint64(0)-(size-1) {
+		return fmt.Errorf("shared memory mapping overflows guest address space")
+	}
+	// The current amd64 platform devices occupy the 0xd0000000 aperture.
+	if guestPhysAddr < 0xd1000000 && 0xd0000000 < guestPhysAddr+size {
+		return fmt.Errorf("shared memory mapping overlaps the platform device aperture")
+	}
+	v.lifecycleMu.Lock()
+	defer v.lifecycleMu.Unlock()
+	if v.kvm == nil || v.memoryClosing {
+		return fmt.Errorf("VM is closing")
+	}
+	if rangesOverlapGuestMemory(guestPhysAddr, size, 0, v.lowMemLimit) {
+		return fmt.Errorf("shared memory mapping overlaps guest RAM")
+	}
+	for _, existing := range v.regions {
+		if rangesOverlapGuestMemory(guestPhysAddr, size, existing.guestPhysAddr, uint64(len(existing.mem))) {
+			return fmt.Errorf("shared memory mapping overlaps an existing guest mapping")
+		}
+	}
+	slot := uint32(1 + len(v.regions))
+	region := kvmUserspaceMemoryRegion{
+		Slot:          slot,
+		GuestPhysAddr: guestPhysAddr,
+		MemorySize:    size,
+		UserspaceAddr: uint64(uintptr(unsafe.Pointer(&mem[0]))),
+	}
+	if err := setUserMemoryRegion(v.vmfd, &region); err != nil {
+		return fmt.Errorf("map shared memory slot %d: %w", slot, err)
+	}
+	v.regions = append(v.regions, memoryMapping{guestPhysAddr: guestPhysAddr, mem: mem})
+	return nil
+}
+
+func rangesOverlapGuestMemory(a, aSize, b, bSize uint64) bool {
+	return a < b+bSize && b < a+aSize
+}
+
 func mapAMD64GuestMemory(vm *VM, memoryMB uint64) ([]byte, error) {
 	totalSize := amd64vm.MemorySizeBytes(memoryMB)
 	mem, err := unix.Mmap(-1, 0, int(totalSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANONYMOUS|unix.MAP_PRIVATE)

--- a/internal/hv/kvm/vm_linux_arm64.go
+++ b/internal/hv/kvm/vm_linux_arm64.go
@@ -55,10 +55,16 @@ type VM struct {
 	run           []byte
 	mem           []byte
 	extraMem      [][]byte
+	sharedMem     []arm64SharedMapping
 	memRegion     kvmUserspaceMemoryRegion
 	tid           atomic.Int32
 	memoryDetach  []func()
 	memoryClosing bool
+}
+
+type arm64SharedMapping struct {
+	guestPhysAddr uint64
+	mem           []byte
 }
 
 func NewVM() (*VM, error) {
@@ -151,6 +157,7 @@ func (v *VM) Close() error {
 		}
 	}
 	v.extraMem = nil
+	v.sharedMem = nil
 	if v.kvm != nil {
 		_ = v.kvm.CloseVCPU(v.vcpufd)
 		if v.vgicfd >= 0 {
@@ -251,6 +258,46 @@ func (v *VM) MapMemoryAlias(slot uint32, guestPhysAddr uint64, mem []byte) error
 	if err := setUserMemoryRegion(v.vmfd, &region); err != nil {
 		return fmt.Errorf("set user memory alias: %w", err)
 	}
+	return nil
+}
+
+func (v *VM) MapSharedMemory(mem []byte, guestPhysAddr uint64) error {
+	if len(mem) == 0 || guestPhysAddr%4096 != 0 || uint64(len(mem))%4096 != 0 {
+		return fmt.Errorf("shared memory mapping must be non-empty and page-aligned")
+	}
+	size := uint64(len(mem))
+	if guestPhysAddr > ^uint64(0)-(size-1) {
+		return fmt.Errorf("shared memory mapping overflows guest address space")
+	}
+	if guestPhysAddr < 0x22000000 && 0x08000000 < guestPhysAddr+size {
+		return fmt.Errorf("shared memory mapping overlaps the platform device aperture")
+	}
+	v.lifecycleMu.Lock()
+	defer v.lifecycleMu.Unlock()
+	if v.kvm == nil || v.memoryClosing {
+		return fmt.Errorf("VM is closing")
+	}
+	if guestPhysAddr < v.memRegion.GuestPhysAddr+v.memRegion.MemorySize &&
+		v.memRegion.GuestPhysAddr < guestPhysAddr+size {
+		return fmt.Errorf("shared memory mapping overlaps guest RAM")
+	}
+	for _, existing := range v.sharedMem {
+		if guestPhysAddr < existing.guestPhysAddr+uint64(len(existing.mem)) &&
+			existing.guestPhysAddr < guestPhysAddr+size {
+			return fmt.Errorf("shared memory mapping overlaps an existing guest mapping")
+		}
+	}
+	slot := uint32(1 + len(v.extraMem) + len(v.sharedMem))
+	region := kvmUserspaceMemoryRegion{
+		Slot:          slot,
+		GuestPhysAddr: guestPhysAddr,
+		MemorySize:    size,
+		UserspaceAddr: uint64(uintptr(unsafe.Pointer(&mem[0]))),
+	}
+	if err := setUserMemoryRegion(v.vmfd, &region); err != nil {
+		return fmt.Errorf("map shared memory slot %d: %w", slot, err)
+	}
+	v.sharedMem = append(v.sharedMem, arm64SharedMapping{guestPhysAddr: guestPhysAddr, mem: mem})
 	return nil
 }
 

--- a/internal/shmem/backing_unix.go
+++ b/internal/shmem/backing_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package shmem
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func allocateBacking(size uint64) ([]byte, func() error, error) {
+	if size > uint64(^uint(0)>>1) {
+		return nil, nil, fmt.Errorf("shared memory region is too large for this host")
+	}
+	mem, err := syscall.Mmap(-1, 0, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_SHARED)
+	if err != nil {
+		return nil, nil, fmt.Errorf("allocate shared memory: %w", err)
+	}
+	return mem, func() error { return syscall.Munmap(mem) }, nil
+}

--- a/internal/shmem/backing_windows.go
+++ b/internal/shmem/backing_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package shmem
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func allocateBacking(size uint64) ([]byte, func() error, error) {
+	if size == 0 || size > uint64(^uint(0)>>1) {
+		return nil, nil, fmt.Errorf("shared memory region size is not representable on this host")
+	}
+	addr, err := windows.VirtualAlloc(0, uintptr(size), windows.MEM_COMMIT|windows.MEM_RESERVE, windows.PAGE_READWRITE)
+	if err != nil {
+		return nil, nil, fmt.Errorf("allocate shared memory: %w", err)
+	}
+	mem := unsafe.Slice((*byte)(unsafe.Pointer(addr)), int(size))
+	return mem, func() error {
+		return windows.VirtualFree(addr, 0, windows.MEM_RELEASE)
+	}, nil
+}

--- a/internal/shmem/device.go
+++ b/internal/shmem/device.go
@@ -1,0 +1,221 @@
+package shmem
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+const (
+	Magic = uint64(0x0100006d656d6873)
+
+	StatusEmpty     = uint32(0)
+	StatusRequested = uint32(1)
+	StatusMapped    = uint32(2)
+	StatusError     = uint32(3)
+
+	ErrorNone         = uint32(0)
+	ErrorInvalidID    = uint32(1)
+	ErrorInvalidSize  = uint32(2)
+	ErrorSizeConflict = uint32(3)
+	ErrorInvalidGPA   = uint32(4)
+	ErrorMapping      = uint32(5)
+
+	descriptorBase = uint64(0x10)
+	descriptorSize = uint64(0x20)
+)
+
+type Mapper interface {
+	MapSharedMemory(mem []byte, guestPhysAddr uint64) error
+}
+
+type descriptor struct {
+	id     uint32
+	status uint32
+	size   uint64
+	gpa    uint64
+	err    uint32
+}
+
+type Device struct {
+	Base uint64
+	Size uint64
+
+	mu         sync.Mutex
+	attachment *Attachment
+	mapper     Mapper
+	desc       [MaxRegions]descriptor
+}
+
+func NewDevice(base uint64, attachment *Attachment, mapper Mapper) (*Device, error) {
+	if attachment == nil || mapper == nil {
+		return nil, fmt.Errorf("shared memory device requires an attachment and mapper")
+	}
+	if base != attachment.Config().PhysAddr {
+		return nil, fmt.Errorf("shared memory device address does not match attachment")
+	}
+	return &Device{Base: base, Size: ControlWindowSize, attachment: attachment, mapper: mapper}, nil
+}
+
+func (d *Device) Contains(addr uint64, size int) bool {
+	return d != nil && size > 0 && addr >= d.Base && uint64(size) <= d.Size && addr-d.Base <= d.Size-uint64(size)
+}
+
+func (d *Device) Read(addr uint64, size int) (uint64, error) {
+	if !d.Contains(addr, size) {
+		return 0, fmt.Errorf("shared memory read outside control window")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	offset := addr - d.Base
+	switch offset {
+	case 0:
+		return truncate(Magic, size), nil
+	case 8:
+		return truncate(uint64(MaxRegions)|uint64(12)<<32, size), nil
+	}
+	index, field, ok := descriptorOffset(offset, size)
+	if !ok {
+		return 0, fmt.Errorf("invalid shared memory register read offset=%#x size=%d", offset, size)
+	}
+	entry := d.desc[index]
+	switch field {
+	case 0:
+		return truncate(uint64(entry.id), size), nil
+	case 4:
+		return truncate(uint64(entry.status), size), nil
+	case 8:
+		return truncate(entry.size, size), nil
+	case 16:
+		return truncate(entry.gpa, size), nil
+	case 24:
+		return truncate(uint64(entry.err), size), nil
+	default:
+		return 0, nil
+	}
+}
+
+func (d *Device) Write(addr uint64, size int, value uint64) error {
+	if !d.Contains(addr, size) {
+		return fmt.Errorf("shared memory write outside control window")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	offset := addr - d.Base
+	index, field, ok := descriptorOffset(offset, size)
+	if !ok {
+		return fmt.Errorf("invalid shared memory register write offset=%#x size=%d", offset, size)
+	}
+	entry := &d.desc[index]
+	if entry.status == StatusMapped {
+		return nil
+	}
+	switch field {
+	case 0:
+		if size != 4 {
+			return fmt.Errorf("shared memory region ID requires a 32-bit write")
+		}
+		entry.id = uint32(value)
+	case 4:
+		if size != 4 {
+			return fmt.Errorf("shared memory status requires a 32-bit write")
+		}
+		if uint32(value) == StatusEmpty {
+			*entry = descriptor{}
+			return nil
+		}
+		if uint32(value) != StatusRequested {
+			return fmt.Errorf("invalid shared memory descriptor status %d", value)
+		}
+		entry.status = StatusRequested
+		d.commit(entry)
+	case 8:
+		if size != 8 {
+			return fmt.Errorf("shared memory size requires a 64-bit write")
+		}
+		entry.size = value
+	case 16:
+		if size != 8 {
+			return fmt.Errorf("shared memory GPA requires a 64-bit write")
+		}
+		entry.gpa = value
+	case 24:
+		return nil
+	default:
+		return fmt.Errorf("write to reserved shared memory descriptor field")
+	}
+	return nil
+}
+
+func (d *Device) commit(entry *descriptor) {
+	entry.err = ErrorNone
+	fail := func(code uint32) {
+		entry.status = StatusError
+		entry.err = code
+	}
+	if entry.id == 0 {
+		fail(ErrorInvalidID)
+		return
+	}
+	if entry.size == 0 || entry.size%PageSize != 0 || entry.size > MaxRegionSize {
+		fail(ErrorInvalidSize)
+		return
+	}
+	if entry.gpa == 0 || entry.gpa%PageSize != 0 || entry.gpa > ^uint64(0)-(entry.size-1) {
+		fail(ErrorInvalidGPA)
+		return
+	}
+	if rangesOverlap(entry.gpa, entry.size, d.Base, d.Size) {
+		fail(ErrorInvalidGPA)
+		return
+	}
+	mem, err := d.attachment.Region(entry.id, entry.size)
+	if errors.Is(err, ErrRegionSizeConflict) {
+		fail(ErrorSizeConflict)
+		return
+	}
+	if err != nil {
+		fail(ErrorMapping)
+		return
+	}
+	if err := d.mapper.MapSharedMemory(mem, entry.gpa); err != nil {
+		fail(ErrorMapping)
+		return
+	}
+	entry.status = StatusMapped
+}
+
+func rangesOverlap(a, aSize, b, bSize uint64) bool {
+	return a < b+bSize && b < a+aSize
+}
+
+func descriptorOffset(offset uint64, size int) (int, uint64, bool) {
+	if offset < descriptorBase {
+		return 0, 0, false
+	}
+	relative := offset - descriptorBase
+	index := relative / descriptorSize
+	field := relative % descriptorSize
+	if index >= MaxRegions || size != 4 && size != 8 || field+uint64(size) > descriptorSize {
+		return 0, 0, false
+	}
+	return int(index), field, true
+}
+
+func truncate(value uint64, size int) uint64 {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], value)
+	switch size {
+	case 1:
+		return uint64(buf[0])
+	case 2:
+		return uint64(binary.LittleEndian.Uint16(buf[:2]))
+	case 4:
+		return uint64(binary.LittleEndian.Uint32(buf[:4]))
+	case 8:
+		return value
+	default:
+		return 0
+	}
+}

--- a/internal/shmem/device_test.go
+++ b/internal/shmem/device_test.go
@@ -1,0 +1,120 @@
+package shmem
+
+import (
+	"errors"
+	"testing"
+)
+
+type recordingMapper struct {
+	gpa uint64
+	mem []byte
+	err error
+}
+
+func (m *recordingMapper) MapSharedMemory(mem []byte, guestPhysAddr uint64) error {
+	m.gpa = guestPhysAddr
+	m.mem = mem
+	return m.err
+}
+
+func TestDomainRegionIsSharedBetweenAttachedVMs(t *testing.T) {
+	registry := NewRegistry()
+	firstAttachment, err := registry.Attach(Config{Domain: "packets", PhysAddr: 0xd1000000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = firstAttachment.Release() })
+	secondAttachment, err := registry.Attach(Config{Domain: "packets", PhysAddr: 0xd2000000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = secondAttachment.Release() })
+
+	firstMapper := &recordingMapper{}
+	first, err := NewDevice(0xd1000000, firstAttachment, firstMapper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondMapper := &recordingMapper{}
+	second, err := NewDevice(0xd2000000, secondAttachment, secondMapper)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestRegion(t, first, 0, 7, PageSize, 0x100000000)
+	requestRegion(t, second, 0, 7, PageSize, 0x200000000)
+
+	if firstMapper.gpa != 0x100000000 || secondMapper.gpa != 0x200000000 {
+		t.Fatalf("mapped GPAs = %#x and %#x", firstMapper.gpa, secondMapper.gpa)
+	}
+	firstMapper.mem[123] = 0x5a
+	if got := secondMapper.mem[123]; got != 0x5a {
+		t.Fatalf("shared byte = %#x, want 0x5a", got)
+	}
+}
+
+func TestRegionSizeConflictHasStructuredStatus(t *testing.T) {
+	registry := NewRegistry()
+	firstAttachment, err := registry.Attach(Config{Domain: "packets", PhysAddr: 0xd1000000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = firstAttachment.Release() })
+	secondAttachment, err := registry.Attach(Config{Domain: "packets", PhysAddr: 0xd2000000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = secondAttachment.Release() })
+	first, _ := NewDevice(0xd1000000, firstAttachment, &recordingMapper{})
+	second, _ := NewDevice(0xd2000000, secondAttachment, &recordingMapper{})
+
+	requestRegion(t, first, 0, 9, PageSize, 0x100000000)
+	requestRegion(t, second, 0, 9, 2*PageSize, 0x200000000)
+
+	status, err := second.Read(second.Base+descriptorBase+4, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := second.Read(second.Base+descriptorBase+24, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != uint64(StatusError) || code != uint64(ErrorSizeConflict) {
+		t.Fatalf("descriptor result = status %d error %d", status, code)
+	}
+}
+
+func TestMappingFailureDoesNotReportSuccess(t *testing.T) {
+	registry := NewRegistry()
+	attachment, err := registry.Attach(Config{Domain: "packets", PhysAddr: 0xd1000000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = attachment.Release() })
+	mapper := &recordingMapper{err: errors.New("overlap")}
+	device, _ := NewDevice(0xd1000000, attachment, mapper)
+
+	requestRegion(t, device, 0, 4, PageSize, 0x100000000)
+	status, _ := device.Read(device.Base+descriptorBase+4, 4)
+	code, _ := device.Read(device.Base+descriptorBase+24, 4)
+	if status != uint64(StatusError) || code != uint64(ErrorMapping) {
+		t.Fatalf("descriptor result = status %d error %d", status, code)
+	}
+}
+
+func requestRegion(t *testing.T, device *Device, descriptor int, id uint32, size, gpa uint64) {
+	t.Helper()
+	base := device.Base + descriptorBase + uint64(descriptor)*descriptorSize
+	if err := device.Write(base, 4, uint64(id)); err != nil {
+		t.Fatal(err)
+	}
+	if err := device.Write(base+8, 8, size); err != nil {
+		t.Fatal(err)
+	}
+	if err := device.Write(base+16, 8, gpa); err != nil {
+		t.Fatal(err)
+	}
+	if err := device.Write(base+4, 4, uint64(StatusRequested)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/shmem/registry.go
+++ b/internal/shmem/registry.go
@@ -1,0 +1,208 @@
+package shmem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const (
+	PageSize          = uint64(4096)
+	MaxRegionSize     = uint64(1 << 30)
+	MaxDomainSize     = uint64(4 << 30)
+	MaxRegistrySize   = uint64(16 << 30)
+	MaxRegions        = 15
+	ControlWindowSize = uint64(4096)
+)
+
+type Config struct {
+	Domain   string
+	PhysAddr uint64
+}
+
+type Registry struct {
+	mu      sync.Mutex
+	domains map[string]*domain
+	total   uint64
+}
+
+type domain struct {
+	name        string
+	attachments int
+	total       uint64
+	regions     map[uint32]*region
+}
+
+type region struct {
+	size  uint64
+	mem   []byte
+	close func() error
+}
+
+type Attachment struct {
+	registry *Registry
+	domain   *domain
+	config   Config
+
+	mu       sync.Mutex
+	claimed  bool
+	released bool
+}
+
+var ErrRegionSizeConflict = errors.New("shared memory region size conflicts with existing allocation")
+
+func NewRegistry() *Registry {
+	return &Registry{domains: make(map[string]*domain)}
+}
+
+func ValidateConfig(config Config) error {
+	config.Domain = strings.TrimSpace(config.Domain)
+	if config.Domain == "" {
+		return fmt.Errorf("shared memory domain is required")
+	}
+	if len(config.Domain) > 128 {
+		return fmt.Errorf("shared memory domain exceeds 128 bytes")
+	}
+	if config.PhysAddr == 0 || config.PhysAddr%PageSize != 0 {
+		return fmt.Errorf("shared memory control address %#x must be page-aligned and non-zero", config.PhysAddr)
+	}
+	if config.PhysAddr > ^uint64(0)-(ControlWindowSize-1) {
+		return fmt.Errorf("shared memory control address %#x overflows", config.PhysAddr)
+	}
+	return nil
+}
+
+func (r *Registry) Attach(config Config) (*Attachment, error) {
+	if r == nil {
+		return nil, fmt.Errorf("shared memory registry is not configured")
+	}
+	config.Domain = strings.TrimSpace(config.Domain)
+	if err := ValidateConfig(config); err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	d := r.domains[config.Domain]
+	if d == nil {
+		d = &domain{name: config.Domain, regions: make(map[uint32]*region)}
+		r.domains[config.Domain] = d
+	}
+	d.attachments++
+	return &Attachment{registry: r, domain: d, config: config}, nil
+}
+
+func (a *Attachment) Config() Config {
+	if a == nil {
+		return Config{}
+	}
+	return a.config
+}
+
+func (a *Attachment) Claim() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	a.claimed = true
+	a.mu.Unlock()
+}
+
+func (a *Attachment) Claimed() bool {
+	if a == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.claimed
+}
+
+func (a *Attachment) Region(id uint32, size uint64) ([]byte, error) {
+	if a == nil || a.domain == nil || a.registry == nil {
+		return nil, fmt.Errorf("shared memory attachment is unavailable")
+	}
+	if id == 0 {
+		return nil, fmt.Errorf("shared memory region ID zero is reserved")
+	}
+	if size == 0 || size%PageSize != 0 || size > MaxRegionSize {
+		return nil, fmt.Errorf("shared memory region size %d is invalid", size)
+	}
+	r := a.registry
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	a.mu.Lock()
+	released := a.released
+	a.mu.Unlock()
+	if released {
+		return nil, fmt.Errorf("shared memory attachment is released")
+	}
+	if existing := a.domain.regions[id]; existing != nil {
+		if existing.size != size {
+			return nil, ErrRegionSizeConflict
+		}
+		return existing.mem, nil
+	}
+	if len(a.domain.regions) >= MaxRegions {
+		return nil, fmt.Errorf("shared memory domain has reached its region limit")
+	}
+	if a.domain.total > MaxDomainSize-size {
+		return nil, fmt.Errorf("shared memory domain exceeds its size limit")
+	}
+	if r.total > MaxRegistrySize-size {
+		return nil, fmt.Errorf("shared memory registry exceeds its size limit")
+	}
+	mem, closeBacking, err := allocateBacking(size)
+	if err != nil {
+		return nil, err
+	}
+	a.domain.regions[id] = &region{size: size, mem: mem, close: closeBacking}
+	a.domain.total += size
+	r.total += size
+	return mem, nil
+}
+
+func (a *Attachment) Release() error {
+	if a == nil || a.registry == nil || a.domain == nil {
+		return nil
+	}
+	a.mu.Lock()
+	if a.released {
+		a.mu.Unlock()
+		return nil
+	}
+	a.released = true
+	a.mu.Unlock()
+
+	r := a.registry
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	a.domain.attachments--
+	if a.domain.attachments > 0 {
+		return nil
+	}
+	delete(r.domains, a.domain.name)
+	r.total -= a.domain.total
+	var errs []error
+	for _, region := range a.domain.regions {
+		if region.close != nil {
+			errs = append(errs, region.close())
+		}
+	}
+	a.domain.regions = nil
+	return errors.Join(errs...)
+}
+
+type attachmentContextKey struct{}
+
+func WithAttachment(ctx context.Context, attachment *Attachment) context.Context {
+	return context.WithValue(ctx, attachmentContextKey{}, attachment)
+}
+
+func FromContext(ctx context.Context) *Attachment {
+	if ctx == nil {
+		return nil
+	}
+	attachment, _ := ctx.Value(attachmentContextKey{}).(*Attachment)
+	return attachment
+}

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -22,6 +22,7 @@ import (
 	"j5.nz/cc/internal/managed/rootartifact"
 	managedruntime "j5.nz/cc/internal/managed/runtime"
 	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/shmem"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vm/execplan"
 	kvmhost "j5.nz/cc/internal/vm/host/kvm"
@@ -146,6 +147,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 			DisplayHeight:   displayHeight(req.Display),
 			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
 			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
+			SharedMemory:    shmem.FromContext(ctx),
 		},
 	}, onEvent)
 	if err != nil {
@@ -197,6 +199,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			PersistentMounts: append([]client.PersistentMount(nil), req.PersistentMounts...),
 			Network:          req.Network,
 			Display:          req.Display,
+			SharedMemory:     req.SharedMemory,
 			KernelModules:    append([]string(nil), req.KernelModules...),
 			MemoryMB:         req.MemoryMB,
 			BalloonMB:        req.BalloonMB,
@@ -287,6 +290,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			DisplayHeight:   displayHeight(req.Display),
 			SnapshotDir:     strings.TrimSpace(req.SnapshotDir),
 			RestoreSnapshot: strings.TrimSpace(req.RestoreSnapshot),
+			SharedMemory:    shmem.FromContext(ctx),
 		},
 	}, onEvent)
 	if err != nil {

--- a/internal/vm/backend_linux_arm64.go
+++ b/internal/vm/backend_linux_arm64.go
@@ -19,6 +19,7 @@ import (
 	"j5.nz/cc/internal/kernel/alpine"
 	managedguest "j5.nz/cc/internal/managed/guest"
 	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/shmem"
 	"j5.nz/cc/internal/timing"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vm/execplan"
@@ -164,6 +165,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		DisplayWidth:    displayWidth(req.Display),
 		DisplayHeight:   displayHeight(req.Display),
 		NetDevice:       networkDevice(network),
+		SharedMemory:    shmem.FromContext(ctx),
 	}, onEvent)
 	timing.Since(ctx, "startup.kvm_to_ready", stageStart)
 	if err != nil {
@@ -211,6 +213,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Shares:           append([]client.ShareMount(nil), req.Shares...),
 			PersistentMounts: append([]client.PersistentMount(nil), req.PersistentMounts...),
 			Network:          req.Network,
+			SharedMemory:     req.SharedMemory,
 			KernelModules:    append([]string(nil), req.KernelModules...),
 			MemoryMB:         req.MemoryMB,
 			BalloonMB:        req.BalloonMB,
@@ -302,6 +305,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		DisplayWidth:    displayWidth(req.Display),
 		DisplayHeight:   displayHeight(req.Display),
 		NetDevice:       networkDevice(network),
+		SharedMemory:    shmem.FromContext(ctx),
 	}, onEvent)
 	if err != nil {
 		return nil, err

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -17,6 +17,7 @@ import (
 	"j5.nz/cc/internal/hv"
 	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/rfb"
+	"j5.nz/cc/internal/shmem"
 	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vm/builtin"
 	vmhost "j5.nz/cc/internal/vm/host"
@@ -121,6 +122,7 @@ type Manager struct {
 	maxMemoryMB   uint64
 	maxCPUs       int
 	closing       bool
+	sharedMemory  *shmem.Registry
 }
 
 type resourceReservation struct {
@@ -151,6 +153,7 @@ type Machine struct {
 	balloonMB                uint64
 	cpus                     int
 	nestedVirt               bool
+	sharedMemoryConfig       *client.SharedMemoryConfig
 	startedAt                time.Time
 	instance                 Instance
 	lastErr                  error
@@ -160,6 +163,7 @@ type Machine struct {
 	display                  *client.DisplayState
 	vncListener              net.Listener
 	vncServer                *rfb.Server
+	sharedMemory             *shmem.Attachment
 }
 
 type machineStopOperation struct {
@@ -195,11 +199,36 @@ func newManagerBudgets(m *Manager) *Manager {
 	// configured totals are not useful host-capacity ceilings. The vmsh host
 	// observes real memory pressure and dynamically balloons guests instead.
 	// Explicit test/embedding budgets can still set these fields when desired.
+	if m.sharedMemory == nil {
+		m.sharedMemory = shmem.NewRegistry()
+	}
 	return m
 }
 
 func NewManagerWithHosts(hosts ...VMHost) *Manager {
 	return NewManagerWithHost(vmhost.NewPlacement(hosts...))
+}
+
+func validateSharedMemoryRequest(config *client.SharedMemoryConfig) error {
+	if config == nil {
+		return nil
+	}
+	return shmem.ValidateConfig(shmem.Config{Domain: config.Domain, PhysAddr: config.PhysAddr})
+}
+
+func cloneSharedMemoryConfig(config *client.SharedMemoryConfig) *client.SharedMemoryConfig {
+	if config == nil {
+		return nil
+	}
+	cloned := *config
+	return &cloned
+}
+
+func (m *Manager) attachSharedMemory(config *client.SharedMemoryConfig) (*shmem.Attachment, error) {
+	if config == nil {
+		return nil, nil
+	}
+	return m.sharedMemory.Attach(shmem.Config{Domain: config.Domain, PhysAddr: config.PhysAddr})
 }
 
 func Supports() error {
@@ -455,6 +484,12 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	if display != nil && (strings.TrimSpace(req.SnapshotDir) != "" || strings.TrimSpace(req.RestoreSnapshot) != "") {
 		return client.InstanceState{}, fmt.Errorf("display-enabled VMs do not support startup snapshots")
 	}
+	if req.SharedMemory != nil && (strings.TrimSpace(req.SnapshotDir) != "" || strings.TrimSpace(req.RestoreSnapshot) != "") {
+		return client.InstanceState{}, fmt.Errorf("shared-memory VMs do not support startup snapshots")
+	}
+	if err := validateSharedMemoryRequest(req.SharedMemory); err != nil {
+		return client.InstanceState{}, err
+	}
 	canonicalShares, err := mounts.CanonicalRuntimeShares(req.Shares)
 	if err != nil {
 		return client.InstanceState{}, err
@@ -501,32 +536,50 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	req.Network = m.ensureNetworkLeaseLocked(id, req.Image, req.Network)
 	m.mu.Unlock()
 
-	inst, err := m.host.StartStream(startCtx, req, onEvent)
+	attachment, err := m.attachSharedMemory(req.SharedMemory)
 	if err != nil {
 		m.finishStart(id, start)
 		return client.InstanceState{}, err
 	}
+	if attachment != nil {
+		startCtx = shmem.WithAttachment(startCtx, attachment)
+	}
+	inst, err := m.host.StartStream(startCtx, req, onEvent)
+	if err != nil {
+		_ = attachment.Release()
+		m.finishStart(id, start)
+		return client.InstanceState{}, err
+	}
+	if attachment != nil && !attachment.Claimed() {
+		closeErr := inst.Close()
+		releaseErr := attachment.Release()
+		m.finishStart(id, start)
+		return client.InstanceState{}, errors.Join(fmt.Errorf("VM backend does not support shared memory"), closeErr, releaseErr)
+	}
 	displayState, vncListener, vncServer, err := startVNCServer(inst, id, display)
 	if err != nil {
 		closeErr := inst.Close()
+		releaseErr := attachment.Release()
 		m.finishStart(id, start)
-		return client.InstanceState{}, errors.Join(err, closeErr)
+		return client.InstanceState{}, errors.Join(err, closeErr, releaseErr)
 	}
 
 	machine := &Machine{
-		id:          id,
-		image:       req.Image,
-		initSystem:  req.InitSystem,
-		kernel:      req.Kernel,
-		memoryMB:    req.MemoryMB,
-		balloonMB:   req.BalloonMB,
-		cpus:        req.CPUs,
-		nestedVirt:  req.NestedVirt,
-		startedAt:   time.Now().UTC(),
-		instance:    inst,
-		display:     displayState,
-		vncListener: vncListener,
-		vncServer:   vncServer,
+		id:                 id,
+		image:              req.Image,
+		initSystem:         req.InitSystem,
+		kernel:             req.Kernel,
+		memoryMB:           req.MemoryMB,
+		balloonMB:          req.BalloonMB,
+		cpus:               req.CPUs,
+		nestedVirt:         req.NestedVirt,
+		sharedMemoryConfig: cloneSharedMemoryConfig(req.SharedMemory),
+		startedAt:          time.Now().UTC(),
+		instance:           inst,
+		display:            displayState,
+		vncListener:        vncListener,
+		vncServer:          vncServer,
+		sharedMemory:       attachment,
 	}
 
 	m.mu.Lock()
@@ -543,6 +596,7 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 		}
 		_ = vncServer.Close()
 		start.cleanupErr = inst.Close()
+		start.cleanupErr = errors.Join(start.cleanupErr, attachment.Release())
 		close(start.done)
 		return client.InstanceState{}, errors.Join(ErrManagerClosing, start.cleanupErr)
 	}
@@ -592,6 +646,12 @@ func (m *Manager) StartBlankInstanceStream(
 	req.Display = display
 	if display != nil && (strings.TrimSpace(req.SnapshotDir) != "" || strings.TrimSpace(req.RestoreSnapshot) != "") {
 		return client.InstanceState{}, fmt.Errorf("display-enabled VMs do not support startup snapshots")
+	}
+	if req.SharedMemory != nil && (strings.TrimSpace(req.SnapshotDir) != "" || strings.TrimSpace(req.RestoreSnapshot) != "") {
+		return client.InstanceState{}, fmt.Errorf("shared-memory VMs do not support startup snapshots")
+	}
+	if err := validateSharedMemoryRequest(req.SharedMemory); err != nil {
+		return client.InstanceState{}, err
 	}
 	canonicalShares, err := mounts.CanonicalRuntimeShares(req.Shares)
 	if err != nil {
@@ -645,14 +705,29 @@ func (m *Manager) StartBlankInstanceStream(
 	if !startupShares {
 		req.Shares = nil
 	}
-	inst, err := m.host.StartBlankStream(startCtx, req, onEvent)
+	attachment, err := m.attachSharedMemory(req.SharedMemory)
 	if err != nil {
 		m.finishStart(id, start)
 		return client.InstanceState{}, err
 	}
+	if attachment != nil {
+		startCtx = shmem.WithAttachment(startCtx, attachment)
+	}
+	inst, err := m.host.StartBlankStream(startCtx, req, onEvent)
+	if err != nil {
+		_ = attachment.Release()
+		m.finishStart(id, start)
+		return client.InstanceState{}, err
+	}
+	if attachment != nil && !attachment.Claimed() {
+		closeErr := inst.Close()
+		releaseErr := attachment.Release()
+		m.finishStart(id, start)
+		return client.InstanceState{}, errors.Join(fmt.Errorf("VM backend does not support shared memory"), closeErr, releaseErr)
+	}
 	if !startupShares {
 		if err := addInstanceShares(startCtx, inst, shares); err != nil {
-			start.cleanupErr = inst.Close()
+			start.cleanupErr = errors.Join(inst.Close(), attachment.Release())
 			m.finishStart(id, start)
 			return client.InstanceState{}, errors.Join(err, start.cleanupErr)
 		}
@@ -660,24 +735,27 @@ func (m *Manager) StartBlankInstanceStream(
 	displayState, vncListener, vncServer, err := startVNCServer(inst, id, display)
 	if err != nil {
 		closeErr := inst.Close()
+		releaseErr := attachment.Release()
 		m.finishStart(id, start)
-		return client.InstanceState{}, errors.Join(err, closeErr)
+		return client.InstanceState{}, errors.Join(err, closeErr, releaseErr)
 	}
 
 	machine := &Machine{
-		id:          id,
-		image:       req.Image,
-		initSystem:  req.InitSystem,
-		kernel:      req.Kernel,
-		memoryMB:    req.MemoryMB,
-		balloonMB:   req.BalloonMB,
-		cpus:        req.CPUs,
-		nestedVirt:  req.NestedVirt,
-		startedAt:   time.Now().UTC(),
-		instance:    inst,
-		display:     displayState,
-		vncListener: vncListener,
-		vncServer:   vncServer,
+		id:                 id,
+		image:              req.Image,
+		initSystem:         req.InitSystem,
+		kernel:             req.Kernel,
+		memoryMB:           req.MemoryMB,
+		balloonMB:          req.BalloonMB,
+		cpus:               req.CPUs,
+		nestedVirt:         req.NestedVirt,
+		sharedMemoryConfig: cloneSharedMemoryConfig(req.SharedMemory),
+		startedAt:          time.Now().UTC(),
+		instance:           inst,
+		display:            displayState,
+		vncListener:        vncListener,
+		vncServer:          vncServer,
+		sharedMemory:       attachment,
 	}
 
 	m.mu.Lock()
@@ -694,6 +772,7 @@ func (m *Manager) StartBlankInstanceStream(
 		}
 		_ = vncServer.Close()
 		start.cleanupErr = inst.Close()
+		start.cleanupErr = errors.Join(start.cleanupErr, attachment.Release())
 		close(start.done)
 		return client.InstanceState{}, errors.Join(ErrManagerClosing, start.cleanupErr)
 	}
@@ -858,7 +937,7 @@ func (m *Manager) runMachineStop(machine *Machine, stop *machineStopOperation) {
 	if errors.Is(vncErr, net.ErrClosed) {
 		vncErr = nil
 	}
-	err := errors.Join(vncErr, machine.vncServer.Close(), machine.instance.Close())
+	err := errors.Join(vncErr, machine.vncServer.Close(), machine.instance.Close(), machine.sharedMemory.Release())
 	machine.lifecycleMu.Unlock()
 	m.mu.Lock()
 	stop.err = err
@@ -1314,17 +1393,18 @@ func (m *Manager) statusSnapshotLocked(id string) managerStatusSnapshot {
 	}
 	machine := m.running[id]
 	state := client.InstanceState{
-		ID:         id,
-		Status:     "running",
-		Image:      machine.image,
-		InitSystem: machine.initSystem,
-		Kernel:     machine.kernel,
-		MemoryMB:   machine.memoryMB,
-		BalloonMB:  machine.balloonMB,
-		CPUs:       machine.cpus,
-		NestedVirt: machine.nestedVirt,
-		StartedAt:  machine.startedAt.Format(time.RFC3339Nano),
-		Display:    machine.display,
+		ID:           id,
+		Status:       "running",
+		Image:        machine.image,
+		InitSystem:   machine.initSystem,
+		Kernel:       machine.kernel,
+		MemoryMB:     machine.memoryMB,
+		BalloonMB:    machine.balloonMB,
+		CPUs:         machine.cpus,
+		NestedVirt:   machine.nestedVirt,
+		SharedMemory: cloneSharedMemoryConfig(machine.sharedMemoryConfig),
+		StartedAt:    machine.startedAt.Format(time.RFC3339Nano),
+		Display:      machine.display,
 	}
 	snapshot := managerStatusSnapshot{id: id, machine: machine, state: state}
 	if machine.stopping {
@@ -1501,6 +1581,7 @@ func saturatingUint64Add(a, b uint64) uint64 {
 
 func (m *Manager) watch(machine *Machine) {
 	err := machine.instance.Wait()
+	err = errors.Join(err, machine.sharedMemory.Release())
 	if machine.vncListener != nil {
 		_ = machine.vncListener.Close()
 	}
@@ -1529,7 +1610,7 @@ func (m *Manager) recordExitLocked(machine *Machine, err error) {
 	if m.exited == nil {
 		m.exited = make(map[string]client.InstanceState)
 	}
-	state := client.InstanceState{ID: machine.id, Status: "stopped", Image: machine.image, InitSystem: machine.initSystem, Kernel: machine.kernel, MemoryMB: machine.memoryMB, BalloonMB: machine.balloonMB, CPUs: machine.cpus, NestedVirt: machine.nestedVirt, StartedAt: machine.startedAt.Format(time.RFC3339), ExitedAt: machine.exitedAt.Format(time.RFC3339)}
+	state := client.InstanceState{ID: machine.id, Status: "stopped", Image: machine.image, InitSystem: machine.initSystem, Kernel: machine.kernel, MemoryMB: machine.memoryMB, BalloonMB: machine.balloonMB, CPUs: machine.cpus, NestedVirt: machine.nestedVirt, SharedMemory: cloneSharedMemoryConfig(machine.sharedMemoryConfig), StartedAt: machine.startedAt.Format(time.RFC3339), ExitedAt: machine.exitedAt.Format(time.RFC3339)}
 	if err != nil {
 		state.Status = "crashed"
 		state.Error = boundedLifecycleDiagnostic(err.Error())


### PR DESCRIPTION
## Summary

- add a daemon-owned, reference-counted shared-memory domain registry
- define a structured MMIO descriptor ABI with synchronous mapping and explicit status/error codes
- map borrowed shared backing into managed Linux guests on KVM amd64 and arm64
- validate alignment, overlap, lifecycle, quotas, and snapshot incompatibility
- expose shared-memory configuration through the client protocol and OpenAPI schema

## Why

This provides the runtime half of tinyrange/vmsh#40. Multiple long-lived VMs attached to the same domain can request an identical region ID and receive the same underlying allocation without copying.

HVF and WHP intentionally reject unclaimed attachments until their borrowed-mapping teardown paths are implemented.

## Validation

- `go test ./...`
- Linux amd64 cross-build: `GOOS=linux GOARCH=amd64 go test -exec=true ./internal/hv/kvm ./internal/vm ./internal/shmem`
- Linux arm64 cross-build: `GOOS=linux GOARCH=arm64 go test -exec=true ./internal/hv/kvm ./internal/vm ./internal/shmem`
- Windows amd64/arm64 registry and VM-manager cross-builds

Hardware validation still requires a Linux KVM host capable of running two VMs concurrently.