### PR TITLE
Stop HVF devices before unmapping memory

### DIFF
--- a/internal/hv/hvf/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings_darwin_arm64.go
@@ -288,24 +288,27 @@ func registerOptionalLibFunc(fptr any, handle uintptr, name string) bool {
 }
 
 type VM struct {
-	vcpu        VCPU
-	vcpuCreated bool
-	exitInfo    *VcpuExit
-	vcpus       []*hvfVCPU
-	mappings    []mapping
-	mappingsMu  sync.RWMutex
-	fastMem     []byte
-	fastMemBase uint64
-	fastMemEnd  uint64
-	gicMu       sync.Mutex
-	threadCh    chan func()
-	threadMu    sync.Mutex
-	closed      bool
-	dit         bool
-	mdscrEL1    uint64
-	osdlrEL1    uint64
-	nestedVirt  bool
-	osLock      bool
+	vcpu          VCPU
+	vcpuCreated   bool
+	exitInfo      *VcpuExit
+	vcpus         []*hvfVCPU
+	mappings      []mapping
+	mappingsMu    sync.RWMutex
+	lifecycleMu   sync.Mutex
+	memoryDetach  []func()
+	memoryClosing bool
+	fastMem       []byte
+	fastMemBase   uint64
+	fastMemEnd    uint64
+	gicMu         sync.Mutex
+	threadCh      chan func()
+	threadMu      sync.Mutex
+	closed        bool
+	dit           bool
+	mdscrEL1      uint64
+	osdlrEL1      uint64
+	nestedVirt    bool
+	osLock        bool
 }
 
 type hvfVCPU struct {
@@ -1328,6 +1331,16 @@ func (v *VM) Close() error {
 			v.vcpu = 0
 		}
 	}
+	v.lifecycleMu.Lock()
+	v.memoryClosing = true
+	detaches := v.memoryDetach
+	v.memoryDetach = nil
+	v.lifecycleMu.Unlock()
+	for _, detach := range detaches {
+		if detach != nil {
+			detach()
+		}
+	}
 	v.mappingsMu.Lock()
 	mappings := append([]mapping(nil), v.mappings...)
 	v.mappings = nil
@@ -1364,6 +1377,23 @@ func (v *VM) Close() error {
 	}
 	v.closeThreads()
 	return firstErr
+}
+
+// RegisterGuestMemoryDetach registers work that must finish before guest
+// memory is unmapped. Devices with asynchronous host-side workers use this to
+// stop dereferencing virtqueues during VM teardown.
+func (v *VM) RegisterGuestMemoryDetach(detach func()) {
+	if v == nil || detach == nil {
+		return
+	}
+	v.lifecycleMu.Lock()
+	if v.memoryClosing {
+		v.lifecycleMu.Unlock()
+		detach()
+		return
+	}
+	v.memoryDetach = append(v.memoryDetach, detach)
+	v.lifecycleMu.Unlock()
 }
 
 type ExceptionClass uint64

--- a/internal/hv/hvf/container_darwin_arm64.go
+++ b/internal/hv/hvf/container_darwin_arm64.go
@@ -1489,6 +1489,10 @@ func startPersistentContainer(ctx context.Context, req ContainerRunRequest, onEv
 	go func() {
 		defer close(closeDone)
 		defer func() {
+			_ = vm.Close()
+			exitTiming.Dump()
+		}()
+		defer func() {
 			var errs []error
 			for _, device := range fsdevs {
 				if device != nil {
@@ -1498,8 +1502,7 @@ func startPersistentContainer(ctx context.Context, req ContainerRunRequest, onEv
 			fsCloseErr = errors.Join(errs...)
 		}()
 		defer func() {
-			_ = vm.Close()
-			exitTiming.Dump()
+			_ = vsock.Close()
 		}()
 		defer cancel()
 		runner := newVMRunManager(vm)

--- a/internal/virtio/vsock.go
+++ b/internal/virtio/vsock.go
@@ -110,9 +110,22 @@ func NewVsock(base, size uint64, irq uint32, guestCID uint64, backend VsockBacke
 
 func (v *Vsock) Attach(mem GuestMemory, irq IRQController) {
 	v.mu.Lock()
-	defer v.mu.Unlock()
 	v.mem = mem
 	v.irq = irq
+	v.mu.Unlock()
+	if registrar, ok := mem.(guestMemoryDetachRegistrar); ok {
+		registrar.RegisterGuestMemoryDetach(v.Detach)
+	}
+}
+
+// Detach prevents asynchronous backend readers from touching guest memory
+// after the hypervisor starts unmapping it.
+func (v *Vsock) Detach() {
+	v.mu.Lock()
+	v.mem = nil
+	v.irq = nil
+	v.pendingRx = nil
+	v.mu.Unlock()
 }
 
 func (v *Vsock) Contains(addr uint64, size int) bool {
@@ -849,6 +862,11 @@ func (v *Vsock) configBytesLocked() []byte {
 }
 
 func (v *Vsock) resetLocked() {
+	for _, conn := range v.connections {
+		if conn != nil && conn.backend != nil {
+			_ = conn.backend.Close()
+		}
+	}
 	v.deviceFeatureSel = 0
 	v.driverFeatureSel = 0
 	v.driverFeatures = 0

--- a/internal/virtio/vsock_credit_test.go
+++ b/internal/virtio/vsock_credit_test.go
@@ -84,6 +84,65 @@ func TestVsockBackendDeliveryWaitsForPeerCredit(t *testing.T) {
 	waitForVsockTxCount(t, device, key, 8)
 }
 
+func TestVsockDetachesBeforeGuestMemoryIsReleased(t *testing.T) {
+	memory := &lifecycleTestNetMemory{testGuestMemory: make(testGuestMemory, 4096)}
+	device := NewVsock(0, 0x1000, 11, 3, nil)
+	device.Attach(memory, &testIRQ{})
+	if memory.detach == nil {
+		t.Fatal("vsock did not register a guest-memory detach callback")
+	}
+
+	device.pendingRx = [][]byte{{1, 2, 3}}
+	memory.detach()
+	device.mu.Lock()
+	defer device.mu.Unlock()
+	if device.mem != nil || device.irq != nil || len(device.pendingRx) != 0 {
+		t.Fatal("vsock retained guest-memory state after detach")
+	}
+	if err := device.processRXLocked(); err != nil {
+		t.Fatalf("detached RX processing returned an error: %v", err)
+	}
+}
+
+func TestVsockResetClosesDiscardedConnections(t *testing.T) {
+	backend := NewSimpleVsockBackend()
+	listener, err := backend.Listen(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	clientConn, err := backend.Connect(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+	serverConn, err := listener.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device := NewVsock(0, 0, 0, 3, backend)
+	key := vsockConnKey{localPort: 1024, remotePort: 2048}
+	device.connections[key] = &vsockConnection{
+		key: key, state: vsockConnStateConnected, backend: serverConn,
+	}
+	device.wg.Add(1)
+	readDone := make(chan struct{})
+	go func() {
+		device.readFromBackend(serverConn, key)
+		close(readDone)
+	}()
+
+	device.mu.Lock()
+	device.resetLocked()
+	device.mu.Unlock()
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("vsock reset left a discarded connection reader running")
+	}
+}
+
 func waitForVsockTxCount(t *testing.T, device *Vsock, key vsockConnKey, want uint32) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)


### PR DESCRIPTION
## What changed

- detach asynchronous virtio devices before Hypervisor.framework unmaps guest memory
- close vsock and filesystem devices before destroying the HVF VM
- close discarded vsock connections during device reset
- cover guest-memory detachment and reset reader cleanup with regression tests

## Why

Stopping SquadVM could race a vsock backend reader against HVF guest-memory teardown. Pressing Escape could therefore fault in `ReadIPAInto` while the VM was being destroyed. Guest-initiated poweroff also exposed a discarded vsock connection whose reader never stopped.

## Impact

HVF shutdown now waits for asynchronous device work to detach before releasing guest mappings. Both host-requested shutdown and guest poweroff terminate cleanly without retaining backend readers.

## Validation

- `go test ./...`
- `go test ./internal/virtio ./internal/hv/hvf`
- `go test ./internal/vm -run '^TestRuntimeGuestPoweroffTerminatesSessionAndActiveCommand$' -count=1 -v`
