### PR TITLE
Prevent shared-folder rename corruption

### DIFF
--- a/internal/virtio/fs_backends.go
+++ b/internal/virtio/fs_backends.go
@@ -34,13 +34,18 @@ type passthroughFS struct {
 	nodes      map[uint64]string
 	pathToNode map[string]uint64
 	handles    map[uint64]*passthroughHandle
-	dirHandles map[uint64][]dirEntry
+	dirHandles map[uint64]*passthroughDirHandle
 }
 
 type passthroughHandle struct {
 	nodeID uint64
 	file   *os.File
 	append bool
+}
+
+type passthroughDirHandle struct {
+	nodeID  uint64
+	entries []dirEntry
 }
 
 type imageFS struct {
@@ -367,7 +372,7 @@ func newPassthroughFS(root string, meta map[string]fsmeta.Entry, uid, gid uint32
 		nodes:      map[uint64]string{1: "/"},
 		pathToNode: map[string]uint64{"/": 1},
 		handles:    map[uint64]*passthroughHandle{},
-		dirHandles: map[uint64][]dirEntry{},
+		dirHandles: map[uint64]*passthroughDirHandle{},
 	}
 	return fs
 }
@@ -912,13 +917,26 @@ func (p *passthroughFS) Lseek(nodeID uint64, fh uint64, offset uint64, whence ui
 
 func (p *passthroughFS) OpenDir(nodeID uint64, _ uint32) (uint64, int32) {
 	p.logNode("opendir", nodeID)
-	host, guest, errno := p.hostAndGuestPath(nodeID)
+	dirEntries, errno := p.readDirEntries(nodeID)
 	if errno != 0 {
 		return 0, errno
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	handle := p.nextHandle
+	p.nextHandle++
+	p.dirHandles[handle] = &passthroughDirHandle{nodeID: nodeID, entries: dirEntries}
+	return handle, 0
+}
+
+func (p *passthroughFS) readDirEntries(nodeID uint64) ([]dirEntry, int32) {
+	host, guest, errno := p.hostAndGuestPath(nodeID)
+	if errno != 0 {
+		return nil, errno
+	}
 	entries, err := os.ReadDir(host)
 	if err != nil {
-		return 0, errnoFromError(err)
+		return nil, errnoFromError(err)
 	}
 	parentID := nodeID
 	if guest != "/" {
@@ -937,12 +955,7 @@ func (p *passthroughFS) OpenDir(nodeID uint64, _ uint32) (uint64, int32) {
 			ino:  childID,
 		})
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	handle := p.nextHandle
-	p.nextHandle++
-	p.dirHandles[handle] = dirEntries
-	return handle, 0
+	return dirEntries, 0
 }
 
 func (p *passthroughFS) Write(nodeID uint64, fh uint64, off uint64, data []byte, _ uint32) (uint32, int32) {
@@ -967,13 +980,27 @@ func (p *passthroughFS) Write(nodeID uint64, fh uint64, off uint64, data []byte,
 	return uint32(n), 0
 }
 
-func (p *passthroughFS) ReadDir(_ uint64, fh uint64, off uint64, maxBytes uint32) ([]byte, int32) {
-	p.mu.Lock()
-	entries := append([]dirEntry(nil), p.dirHandles[fh]...)
-	p.mu.Unlock()
-	if entries == nil {
+func (p *passthroughFS) ReadDir(nodeID uint64, fh uint64, off uint64, maxBytes uint32) ([]byte, int32) {
+	p.mu.RLock()
+	handle := p.dirHandles[fh]
+	p.mu.RUnlock()
+	if handle == nil || handle.nodeID != nodeID {
 		return nil, -linuxEBADF
 	}
+	if off == 0 {
+		entries, errno := p.readDirEntries(nodeID)
+		if errno != 0 {
+			return nil, errno
+		}
+		p.mu.Lock()
+		if current := p.dirHandles[fh]; current == handle {
+			handle.entries = entries
+		}
+		p.mu.Unlock()
+	}
+	p.mu.RLock()
+	entries := append([]dirEntry(nil), handle.entries...)
+	p.mu.RUnlock()
 	var out []byte
 	for i := int(off); i < len(entries); i++ {
 		entry := entries[i]

--- a/internal/virtio/fs_backends.go
+++ b/internal/virtio/fs_backends.go
@@ -46,6 +46,7 @@ type passthroughHandle struct {
 type passthroughDirHandle struct {
 	nodeID  uint64
 	entries []dirEntry
+	started bool
 }
 
 type imageFS struct {
@@ -981,13 +982,18 @@ func (p *passthroughFS) Write(nodeID uint64, fh uint64, off uint64, data []byte,
 }
 
 func (p *passthroughFS) ReadDir(nodeID uint64, fh uint64, off uint64, maxBytes uint32) ([]byte, int32) {
-	p.mu.RLock()
+	p.mu.Lock()
 	handle := p.dirHandles[fh]
-	p.mu.RUnlock()
 	if handle == nil || handle.nodeID != nodeID {
+		p.mu.Unlock()
 		return nil, -linuxEBADF
 	}
+	refresh := off == 0 && handle.started
 	if off == 0 {
+		handle.started = true
+	}
+	p.mu.Unlock()
+	if refresh {
 		entries, errno := p.readDirEntries(nodeID)
 		if errno != 0 {
 			return nil, errno
@@ -1085,7 +1091,7 @@ func (p *passthroughFS) Unlink(parent uint64, name string) int32 {
 	return 0
 }
 
-func (p *passthroughFS) Rename(parent uint64, name string, newParent uint64, newName string, _ uint32) int32 {
+func (p *passthroughFS) Rename(parent uint64, name string, newParent uint64, newName string, flags uint32) int32 {
 	oldParent, oldGuestParent, errno := p.hostAndGuestPath(parent)
 	if errno != 0 {
 		return errno
@@ -1094,14 +1100,49 @@ func (p *passthroughFS) Rename(parent uint64, name string, newParent uint64, new
 	if errno != 0 {
 		return errno
 	}
-	oldRel := strings.TrimPrefix(path.Clean("/"+name), "/")
-	newRel := strings.TrimPrefix(path.Clean("/"+newName), "/")
+	oldRel, ok := cleanChildName(name)
+	if !ok {
+		return -linuxEINVAL
+	}
+	newRel, ok := cleanChildName(newName)
+	if !ok {
+		return -linuxEINVAL
+	}
+	if flags & ^uint32(linuxRenameNoReplace) != 0 {
+		return -linuxEINVAL
+	}
 	oldHost := filepath.Join(oldParent, filepath.FromSlash(oldRel))
 	newHost := filepath.Join(newParentPath, filepath.FromSlash(newRel))
-	if err := os.Rename(oldHost, newHost); err != nil {
+	oldGuest := joinGuestChild(oldGuestParent, oldRel)
+	newGuest := joinGuestChild(newGuestParent, newRel)
+	if oldGuest == newGuest {
+		return 0
+	}
+	oldInfo, err := os.Lstat(oldHost)
+	if err != nil {
 		return errnoFromError(err)
 	}
-	p.renameNodeGuestPath(joinGuestChild(oldGuestParent, oldRel), joinGuestChild(newGuestParent, newRel))
+	newInfo, newInfoErr := os.Lstat(newHost)
+	targetExists := newInfoErr == nil
+	if newInfoErr != nil && !errors.Is(newInfoErr, fs.ErrNotExist) {
+		return errnoFromError(newInfoErr)
+	}
+	sameFile := targetExists && os.SameFile(oldInfo, newInfo)
+	if flags&linuxRenameNoReplace != 0 {
+		err = renameNoReplace(oldHost, newHost)
+	} else {
+		err = os.Rename(oldHost, newHost)
+	}
+	if err != nil {
+		return errnoFromError(err)
+	}
+	// Renaming one hard link over another link to the same inode is a no-op:
+	// both directory entries remain. A case-only rename on a case-insensitive
+	// host does change the exact directory entry and still needs cache updates.
+	if sameFile && hostDirectoryHasExactEntry(oldHost) {
+		return 0
+	}
+	p.renameNodeGuestPath(oldGuest, newGuest)
 	return 0
 }
 
@@ -1254,11 +1295,70 @@ func (p *passthroughFS) removeNodeForGuestPath(guestPath string) {
 func (p *passthroughFS) renameNodeGuestPath(oldPath, newPath string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if id, ok := p.pathToNode[oldPath]; ok {
-		delete(p.pathToNode, oldPath)
-		p.pathToNode[newPath] = id
-		p.nodes[id] = newPath
+	oldPath = path.Clean(oldPath)
+	newPath = path.Clean(newPath)
+	if oldPath == newPath {
+		return
 	}
+	nodeUpdates := make(map[string]uint64)
+	for existingPath, id := range p.pathToNode {
+		if !pathWithin(existingPath, oldPath) {
+			continue
+		}
+		suffix := strings.TrimPrefix(existingPath, oldPath)
+		nodeUpdates[path.Clean(newPath+suffix)] = id
+	}
+	for existingPath, id := range p.pathToNode {
+		if pathWithin(existingPath, newPath) && !pathWithin(existingPath, oldPath) {
+			delete(p.pathToNode, existingPath)
+			delete(p.nodes, id)
+		}
+	}
+	for existingPath := range p.pathToNode {
+		if pathWithin(existingPath, oldPath) {
+			delete(p.pathToNode, existingPath)
+		}
+	}
+	for updatedPath, id := range nodeUpdates {
+		p.pathToNode[updatedPath] = id
+		p.nodes[id] = updatedPath
+	}
+	if p.meta != nil {
+		metaUpdates := make(map[string]fsmeta.Entry)
+		for existingPath, entry := range p.meta {
+			if !pathWithin(existingPath, oldPath) {
+				continue
+			}
+			suffix := strings.TrimPrefix(existingPath, oldPath)
+			metaUpdates[path.Clean(newPath+suffix)] = entry
+		}
+		for existingPath := range p.meta {
+			if pathWithin(existingPath, oldPath) || pathWithin(existingPath, newPath) {
+				delete(p.meta, existingPath)
+			}
+		}
+		for updatedPath, entry := range metaUpdates {
+			p.meta[updatedPath] = entry
+		}
+	}
+}
+
+func pathWithin(candidate, root string) bool {
+	return candidate == root || strings.HasPrefix(candidate, strings.TrimSuffix(root, "/")+"/")
+}
+
+func hostDirectoryHasExactEntry(hostPath string) bool {
+	entries, err := os.ReadDir(filepath.Dir(hostPath))
+	if err != nil {
+		return false
+	}
+	name := filepath.Base(hostPath)
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *passthroughFS) fileAttr(nodeID uint64, hostPath string, info os.FileInfo) FuseAttr {

--- a/internal/virtio/fs_passthrough_test.go
+++ b/internal/virtio/fs_passthrough_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"j5.nz/cc/internal/fsmeta"
 )
 
 func TestPassthroughFSParentLookupAndReadDirUseParentNode(t *testing.T) {
@@ -92,6 +94,146 @@ func TestPassthroughFSReadDirRefreshesWhenEnumerationRestarts(t *testing.T) {
 	}
 }
 
+func TestMountedPassthroughReadDirRefreshesWhenEnumerationRestarts(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "item.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "folder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewMountedFS(imageBackend(t, nil), []ShareMount{{
+		GuestPath: "/shared",
+		Backend:   NewPassthroughFS(root, nil),
+		Writable:  true,
+		CacheMode: fsCacheStrict,
+	}}).(*mountedFS)
+	sharedID, _, errno := fsys.Lookup(1, "shared")
+	if errno != 0 {
+		t.Fatalf("lookup share errno = %d", errno)
+	}
+	folderID, _, errno := fsys.Lookup(sharedID, "folder")
+	if errno != 0 {
+		t.Fatalf("lookup folder errno = %d", errno)
+	}
+	handle, errno := fsys.OpenDir(sharedID, 0)
+	if errno != 0 {
+		t.Fatalf("opendir share errno = %d", errno)
+	}
+	defer fsys.ReleaseDir(sharedID, handle)
+
+	entries := readTestPassthroughDir(t, fsys, sharedID, handle)
+	if _, ok := entries["item.txt"]; !ok {
+		t.Fatalf("initial mounted entries = %v", entries)
+	}
+	if errno := fsys.Rename(sharedID, "item.txt", folderID, "item.txt", 0); errno != 0 {
+		t.Fatalf("mounted move into folder errno = %d", errno)
+	}
+	entries = readTestPassthroughDir(t, fsys, sharedID, handle)
+	if _, ok := entries["item.txt"]; ok {
+		t.Fatalf("mounted entries after move still contain item.txt: %v", entries)
+	}
+	if errno := fsys.Rename(folderID, "item.txt", sharedID, "item.txt", 0); errno != 0 {
+		t.Fatalf("mounted move back errno = %d", errno)
+	}
+	entries = readTestPassthroughDir(t, fsys, sharedID, handle)
+	if _, ok := entries["item.txt"]; !ok {
+		t.Fatalf("mounted entries after move back = %v", entries)
+	}
+}
+
+func TestPassthroughFSRenamePreservesCachedDescendantIdentity(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "source", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "source", "nested", "item.txt"), []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := map[string]fsmeta.Entry{
+		"/source":                 {UID: 1000, GID: 1000},
+		"/source/nested/item.txt": {UID: 1000, GID: 1000},
+	}
+	fsys := NewPassthroughFS(root, meta)
+	renameFS := fsys.(fsRenameBackend)
+	sourceID := lookupTestPassthroughNode(t, fsys, 1, "source")
+	nestedID := lookupTestPassthroughNode(t, fsys, sourceID, "nested")
+	itemID := lookupTestPassthroughNode(t, fsys, nestedID, "item.txt")
+
+	if errno := renameFS.Rename(1, "source", 1, "moved", 0); errno != 0 {
+		t.Fatalf("rename directory errno = %d", errno)
+	}
+	if got := readTestPassthroughFile(t, fsys, itemID); got != "original" {
+		t.Fatalf("cached descendant after move = %q", got)
+	}
+	if _, ok := meta["/source/nested/item.txt"]; ok {
+		t.Fatalf("metadata retained old descendant path: %v", meta)
+	}
+	if _, ok := meta["/moved/nested/item.txt"]; !ok {
+		t.Fatalf("metadata did not follow moved descendant: %v", meta)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "source", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "source", "nested", "item.txt"), []byte("replacement"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readTestPassthroughFile(t, fsys, itemID); got != "original" {
+		t.Fatalf("cached descendant redirected into reused source path: %q", got)
+	}
+}
+
+func TestPassthroughFSRenameDetachesOverwrittenTargetNode(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "source.txt"), []byte("source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("target"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewPassthroughFS(root, nil)
+	renameFS := fsys.(fsRenameBackend)
+	sourceID := lookupTestPassthroughNode(t, fsys, 1, "source.txt")
+	targetID := lookupTestPassthroughNode(t, fsys, 1, "target.txt")
+	if errno := renameFS.Rename(1, "source.txt", 1, "target.txt", 0); errno != 0 {
+		t.Fatalf("overwrite target errno = %d", errno)
+	}
+	if _, errno := fsys.GetAttr(targetID); errno != -linuxENOENT {
+		t.Fatalf("overwritten target node getattr errno = %d, want %d", errno, -linuxENOENT)
+	}
+	if got := readTestPassthroughFile(t, fsys, sourceID); got != "source" {
+		t.Fatalf("renamed source data = %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(root, "source.txt"), []byte("replacement"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errno := fsys.GetAttr(targetID); errno != -linuxENOENT {
+		t.Fatalf("overwritten target node aliased a replacement: errno %d", errno)
+	}
+}
+
+func TestPassthroughFSRenameNoReplacePreservesBothFiles(t *testing.T) {
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "source.txt")
+	newPath := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(oldPath, []byte("source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("target"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewPassthroughFS(root, nil)
+	if errno := fsys.(fsRenameBackend).Rename(1, "source.txt", 1, "target.txt", linuxRenameNoReplace); errno != -linuxEEXIST {
+		t.Fatalf("noreplace errno = %d, want %d", errno, -linuxEEXIST)
+	}
+	if data, err := os.ReadFile(oldPath); err != nil || string(data) != "source" {
+		t.Fatalf("source after failed noreplace = %q, %v", data, err)
+	}
+	if data, err := os.ReadFile(newPath); err != nil || string(data) != "target" {
+		t.Fatalf("target after failed noreplace = %q, %v", data, err)
+	}
+}
+
 func readTestPassthroughDir(t *testing.T, fsys FSBackend, nodeID, handle uint64) map[string]uint64 {
 	t.Helper()
 	data, errno := fsys.ReadDir(nodeID, handle, 0, 4096)
@@ -99,6 +241,29 @@ func readTestPassthroughDir(t *testing.T, fsys FSBackend, nodeID, handle uint64)
 		t.Fatalf("readdir errno = %d", errno)
 	}
 	return parseTestFuseDirents(data)
+}
+
+func lookupTestPassthroughNode(t *testing.T, fsys FSBackend, parent uint64, name string) uint64 {
+	t.Helper()
+	nodeID, _, errno := fsys.Lookup(parent, name)
+	if errno != 0 {
+		t.Fatalf("lookup %q errno = %d", name, errno)
+	}
+	return nodeID
+}
+
+func readTestPassthroughFile(t *testing.T, fsys FSBackend, nodeID uint64) string {
+	t.Helper()
+	handle, errno := fsys.Open(nodeID, linuxORDONLY)
+	if errno != 0 {
+		t.Fatalf("open node %d errno = %d", nodeID, errno)
+	}
+	defer fsys.Release(nodeID, handle)
+	data, errno := fsys.Read(nodeID, handle, 0, 4096)
+	if errno != 0 {
+		t.Fatalf("read node %d errno = %d", nodeID, errno)
+	}
+	return string(data)
 }
 
 func parseTestFuseDirents(data []byte) map[string]uint64 {

--- a/internal/virtio/fs_passthrough_test.go
+++ b/internal/virtio/fs_passthrough_test.go
@@ -47,6 +47,60 @@ func TestPassthroughFSParentLookupAndReadDirUseParentNode(t *testing.T) {
 	}
 }
 
+func TestPassthroughFSReadDirRefreshesWhenEnumerationRestarts(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "item.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "folder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewPassthroughFS(root, nil)
+	renameFS, ok := fsys.(fsRenameBackend)
+	if !ok {
+		t.Fatal("passthrough filesystem does not support rename")
+	}
+	rootHandle, errno := fsys.OpenDir(1, 0)
+	if errno != 0 {
+		t.Fatalf("opendir root errno = %d", errno)
+	}
+	defer fsys.ReleaseDir(1, rootHandle)
+
+	entries := readTestPassthroughDir(t, fsys, 1, rootHandle)
+	if _, ok := entries["item.txt"]; !ok {
+		t.Fatalf("initial directory entries = %v", entries)
+	}
+
+	folderID, _, errno := fsys.Lookup(1, "folder")
+	if errno != 0 {
+		t.Fatalf("lookup folder errno = %d", errno)
+	}
+	if errno := renameFS.Rename(1, "item.txt", folderID, "item.txt", 0); errno != 0 {
+		t.Fatalf("move into folder errno = %d", errno)
+	}
+	entries = readTestPassthroughDir(t, fsys, 1, rootHandle)
+	if _, ok := entries["item.txt"]; ok {
+		t.Fatalf("entries after move still contain item.txt: %v", entries)
+	}
+
+	if errno := renameFS.Rename(folderID, "item.txt", 1, "item.txt", 0); errno != 0 {
+		t.Fatalf("move back to root errno = %d", errno)
+	}
+	entries = readTestPassthroughDir(t, fsys, 1, rootHandle)
+	if _, ok := entries["item.txt"]; !ok {
+		t.Fatalf("entries after move back = %v", entries)
+	}
+}
+
+func readTestPassthroughDir(t *testing.T, fsys FSBackend, nodeID, handle uint64) map[string]uint64 {
+	t.Helper()
+	data, errno := fsys.ReadDir(nodeID, handle, 0, 4096)
+	if errno != 0 {
+		t.Fatalf("readdir errno = %d", errno)
+	}
+	return parseTestFuseDirents(data)
+}
+
 func parseTestFuseDirents(data []byte) map[string]uint64 {
 	out := map[string]uint64{}
 	for off := 0; off+fuseDirentBaseSize <= len(data); {

--- a/internal/virtio/fs_rename_noreplace_darwin.go
+++ b/internal/virtio/fs_rename_noreplace_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package virtio
+
+import "golang.org/x/sys/unix"
+
+func renameNoReplace(oldPath, newPath string) error {
+	return unix.RenamexNp(oldPath, newPath, unix.RENAME_EXCL)
+}

--- a/internal/virtio/fs_rename_noreplace_linux.go
+++ b/internal/virtio/fs_rename_noreplace_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package virtio
+
+import "golang.org/x/sys/unix"
+
+func renameNoReplace(oldPath, newPath string) error {
+	return unix.Renameat2(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_NOREPLACE)
+}

--- a/internal/virtio/fs_rename_noreplace_other.go
+++ b/internal/virtio/fs_rename_noreplace_other.go
@@ -1,0 +1,17 @@
+//go:build !linux && !darwin && !windows
+
+package virtio
+
+import (
+	"io/fs"
+	"os"
+)
+
+func renameNoReplace(oldPath, newPath string) error {
+	if _, err := os.Lstat(newPath); err == nil {
+		return fs.ErrExist
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(oldPath, newPath)
+}

--- a/internal/virtio/fs_rename_noreplace_windows.go
+++ b/internal/virtio/fs_rename_noreplace_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package virtio
+
+import "golang.org/x/sys/windows"
+
+func renameNoReplace(oldPath, newPath string) error {
+	oldPathUTF16, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPathUTF16, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFile(oldPathUTF16, newPathUTF16)
+}

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -337,6 +337,7 @@ type mountedHandle struct {
 	fh      uint64
 	dir     bool
 	entries []dirEntry
+	started bool
 }
 
 type mountedBackendInode struct {
@@ -860,14 +861,37 @@ func (m *mountedFS) OpenDir(nodeID uint64, flags uint32) (uint64, int32) {
 }
 
 func (m *mountedFS) ReadDir(nodeID uint64, fh uint64, off uint64, maxBytes uint32) ([]byte, int32) {
-	if m.node(nodeID) == nil {
+	node := m.node(nodeID)
+	if node == nil {
 		return nil, -linuxENOENT
 	}
 	handle := m.handle(fh, true)
 	if handle == nil {
 		return nil, -linuxEBADF
 	}
-	return encodeDirEntries(handle.entries, off, maxBytes), 0
+	m.mu.Lock()
+	refresh := off == 0 && handle.started
+	if off == 0 {
+		handle.started = true
+	}
+	entries := append([]dirEntry(nil), handle.entries...)
+	m.mu.Unlock()
+	if refresh {
+		refreshed, errno := m.snapshotDirEntries(node, handle.backend, handle.nodeID, handle.fh)
+		if errno != 0 {
+			return nil, errno
+		}
+		m.mu.Lock()
+		if current := m.handles[fh]; current == handle {
+			handle.entries = refreshed
+			entries = append(entries[:0], refreshed...)
+		} else {
+			m.mu.Unlock()
+			return nil, -linuxEBADF
+		}
+		m.mu.Unlock()
+	}
+	return encodeDirEntries(entries, off, maxBytes), 0
 }
 
 func (m *mountedFS) snapshotDirEntries(node *mountedNode, backend FSBackend, backendNodeID uint64, fh uint64) ([]dirEntry, int32) {


### PR DESCRIPTION
## Summary

- refresh both mounted and passthrough directory entries when a guest restarts enumeration at offset zero
- preserve one stable entry snapshot while an enumeration continues at nonzero offsets
- validate directory handles against their node IDs
- move cached descendant paths and ownership metadata with renamed directories
- detach overwritten target nodes so stale inode IDs cannot alias replacement files
- honor `RENAME_NOREPLACE` atomically on Linux, macOS, and Windows

## Root cause

Both the mounted and passthrough virtio-fs layers captured directory entries only in `OpenDir`. Desktop file managers commonly keep a directory handle open and restart `ReadDir` at offset zero after moving files. Those refreshes received old snapshots, so files moved away still appeared in the source directory and files moved back could remain absent.

The deeper rename audit found two data-safety hazards. Passthrough cache updates moved only the renamed path, leaving cached descendants attached to the old location; recreating that location could redirect an existing guest inode to unrelated host data. Overwritten target nodes were also left attached to the replacement path. Finally, writable shares ignored `RENAME_NOREPLACE`, permitting an explicitly non-destructive rename to overwrite its destination.

## Validation

- regression test moving a file into a child folder and back through the complete mounted filesystem while reusing the source directory handle
- cached-descendant identity test that reuses the old source path with different content
- overwrite test proving the displaced target node cannot alias the replacement
- no-replace test proving both source and destination bytes survive an expected `EEXIST`
- 100 repeated runs of the shared-folder read-directory and rename regression group
- `go test ./internal/virtio`
- `go test -race ./internal/virtio`
- `go vet ./internal/virtio`
- `go test ./internal/amd64vm ./internal/arm64vm`
- `go vet ./internal/amd64vm ./internal/arm64vm`
- Windows/amd64, Linux/arm64, and macOS/amd64 test compiles for `internal/virtio`
- `git diff --check`
