### PR TITLE
Fix serial console output and expose guest cursor

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -16,6 +16,18 @@ type FramebufferUpdate struct {
 	Pixels     []byte
 }
 
+// CursorUpdate is the guest-provided ARGB cursor image. Pixels are tightly
+// packed in blue, green, red, alpha byte order.
+type CursorUpdate struct {
+	Width      int
+	Height     int
+	HotX       int
+	HotY       int
+	Visible    bool
+	Generation uint64
+	Pixels     []byte
+}
+
 // Session provides direct access to a running VM's graphical desktop. Key
 // accepts Linux input-event key codes. Pointer uses absolute guest coordinates
 // and the conventional VNC button mask: left=1, middle=2, right=4, wheel=8/16.
@@ -35,4 +47,10 @@ type Session interface {
 // conventional wheel detent.
 type HighResolutionScroller interface {
 	Scroll(deltaX120, deltaY120 int32) error
+}
+
+// CursorProvider is implemented by display sessions that expose the guest's
+// hardware cursor independently from the framebuffer.
+type CursorProvider interface {
+	Cursor() CursorUpdate
 }

--- a/internal/amd64vm/boot.go
+++ b/internal/amd64vm/boot.go
@@ -57,7 +57,6 @@ func BootCommandLine(dmesg bool, extra ...string) string {
 	if dmesg {
 		args = append([]string{
 			fmt.Sprintf("earlycon=uart8250,io,0x%x,115200n8", COM1Base),
-			"keep_bootcon",
 			"loglevel=8",
 		}, args...)
 	}

--- a/internal/arm64vm/boot.go
+++ b/internal/arm64vm/boot.go
@@ -43,7 +43,6 @@ func BootCommandLine(dmesg bool, serialConsole bool) string {
 	if dmesg {
 		args = append([]string{
 			fmt.Sprintf("earlycon=uart8250,mmio,0x%x", bootarm64.DefaultUARTBase),
-			"keep_bootcon",
 			"loglevel=8",
 		}, args...)
 	}

--- a/internal/virtio/display.go
+++ b/internal/virtio/display.go
@@ -26,6 +26,62 @@ type FramebufferUpdate struct {
 	Pixels     []byte
 }
 
+type CursorUpdate struct {
+	Width      int
+	Height     int
+	HotX       int
+	HotY       int
+	Visible    bool
+	Generation uint64
+	Pixels     []byte
+}
+
+// Cursor is the host-visible virtio-gpu cursor plane.
+type Cursor struct {
+	mu         sync.Mutex
+	width      int
+	height     int
+	hotX       int
+	hotY       int
+	visible    bool
+	generation uint64
+	pixels     []byte
+}
+
+func (c *Cursor) Update(width, height, hotX, hotY int, pixels []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.width = width
+	c.height = height
+	c.hotX = hotX
+	c.hotY = hotY
+	c.visible = true
+	// Publish a new immutable backing slice so snapshots can be consumed after
+	// releasing the lock without racing the next cursor update.
+	c.pixels = append([]byte(nil), pixels...)
+	c.generation++
+}
+
+func (c *Cursor) Hide() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.visible {
+		return
+	}
+	c.visible = false
+	c.generation++
+}
+
+func (c *Cursor) Snapshot() CursorUpdate {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return CursorUpdate{
+		Width: c.width, Height: c.height, HotX: c.hotX, HotY: c.hotY,
+		Visible: c.visible, Generation: c.generation,
+		Pixels: c.pixels,
+	}
+}
+
 func NewFramebuffer(width, height int) (*Framebuffer, error) {
 	if width <= 0 || height <= 0 {
 		return nil, fmt.Errorf("framebuffer dimensions must be positive")

--- a/internal/virtio/display_test.go
+++ b/internal/virtio/display_test.go
@@ -174,6 +174,59 @@ func TestGPUCursorQueueDoesNotRequireResponseBuffer(t *testing.T) {
 	}
 }
 
+func TestGPUCursorUpdatePublishesGuestShape(t *testing.T) {
+	mem := make(testGuestMemory, 64<<10)
+	framebuffer, err := NewFramebuffer(800, 600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gpu := NewGPU(0x1000, 0x1000, 9, framebuffer)
+	gpu.Attach(mem, &testIRQ{})
+
+	create := gpuTestRequest(gpuCmdResourceCreate2D, 40)
+	binary.LittleEndian.PutUint32(create[24:28], 7)
+	binary.LittleEndian.PutUint32(create[28:32], gpuFormatB8G8R8A8)
+	binary.LittleEndian.PutUint32(create[32:36], 2)
+	binary.LittleEndian.PutUint32(create[36:40], 2)
+	requireGPUResponse(t, gpu.dispatchLocked(create, gpuQueueControl), gpuRespOKNoData)
+
+	pixels := []byte{
+		0, 0, 0, 0, 10, 20, 30, 255,
+		40, 50, 60, 128, 70, 80, 90, 255,
+	}
+	copy(mem[0x4000:], pixels)
+	attach := gpuTestRequest(gpuCmdResourceAttachBacking, 48)
+	binary.LittleEndian.PutUint32(attach[24:28], 7)
+	binary.LittleEndian.PutUint32(attach[28:32], 1)
+	binary.LittleEndian.PutUint64(attach[32:40], 0x4000)
+	binary.LittleEndian.PutUint32(attach[40:44], uint32(len(pixels)))
+	requireGPUResponse(t, gpu.dispatchLocked(attach, gpuQueueControl), gpuRespOKNoData)
+
+	transfer := gpuTestRequest(gpuCmdTransferToHost2D, 56)
+	putGPUTestRect(transfer[24:40], 0, 0, 2, 2)
+	binary.LittleEndian.PutUint32(transfer[48:52], 7)
+	requireGPUResponse(t, gpu.dispatchLocked(transfer, gpuQueueControl), gpuRespOKNoData)
+
+	update := gpuTestRequest(gpuCmdUpdateCursor, 56)
+	binary.LittleEndian.PutUint32(update[40:44], 7)
+	binary.LittleEndian.PutUint32(update[44:48], 1)
+	requireGPUResponse(t, gpu.dispatchLocked(update, gpuQueueCursor), gpuRespOKNoData)
+
+	cursor := gpu.Cursor().Snapshot()
+	if !cursor.Visible || cursor.Width != 2 || cursor.Height != 2 || cursor.HotX != 1 || cursor.HotY != 0 {
+		t.Fatalf("cursor metadata = %+v", cursor)
+	}
+	if !bytes.Equal(cursor.Pixels, pixels) {
+		t.Fatalf("cursor pixels = %v, want %v", cursor.Pixels, pixels)
+	}
+
+	hide := gpuTestRequest(gpuCmdUpdateCursor, 56)
+	requireGPUResponse(t, gpu.dispatchLocked(hide, gpuQueueCursor), gpuRespOKNoData)
+	if cursor := gpu.Cursor().Snapshot(); cursor.Visible {
+		t.Fatal("zero-resource cursor update did not hide the cursor")
+	}
+}
+
 func TestInputDeliversOrderedEventsToPostedBuffers(t *testing.T) {
 	mem := make(testGuestMemory, 64<<10)
 	irq := &testIRQ{}

--- a/internal/virtio/gpu.go
+++ b/internal/virtio/gpu.go
@@ -80,6 +80,8 @@ type GPU struct {
 	scanoutResource  uint32
 	scanoutRect      image.Rectangle
 	framebuffer      *Framebuffer
+	cursor           *Cursor
+	cursorResource   uint32
 }
 
 func NewGPU(base, size uint64, irq uint32, framebuffer *Framebuffer) *GPU {
@@ -88,6 +90,7 @@ func NewGPU(base, size uint64, irq uint32, framebuffer *Framebuffer) *GPU {
 		Size:        size,
 		IRQ:         irq,
 		framebuffer: framebuffer,
+		cursor:      &Cursor{},
 	}
 	g.resetLocked()
 	return g
@@ -95,6 +98,10 @@ func NewGPU(base, size uint64, irq uint32, framebuffer *Framebuffer) *GPU {
 
 func (g *GPU) Framebuffer() *Framebuffer {
 	return g.framebuffer
+}
+
+func (g *GPU) Cursor() *Cursor {
+	return g.cursor
 }
 
 func (g *GPU) Resize(width, height int) error {
@@ -390,6 +397,10 @@ func (g *GPU) dispatchLocked(request []byte, queueIndex int) []byte {
 			return gpuResponse(request, gpuRespErrInvalidResourceID, nil)
 		}
 		delete(g.resources, id)
+		if g.cursorResource == id {
+			g.cursorResource = 0
+			g.cursor.Hide()
+		}
 		if g.scanoutResource == id {
 			g.scanoutResource = 0
 			g.scanoutRect = image.Rectangle{}
@@ -518,8 +529,26 @@ func (g *GPU) dispatchLocked(request []byte, queueIndex int) []byte {
 		if binary.LittleEndian.Uint32(request[24:28]) != 0 {
 			return gpuResponse(request, gpuRespErrInvalidScanoutID, nil)
 		}
-		// Cursor shape transport is accepted here; the first RFB version uses
-		// the viewer's local pointer until cursor pseudo-encoding is enabled.
+		if command == gpuCmdMoveCursor {
+			return gpuResponse(request, gpuRespOKNoData, nil)
+		}
+		id := binary.LittleEndian.Uint32(request[40:44])
+		if id == 0 {
+			g.cursorResource = 0
+			g.cursor.Hide()
+			return gpuResponse(request, gpuRespOKNoData, nil)
+		}
+		resource := g.resources[id]
+		if resource == nil {
+			return gpuResponse(request, gpuRespErrInvalidResourceID, nil)
+		}
+		hotX := binary.LittleEndian.Uint32(request[44:48])
+		hotY := binary.LittleEndian.Uint32(request[48:52])
+		if hotX >= resource.width || hotY >= resource.height {
+			return gpuResponse(request, gpuRespErrInvalidParameter, nil)
+		}
+		g.cursorResource = id
+		g.cursor.Update(int(resource.width), int(resource.height), int(hotX), int(hotY), resource.pixels)
 		return gpuResponse(request, gpuRespOKNoData, nil)
 	}
 	return gpuResponse(request, gpuRespErrUnspecified, nil)
@@ -660,6 +689,8 @@ func (g *GPU) resetLocked() {
 	g.resources = make(map[uint32]*gpuResource)
 	g.scanoutResource = 0
 	g.scanoutRect = image.Rectangle{}
+	g.cursorResource = 0
+	g.cursor.Hide()
 	for index := range g.queues {
 		g.queues[index] = queue{}
 	}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -429,6 +429,17 @@ func (s desktopSession) Changed() <-chan struct{} {
 	return s.desktop.Framebuffer.Changed()
 }
 
+func (s desktopSession) Cursor() display.CursorUpdate {
+	if s.desktop.GPU == nil || s.desktop.GPU.Cursor() == nil {
+		return display.CursorUpdate{}
+	}
+	update := s.desktop.GPU.Cursor().Snapshot()
+	return display.CursorUpdate{
+		Width: update.Width, Height: update.Height, HotX: update.HotX, HotY: update.HotY,
+		Visible: update.Visible, Generation: update.Generation, Pixels: update.Pixels,
+	}
+}
+
 func (s desktopSession) Resize(width, height int) error {
 	return s.desktop.Resize(width, height)
 }


### PR DESCRIPTION
## Summary

- stop duplicate serial output after the normal UART console registers
- retain virtio-gpu cursor images and expose them to direct display frontends

## Root causes

With dmesg enabled, `earlycon` and the normal `ttyS0` console target the same UART. `keep_bootcon` retained both after ttyS0 came online, causing every later line to be emitted twice.

The virtio-gpu cursor queue accepted update commands but discarded the referenced cursor resource. The new host-visible cursor plane retains the guest image, hotspot, visibility, and generation independently from the framebuffer.

## Validation

- `go test ./internal/amd64vm ./internal/arm64vm`
- `go test ./internal/virtio ./internal/vm ./display`
- `go vet ./internal/virtio ./internal/vm ./display`
- full SquadVM boot on Windows/WHP with serial output appearing once
- Windows interactive-session validation that the active cursor is guest-created rather than the stock host arrow
