### PR TITLE
Serve and monitor CVMFS mounts from the host

### DIFF
--- a/ccvmd/ccvmd.go
+++ b/ccvmd/ccvmd.go
@@ -26,6 +26,18 @@ type ServerOptions struct {
 	NormalizeStartRequest  func(*client.StartInstanceRequest, RuntimeView) error
 	NormalizeRunRequest    func(*client.RunRequest, RuntimeView) error
 	CompleteRequest        func(string, uint64, RuntimeView)
+	CVMFSMounts            []CVMFSHostMount
+}
+
+// CVMFSHostMount configures a host-served CVMFS repository that is attached
+// read-only to every VM started by this daemon.
+type CVMFSHostMount struct {
+	Mount           string
+	Mirror          string
+	Mirrors         []string
+	Repo            string
+	Path            string
+	CacheLimitBytes int64
 }
 
 // ServerAuthentication is a validated transport authentication policy for a
@@ -68,6 +80,13 @@ func Main(args []string) {
 }
 
 func RunServer(args []string, opts ServerOptions) (bool, error) {
+	cvmfsMounts := make([]internal.CVMFSHostMount, 0, len(opts.CVMFSMounts))
+	for _, mount := range opts.CVMFSMounts {
+		cvmfsMounts = append(cvmfsMounts, internal.CVMFSHostMount{
+			Mount: mount.Mount, Mirror: mount.Mirror, Mirrors: append([]string(nil), mount.Mirrors...),
+			Repo: mount.Repo, Path: mount.Path, CacheLimitBytes: mount.CacheLimitBytes,
+		})
+	}
 	return internal.RunServer(args, internal.ServerOptions{
 		Kind:      opts.Kind,
 		TokenPath: opts.TokenPath,
@@ -110,6 +129,7 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 			}
 		},
 		WrapHandler: opts.WrapHandler,
+		CVMFSMounts: cvmfsMounts,
 	})
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -338,6 +338,16 @@ func (c *Client) CapabilitiesContext(ctx context.Context) (CapabilitiesResponse,
 	return ret, err
 }
 
+func (c *Client) CVMFSStatus() (CVMFSStatusResponse, error) {
+	return c.CVMFSStatusContext(context.Background())
+}
+
+func (c *Client) CVMFSStatusContext(ctx context.Context) (CVMFSStatusResponse, error) {
+	var ret CVMFSStatusResponse
+	err := c.getJSONContext(ctx, "/cvmfs/status", &ret)
+	return ret, err
+}
+
 func (c *Client) CreateWatchdogLease(req WatchdogLeaseRequest) (WatchdogLeaseResponse, error) {
 	return c.CreateWatchdogLeaseContext(context.Background(), req)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -348,6 +348,16 @@ func (c *Client) CVMFSStatusContext(ctx context.Context) (CVMFSStatusResponse, e
 	return ret, err
 }
 
+func (c *Client) ProbeCVMFSMirrorsContext(ctx context.Context, req CVMFSMirrorProbeRequest) (CVMFSMirrorProbeResponse, error) {
+	var ret CVMFSMirrorProbeResponse
+	err := c.postJSONExpectOKContext(ctx, "/cvmfs/mirrors/probe", req, &ret)
+	return ret, err
+}
+
+func (c *Client) SelectCVMFSMirrorContext(ctx context.Context, req CVMFSMirrorSelectionRequest) error {
+	return c.postJSONExpectOKContext(ctx, "/cvmfs/mirrors/selection", req, nil)
+}
+
 func (c *Client) CreateWatchdogLease(req WatchdogLeaseRequest) (WatchdogLeaseResponse, error) {
 	return c.CreateWatchdogLeaseContext(context.Background(), req)
 }

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -175,6 +175,29 @@ type CVMFSReadResponse struct {
 	EOF    bool   `json:"eof,omitempty"`
 }
 
+type CVMFSTransferState struct {
+	ID         uint64  `json:"id"`
+	Path       string  `json:"path"`
+	Mirror     string  `json:"mirror,omitempty"`
+	Bytes      int64   `json:"bytes"`
+	TotalBytes int64   `json:"total_bytes,omitempty"`
+	Progress   float64 `json:"progress,omitempty"`
+	StartedAt  string  `json:"started_at,omitempty"`
+}
+
+type CVMFSStatusResponse struct {
+	State           string               `json:"state"`
+	SelectedMirror  string               `json:"selected_mirror,omitempty"`
+	Bytes           int64                `json:"bytes"`
+	TotalBytes      int64                `json:"total_bytes,omitempty"`
+	Progress        float64              `json:"progress,omitempty"`
+	CacheBytes      int64                `json:"cache_bytes,omitempty"`
+	CacheLimitBytes int64                `json:"cache_limit_bytes,omitempty"`
+	ActiveTransfers []CVMFSTransferState `json:"active_transfers"`
+	LastError       string               `json:"last_error,omitempty"`
+	LastErrorUnix   int64                `json:"last_error_unix,omitempty"`
+}
+
 func (r PullImageRequest) MarshalJSON() ([]byte, error) {
 	payload := map[string]any{}
 	switch {
@@ -436,6 +459,7 @@ type CreateInstanceRequest struct {
 	Display          *DisplayConfig      `json:"display,omitempty"`
 	SharedMemory     *SharedMemoryConfig `json:"shared_memory,omitempty"`
 	KernelModules    []string            `json:"kernel_modules,omitempty"`
+	Env              []string            `json:"env,omitempty"`
 	MemoryMB         uint64              `json:"memory_mb,omitempty"`
 	BalloonMB        uint64              `json:"balloon_mb,omitempty"`
 	CPUs             int                 `json:"cpus,omitempty"`
@@ -460,6 +484,7 @@ type StartInstanceRequest struct {
 	Display          *DisplayConfig      `json:"display,omitempty"`
 	SharedMemory     *SharedMemoryConfig `json:"shared_memory,omitempty"`
 	KernelModules    []string            `json:"kernel_modules,omitempty"`
+	Env              []string            `json:"env,omitempty"`
 	MemoryMB         uint64              `json:"memory_mb,omitempty"`
 	BalloonMB        uint64              `json:"balloon_mb,omitempty"`
 	CPUs             int                 `json:"cpus,omitempty"`

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -198,6 +198,29 @@ type CVMFSStatusResponse struct {
 	LastErrorUnix   int64                `json:"last_error_unix,omitempty"`
 }
 
+type CVMFSMirrorProbeRequest struct {
+	Repo string `json:"repo"`
+}
+
+type CVMFSMirrorProbeResult struct {
+	Mirror                 string  `json:"mirror"`
+	ManifestLatencyMillis  int64   `json:"manifest_latency_millis,omitempty"`
+	RootCatalogMillis      int64   `json:"root_catalog_millis,omitempty"`
+	RootCatalogBytes       int64   `json:"root_catalog_bytes,omitempty"`
+	RootCatalogBytesPerSec float64 `json:"root_catalog_bytes_per_second,omitempty"`
+	Error                  string  `json:"error,omitempty"`
+}
+
+type CVMFSMirrorProbeResponse struct {
+	SelectedMirror string                   `json:"selected_mirror"`
+	Results        []CVMFSMirrorProbeResult `json:"results"`
+}
+
+type CVMFSMirrorSelectionRequest struct {
+	Repo   string `json:"repo"`
+	Mirror string `json:"mirror"`
+}
+
 func (r PullImageRequest) MarshalJSON() ([]byte, error) {
 	payload := map[string]any{}
 	switch {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -468,6 +468,22 @@
         }
       }
     },
+    "/cvmfs/status": {
+      "get": {
+        "tags": ["cvmfs"],
+        "summary": "Inspect host CVMFS transfers and cache usage",
+        "responses": {
+          "200": {
+            "description": "CVMFS status",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CVMFSStatusResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/vm/supported": {
       "get": {
         "tags": ["vms"],
@@ -1110,6 +1126,35 @@
           "eof": { "type": "boolean" }
         }
       },
+      "CVMFSTransferState": {
+        "type": "object",
+        "required": ["id", "path", "bytes"],
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "path": { "type": "string" },
+          "mirror": { "type": "string" },
+          "bytes": { "type": "integer", "format": "int64" },
+          "total_bytes": { "type": "integer", "format": "int64" },
+          "progress": { "type": "number", "format": "double" },
+          "started_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "CVMFSStatusResponse": {
+        "type": "object",
+        "required": ["state", "bytes", "active_transfers"],
+        "properties": {
+          "state": { "type": "string", "enum": ["idle", "downloading", "error"] },
+          "selected_mirror": { "type": "string" },
+          "bytes": { "type": "integer", "format": "int64" },
+          "total_bytes": { "type": "integer", "format": "int64" },
+          "progress": { "type": "number", "format": "double" },
+          "cache_bytes": { "type": "integer", "format": "int64" },
+          "cache_limit_bytes": { "type": "integer", "format": "int64" },
+          "active_transfers": { "type": "array", "items": { "$ref": "#/components/schemas/CVMFSTransferState" } },
+          "last_error": { "type": "string" },
+          "last_error_unix": { "type": "integer", "format": "int64" }
+        }
+      },
       "VMSupportedResponse": {
         "type": "object",
         "required": ["supported"],
@@ -1231,6 +1276,7 @@
           "default_user": { "type": "string", "description": "Default guest user for commands. An explicit per-command user takes precedence." },
           "init": { "type": "string" },
           "kernel": { "type": "string" },
+          "env": { "type": "array", "items": { "type": "string" } },
           "shares": { "type": "array", "items": { "$ref": "#/components/schemas/ShareMount" } },
           "persistent_mounts": { "type": "array", "items": { "$ref": "#/components/schemas/PersistentMount" } },
           "network": { "$ref": "#/components/schemas/NetworkConfig" },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -484,6 +484,33 @@
         }
       }
     },
+    "/cvmfs/mirrors/probe": {
+      "post": {
+        "tags": ["cvmfs"],
+        "summary": "Measure configured mirrors using the repository root catalog",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CVMFSMirrorProbeRequest" } } }
+        },
+        "responses": {
+          "200": {
+            "description": "Measured mirrors and automatic selection",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CVMFSMirrorProbeResponse" } } }
+          }
+        }
+      }
+    },
+    "/cvmfs/mirrors/selection": {
+      "post": {
+        "tags": ["cvmfs"],
+        "summary": "Select the preferred mirror for a configured host mount",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CVMFSMirrorSelectionRequest" } } }
+        },
+        "responses": { "200": { "description": "Mirror selected" } }
+      }
+    },
     "/vm/supported": {
       "get": {
         "tags": ["vms"],
@@ -1153,6 +1180,39 @@
           "active_transfers": { "type": "array", "items": { "$ref": "#/components/schemas/CVMFSTransferState" } },
           "last_error": { "type": "string" },
           "last_error_unix": { "type": "integer", "format": "int64" }
+        }
+      },
+      "CVMFSMirrorProbeRequest": {
+        "type": "object",
+        "required": ["repo"],
+        "properties": { "repo": { "type": "string" } }
+      },
+      "CVMFSMirrorProbeResult": {
+        "type": "object",
+        "required": ["mirror"],
+        "properties": {
+          "mirror": { "type": "string" },
+          "manifest_latency_millis": { "type": "integer", "format": "int64" },
+          "root_catalog_millis": { "type": "integer", "format": "int64" },
+          "root_catalog_bytes": { "type": "integer", "format": "int64" },
+          "root_catalog_bytes_per_second": { "type": "number", "format": "double" },
+          "error": { "type": "string" }
+        }
+      },
+      "CVMFSMirrorProbeResponse": {
+        "type": "object",
+        "required": ["selected_mirror", "results"],
+        "properties": {
+          "selected_mirror": { "type": "string" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/CVMFSMirrorProbeResult" } }
+        }
+      },
+      "CVMFSMirrorSelectionRequest": {
+        "type": "object",
+        "required": ["repo", "mirror"],
+        "properties": {
+          "repo": { "type": "string" },
+          "mirror": { "type": "string" }
         }
       },
       "VMSupportedResponse": {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,11 +93,28 @@ type server struct {
 	vms           *vm.Manager
 	cvmfsCacheDir string
 	cvmfsMonitor  *cvmfsMonitor
+	cvmfsMounts   []preparedCVMFSHostMount
 }
 
 type preparedCVMFSHostMount struct {
 	guestPath string
 	root      imagefs.Directory
+	repo      string
+	mirrors   []string
+	client    *intcvmfs.Client
+}
+
+func (s *server) cvmfsMount(repo string) *preparedCVMFSHostMount {
+	if s == nil {
+		return nil
+	}
+	repo = strings.TrimSpace(repo)
+	for index := range s.cvmfsMounts {
+		if s.cvmfsMounts[index].repo == repo {
+			return &s.cvmfsMounts[index]
+		}
+	}
+	return nil
 }
 
 func prepareCVMFSHostMounts(configs []CVMFSHostMount, cacheDir string, monitor *cvmfsMonitor) ([]preparedCVMFSHostMount, error) {
@@ -135,7 +153,17 @@ func prepareCVMFSHostMounts(configs []CVMFSHostMount, cacheDir string, monitor *
 		if err != nil {
 			return nil, fmt.Errorf("configure CVMFS host mount %q: %w", guestPath, err)
 		}
-		prepared = append(prepared, preparedCVMFSHostMount{guestPath: guestPath, root: root})
+		mirrors := make([]string, 0, len(config.Mirrors)+1)
+		seenMirrors := make(map[string]bool, len(config.Mirrors)+1)
+		for _, candidate := range append([]string{mirror}, config.Mirrors...) {
+			candidate = intcvmfs.NormalizeMirror(candidate)
+			if candidate == "" || seenMirrors[candidate] {
+				continue
+			}
+			seenMirrors[candidate] = true
+			mirrors = append(mirrors, candidate)
+		}
+		prepared = append(prepared, preparedCVMFSHostMount{guestPath: guestPath, root: root, repo: repo, mirrors: mirrors, client: client})
 	}
 	return prepared, nil
 }
@@ -556,6 +584,7 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 		if err != nil {
 			return false, err
 		}
+		srvState.cvmfsMounts = mounts
 		srvState.vms.SetHostMountProvider(func(context.Context, string) ([]virtio.ShareMount, error) {
 			out := make([]virtio.ShareMount, 0, len(mounts))
 			for _, mount := range mounts {
@@ -1811,6 +1840,56 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 
 	mux.HandleFunc("GET /cvmfs/status", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, srvState.cvmfsMonitor.Status())
+	})
+
+	mux.HandleFunc("POST /cvmfs/mirrors/probe", func(w http.ResponseWriter, r *http.Request) {
+		var req client.CVMFSMirrorProbeRequest
+		if err := decodeRequiredJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		mount := srvState.cvmfsMount(req.Repo)
+		if mount == nil {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("CVMFS repository %q is not configured as a host mount", req.Repo))
+			return
+		}
+		selected, measured, err := intcvmfs.ProbeMirrors(r.Context(), mount.client.HTTPClient, mount.repo, mount.mirrors)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, err)
+			return
+		}
+		mount.client.SetPreferredMirror(selected)
+		srvState.cvmfsMonitor.SetSelectedMirror(selected)
+		results := make([]client.CVMFSMirrorProbeResult, 0, len(measured))
+		for _, result := range measured {
+			results = append(results, client.CVMFSMirrorProbeResult{
+				Mirror: result.Mirror, ManifestLatencyMillis: result.ManifestLatency.Milliseconds(),
+				RootCatalogMillis: result.RootCatalogDuration.Milliseconds(), RootCatalogBytes: result.RootCatalogBytes,
+				RootCatalogBytesPerSec: result.RootCatalogBytesPerSec, Error: result.Error,
+			})
+		}
+		writeJSON(w, http.StatusOK, client.CVMFSMirrorProbeResponse{SelectedMirror: selected, Results: results})
+	})
+
+	mux.HandleFunc("POST /cvmfs/mirrors/selection", func(w http.ResponseWriter, r *http.Request) {
+		var req client.CVMFSMirrorSelectionRequest
+		if err := decodeRequiredJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		mount := srvState.cvmfsMount(req.Repo)
+		if mount == nil {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("CVMFS repository %q is not configured as a host mount", req.Repo))
+			return
+		}
+		selected := intcvmfs.NormalizeMirror(req.Mirror)
+		if !slices.Contains(mount.mirrors, selected) {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("CVMFS mirror %q is not configured for repository %q", req.Mirror, req.Repo))
+			return
+		}
+		mount.client.SetPreferredMirror(selected)
+		srvState.cvmfsMonitor.SetSelectedMirror(selected)
+		writeJSON(w, http.StatusOK, map[string]string{"selected_mirror": selected})
 	})
 
 	mux.HandleFunc("POST /cvmfs/read", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -16,6 +16,7 @@ import (
 	"net/http/pprof"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -30,10 +31,12 @@ import (
 	"j5.nz/cc/internal/cachepath"
 	intcvmfs "j5.nz/cc/internal/cvmfs"
 	"j5.nz/cc/internal/hv/hvf"
+	"j5.nz/cc/internal/imagefs"
 	"j5.nz/cc/internal/kernel/alpine"
 	"j5.nz/cc/internal/macos"
 	managedguest "j5.nz/cc/internal/managed/guest"
 	"j5.nz/cc/internal/oci"
+	"j5.nz/cc/internal/virtio"
 	"j5.nz/cc/internal/vm"
 )
 
@@ -88,6 +91,70 @@ type server struct {
 	images        *oci.Store
 	vms           *vm.Manager
 	cvmfsCacheDir string
+	cvmfsMonitor  *cvmfsMonitor
+}
+
+type preparedCVMFSHostMount struct {
+	guestPath string
+	root      imagefs.Directory
+}
+
+func prepareCVMFSHostMounts(configs []CVMFSHostMount, cacheDir string, monitor *cvmfsMonitor) ([]preparedCVMFSHostMount, error) {
+	prepared := make([]preparedCVMFSHostMount, 0, len(configs))
+	seen := make(map[string]bool, len(configs))
+	for _, config := range configs {
+		guestPath := path.Clean(strings.TrimSpace(config.Mount))
+		if !strings.HasPrefix(guestPath, "/") || guestPath == "/" {
+			return nil, fmt.Errorf("CVMFS host mount path %q must be an absolute non-root path", config.Mount)
+		}
+		if seen[guestPath] {
+			return nil, fmt.Errorf("duplicate CVMFS host mount path %q", guestPath)
+		}
+		seen[guestPath] = true
+		repo := strings.TrimSpace(config.Repo)
+		if repo == "" || strings.Contains(repo, "/") {
+			return nil, fmt.Errorf("invalid CVMFS repository %q", config.Repo)
+		}
+		mirror := strings.TrimSpace(config.Mirror)
+		if mirror == "" {
+			mirror = intcvmfs.DefaultMirror
+		}
+		client := intcvmfs.NewClient()
+		client.CacheDir = cacheDir
+		client.Mirrors = append([]string(nil), config.Mirrors...)
+		if monitor != nil {
+			client.OnTransfer = monitor.Record
+		}
+		target, err := intcvmfs.FormatTarget(intcvmfs.Target{
+			Remote: true, Mirror: mirror, Repo: repo, Path: ensureAbsolutePath(config.Path),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("configure CVMFS host mount %q: %w", guestPath, err)
+		}
+		root, err := intcvmfs.NewImageFS(client, target)
+		if err != nil {
+			return nil, fmt.Errorf("configure CVMFS host mount %q: %w", guestPath, err)
+		}
+		prepared = append(prepared, preparedCVMFSHostMount{guestPath: guestPath, root: root})
+	}
+	return prepared, nil
+}
+
+func cvmfsHostCacheLimit(configs []CVMFSHostMount) (int64, error) {
+	var limit int64
+	for _, config := range configs {
+		if config.CacheLimitBytes < 0 {
+			return 0, fmt.Errorf("CVMFS cache limit must not be negative")
+		}
+		if config.CacheLimitBytes == 0 {
+			continue
+		}
+		if limit != 0 && limit != config.CacheLimitBytes {
+			return 0, fmt.Errorf("CVMFS host mounts sharing a cache must use one cache limit")
+		}
+		limit = config.CacheLimitBytes
+	}
+	return limit, nil
 }
 
 type ServerOptions struct {
@@ -107,6 +174,16 @@ type ServerOptions struct {
 	NormalizeStartRequest  func(*client.StartInstanceRequest, RuntimeView) error
 	NormalizeRunRequest    func(*client.RunRequest, RuntimeView) error
 	CompleteRequest        func(string, uint64, RuntimeView)
+	CVMFSMounts            []CVMFSHostMount
+}
+
+type CVMFSHostMount struct {
+	Mount           string
+	Mirror          string
+	Mirrors         []string
+	Repo            string
+	Path            string
+	CacheLimitBytes int64
 }
 
 type RuntimeView interface {
@@ -469,6 +546,29 @@ func RunServer(args []string, opts ServerOptions) (bool, error) {
 		rootCache,
 		*worker,
 	)
+	if len(opts.CVMFSMounts) != 0 {
+		cacheLimit, err := cvmfsHostCacheLimit(opts.CVMFSMounts)
+		if err != nil {
+			return false, err
+		}
+		srvState.cvmfsMonitor = newCVMFSMonitor(srvState.cvmfsCacheDir, cacheLimit)
+		mounts, err := prepareCVMFSHostMounts(opts.CVMFSMounts, srvState.cvmfsCacheDir, srvState.cvmfsMonitor)
+		if err != nil {
+			return false, err
+		}
+		srvState.vms.SetHostMountProvider(func(context.Context, string) ([]virtio.ShareMount, error) {
+			out := make([]virtio.ShareMount, 0, len(mounts))
+			for _, mount := range mounts {
+				out = append(out, virtio.ShareMount{
+					GuestPath: mount.guestPath,
+					Backend:   virtio.NewImageFS(mount.root, ""),
+					Writable:  false,
+					CacheMode: "aggressive",
+				})
+			}
+			return out, nil
+		})
+	}
 
 	if *worker {
 		if socketPath := strings.TrimSpace(os.Getenv("CCX3_WORKER_CONTROL_SOCKET")); socketPath != "" {
@@ -1707,6 +1807,10 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 			})
 		}
 		writeJSON(w, http.StatusOK, resp)
+	})
+
+	mux.HandleFunc("GET /cvmfs/status", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, srvState.cvmfsMonitor.Status())
 	})
 
 	mux.HandleFunc("POST /cvmfs/read", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -137,6 +137,7 @@ func prepareCVMFSHostMounts(configs []CVMFSHostMount, cacheDir string, monitor *
 		if mirror == "" {
 			mirror = intcvmfs.DefaultMirror
 		}
+		mirror = intcvmfs.NormalizeMirror(mirror)
 		client := intcvmfs.NewClient()
 		client.CacheDir = cacheDir
 		client.Mirrors = append([]string(nil), config.Mirrors...)

--- a/internal/ccvmd/ccvmd_test.go
+++ b/internal/ccvmd/ccvmd_test.go
@@ -63,6 +63,21 @@ func TestExplicitCacheKeepsRuntimeArtifactsInsideCache(t *testing.T) {
 	}
 }
 
+func TestPrepareCVMFSHostMountAcceptsMirrorOrigin(t *testing.T) {
+	mounts, err := prepareCVMFSHostMounts([]CVMFSHostMount{{
+		Mount:  "/cvmfs/neurodesk.ardc.edu.au",
+		Mirror: "http://cvmfs.example",
+		Repo:   "neurodesk.ardc.edu.au",
+		Path:   "/",
+	}}, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("prepare CVMFS host mount: %v", err)
+	}
+	if len(mounts) != 1 || mounts[0].guestPath != "/cvmfs/neurodesk.ardc.edu.au" || mounts[0].repo != "neurodesk.ardc.edu.au" {
+		t.Fatalf("prepared CVMFS host mounts = %+v", mounts)
+	}
+}
+
 func TestRunServerUsesConfiguredStartupWriter(t *testing.T) {
 	var startup bytes.Buffer
 	shutdownErr := make(chan error, 1)

--- a/internal/ccvmd/cvmfs_monitor.go
+++ b/internal/ccvmd/cvmfs_monitor.go
@@ -25,6 +25,15 @@ type cvmfsMonitor struct {
 	janitorActive bool
 }
 
+func (m *cvmfsMonitor) SetSelectedMirror(mirror string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.selected = mirror
+	m.mu.Unlock()
+}
+
 func newCVMFSMonitor(cacheRoot string, cacheLimit int64) *cvmfsMonitor {
 	m := &cvmfsMonitor{
 		cacheRoot: strings.TrimSpace(cacheRoot), cacheLimit: cacheLimit,

--- a/internal/ccvmd/cvmfs_monitor.go
+++ b/internal/ccvmd/cvmfs_monitor.go
@@ -1,0 +1,165 @@
+package ccvmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"j5.nz/cc/client"
+	intcvmfs "j5.nz/cc/internal/cvmfs"
+)
+
+type cvmfsMonitor struct {
+	mu            sync.Mutex
+	cacheRoot     string
+	cacheLimit    int64
+	cacheBytes    int64
+	active        map[uint64]client.CVMFSTransferState
+	selected      string
+	lastError     string
+	lastErrorTime time.Time
+	janitorActive bool
+}
+
+func newCVMFSMonitor(cacheRoot string, cacheLimit int64) *cvmfsMonitor {
+	m := &cvmfsMonitor{
+		cacheRoot: strings.TrimSpace(cacheRoot), cacheLimit: cacheLimit,
+		active: make(map[uint64]client.CVMFSTransferState), janitorActive: true,
+	}
+	go m.enforceCacheLimit()
+	return m
+}
+
+func (m *cvmfsMonitor) Record(event intcvmfs.TransferEvent) {
+	if m == nil || event.ID == 0 {
+		return
+	}
+	m.mu.Lock()
+	switch event.State {
+	case "started", "progress":
+		started := event.Time
+		if previous, ok := m.active[event.ID]; ok && previous.StartedAt != "" {
+			if parsed, err := time.Parse(time.RFC3339Nano, previous.StartedAt); err == nil {
+				started = parsed
+			}
+		}
+		state := client.CVMFSTransferState{
+			ID: event.ID, Path: "/cvmfs/" + event.Repo + "/" + strings.TrimPrefix(event.Path, "/"),
+			Mirror: event.Mirror, Bytes: event.Bytes, TotalBytes: event.TotalBytes,
+			StartedAt: started.UTC().Format(time.RFC3339Nano),
+		}
+		if state.TotalBytes > 0 {
+			state.Progress = min(1, float64(state.Bytes)/float64(state.TotalBytes))
+		}
+		m.active[event.ID] = state
+		m.selected = event.Mirror
+	case "completed":
+		delete(m.active, event.ID)
+		m.selected = event.Mirror
+		m.triggerJanitorLocked()
+	case "failed":
+		delete(m.active, event.ID)
+		m.selected = event.Mirror
+		m.lastError = event.Error
+		m.lastErrorTime = event.Time
+		m.triggerJanitorLocked()
+	}
+	m.mu.Unlock()
+}
+
+func (m *cvmfsMonitor) Status() client.CVMFSStatusResponse {
+	if m == nil {
+		return client.CVMFSStatusResponse{State: "idle", ActiveTransfers: []client.CVMFSTransferState{}}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status := client.CVMFSStatusResponse{
+		State: "idle", SelectedMirror: m.selected, CacheBytes: m.cacheBytes,
+		CacheLimitBytes: m.cacheLimit, ActiveTransfers: make([]client.CVMFSTransferState, 0, len(m.active)),
+	}
+	totalsKnown := true
+	for _, transfer := range m.active {
+		status.ActiveTransfers = append(status.ActiveTransfers, transfer)
+		status.Bytes += transfer.Bytes
+		status.TotalBytes += transfer.TotalBytes
+		if transfer.TotalBytes <= 0 {
+			totalsKnown = false
+		}
+	}
+	sort.Slice(status.ActiveTransfers, func(i, j int) bool {
+		if status.ActiveTransfers[i].StartedAt == status.ActiveTransfers[j].StartedAt {
+			return status.ActiveTransfers[i].Path < status.ActiveTransfers[j].Path
+		}
+		return status.ActiveTransfers[i].StartedAt < status.ActiveTransfers[j].StartedAt
+	})
+	if len(status.ActiveTransfers) != 0 {
+		status.State = "downloading"
+		if totalsKnown && status.TotalBytes > 0 {
+			status.Progress = min(1, float64(status.Bytes)/float64(status.TotalBytes))
+		} else {
+			status.TotalBytes = 0
+		}
+	} else if m.lastError != "" && time.Since(m.lastErrorTime) < 30*time.Second {
+		status.State = "error"
+		status.LastError = m.lastError
+		status.LastErrorUnix = m.lastErrorTime.Unix()
+	}
+	return status
+}
+
+func (m *cvmfsMonitor) triggerJanitorLocked() {
+	if m.cacheRoot == "" || m.janitorActive {
+		return
+	}
+	m.janitorActive = true
+	go m.enforceCacheLimit()
+}
+
+type cvmfsCacheEntry struct {
+	path    string
+	size    int64
+	modTime time.Time
+}
+
+func (m *cvmfsMonitor) enforceCacheLimit() {
+	if m == nil || m.cacheRoot == "" {
+		return
+	}
+	var total int64
+	var entries []cvmfsCacheEntry
+	_ = filepath.WalkDir(m.cacheRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() {
+			return nil
+		}
+		total += info.Size()
+		rel, err := filepath.Rel(m.cacheRoot, path)
+		if err != nil || strings.HasPrefix(rel, "state"+string(filepath.Separator)) || rel == "requests.log" || strings.HasPrefix(entry.Name(), ".cvmfs-cache-") {
+			return nil
+		}
+		entries = append(entries, cvmfsCacheEntry{path: path, size: info.Size(), modTime: info.ModTime()})
+		return nil
+	})
+	if m.cacheLimit > 0 && total > m.cacheLimit {
+		sort.Slice(entries, func(i, j int) bool { return entries[i].modTime.Before(entries[j].modTime) })
+		for _, entry := range entries {
+			if total <= m.cacheLimit {
+				break
+			}
+			if err := os.Remove(entry.path); err == nil {
+				total -= entry.size
+			}
+		}
+	}
+	m.mu.Lock()
+	m.cacheBytes = max(0, total)
+	m.janitorActive = false
+	m.mu.Unlock()
+}

--- a/internal/ccvmd/cvmfs_monitor_test.go
+++ b/internal/ccvmd/cvmfs_monitor_test.go
@@ -1,0 +1,62 @@
+package ccvmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"j5.nz/cc/client"
+	intcvmfs "j5.nz/cc/internal/cvmfs"
+)
+
+func TestCVMFSMonitorReportsLogicalActiveTransfers(t *testing.T) {
+	monitor := &cvmfsMonitor{active: make(map[uint64]client.CVMFSTransferState)}
+	started := time.Date(2026, 8, 5, 1, 2, 3, 0, time.UTC)
+	monitor.Record(intcvmfs.TransferEvent{
+		Time: started, ID: 7, State: "progress", Repo: "neurodesk.ardc.edu.au",
+		Path: "/containers/tool.sif", Mirror: "http://mirror.example/cvmfs", Bytes: 25, TotalBytes: 100,
+	})
+	status := monitor.Status()
+	if status.State != "downloading" || status.Progress != 0.25 || len(status.ActiveTransfers) != 1 {
+		t.Fatalf("status = %+v", status)
+	}
+	transfer := status.ActiveTransfers[0]
+	if transfer.Path != "/cvmfs/neurodesk.ardc.edu.au/containers/tool.sif" || transfer.Mirror != "http://mirror.example/cvmfs" {
+		t.Fatalf("logical transfer = %+v", transfer)
+	}
+	monitor.Record(intcvmfs.TransferEvent{Time: started.Add(time.Second), ID: 7, State: "completed", Mirror: transfer.Mirror})
+	if status := monitor.Status(); status.State != "idle" || len(status.ActiveTransfers) != 0 {
+		t.Fatalf("completed status = %+v", status)
+	}
+}
+
+func TestCVMFSCacheLimitEvictsOldestDownloadData(t *testing.T) {
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "objects", "old")
+	newPath := filepath.Join(root, "files", "new")
+	statePath := filepath.Join(root, "state", "repo", "manifest")
+	for _, path := range []string{oldPath, newPath, statePath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, make([]byte, 64), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	monitor := &cvmfsMonitor{cacheRoot: root, cacheLimit: 128, active: make(map[uint64]client.CVMFSTransferState)}
+	monitor.enforceCacheLimit()
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old cache object was not evicted: %v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("new cache file was evicted: %v", err)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("repository state was evicted: %v", err)
+	}
+}

--- a/internal/ccvmd/openapi_test.go
+++ b/internal/ccvmd/openapi_test.go
@@ -27,18 +27,22 @@ func TestOpenAPIContract(t *testing.T) {
 		t.Fatalf("validate OpenAPI document: %v", err)
 	}
 	for name, value := range map[string]any{
-		"ErrorResponse":           client.ErrorResponse{},
-		"ImagePullPlan":           client.ImagePullPlan{},
-		"CreateInstanceRequest":   client.CreateInstanceRequest{},
-		"StartInstanceRequest":    client.StartInstanceRequest{},
-		"RunRequest":              client.RunRequest{},
-		"ExecResponse":            client.ExecResponse{},
-		"ExecRequest":             client.ExecRequest{},
-		"ExecInput":               client.ExecInput{},
-		"ExecEvent":               client.ExecEvent{},
-		"PortForward":             client.PortForward{},
-		"ServiceProxyPortRequest": client.ServiceProxyPortRequest{},
-		"BootEvent":               client.BootEvent{},
+		"ErrorResponse":               client.ErrorResponse{},
+		"ImagePullPlan":               client.ImagePullPlan{},
+		"CreateInstanceRequest":       client.CreateInstanceRequest{},
+		"StartInstanceRequest":        client.StartInstanceRequest{},
+		"CVMFSMirrorProbeRequest":     client.CVMFSMirrorProbeRequest{},
+		"CVMFSMirrorProbeResult":      client.CVMFSMirrorProbeResult{},
+		"CVMFSMirrorProbeResponse":    client.CVMFSMirrorProbeResponse{},
+		"CVMFSMirrorSelectionRequest": client.CVMFSMirrorSelectionRequest{},
+		"RunRequest":                  client.RunRequest{},
+		"ExecResponse":                client.ExecResponse{},
+		"ExecRequest":                 client.ExecRequest{},
+		"ExecInput":                   client.ExecInput{},
+		"ExecEvent":                   client.ExecEvent{},
+		"PortForward":                 client.PortForward{},
+		"ServiceProxyPortRequest":     client.ServiceProxyPortRequest{},
+		"BootEvent":                   client.BootEvent{},
 	} {
 		assertSchemaFields(t, document, name, reflect.TypeOf(value))
 	}

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -199,6 +199,12 @@ type repository struct {
 	repo     string
 	manifest *manifest
 	catalogs map[string]*catalog
+
+	indexMu         sync.RWMutex
+	indexedCatalogs map[*catalog]bool
+	globalPaths     map[string]string
+	entriesByPath   map[string]catalogEntry
+	childrenByPath  map[string][]catalogEntry
 }
 
 type mirrorStat struct {
@@ -672,10 +678,14 @@ func (c *Client) newRepository(target Target) *repository {
 		return repo
 	}
 	repo := &repository{
-		client:   client,
-		mirrors:  mirrors,
-		repo:     target.Repo,
-		catalogs: map[string]*catalog{},
+		client:          client,
+		mirrors:         mirrors,
+		repo:            target.Repo,
+		catalogs:        map[string]*catalog{},
+		indexedCatalogs: map[*catalog]bool{},
+		globalPaths:     map[string]string{"0:0": "/"},
+		entriesByPath:   map[string]catalogEntry{},
+		childrenByPath:  map[string][]catalogEntry{},
 	}
 	client.repos[key] = repo
 	return repo
@@ -795,32 +805,27 @@ func walkLocal(root string, visit func(WalkEntry) error) error {
 
 func (r *repository) ReadDir(dirPath string) ([]DirEntry, error) {
 	dirPath = path.Clean("/" + strings.TrimPrefix(dirPath, "/"))
-	foundDir := dirPath == "/"
-	children := map[string]DirEntry{}
-	err := r.walkPrefix(dirPath, func(ent catalogEntry) error {
-		if ent.FullPath == dirPath && ent.isDir() {
-			foundDir = true
-			return nil
-		}
-		if path.Dir(ent.FullPath) != dirPath {
-			return nil
-		}
-		children[ent.Name] = DirEntry{
+	if err := r.ensurePrefixIndexed(dirPath); err != nil {
+		return nil, err
+	}
+	r.indexMu.RLock()
+	dir, foundDir := r.entriesByPath[dirPath]
+	children := append([]catalogEntry(nil), r.childrenByPath[dirPath]...)
+	r.indexMu.RUnlock()
+	if dirPath != "/" && (!foundDir || !dir.isDir()) {
+		return nil, os.ErrNotExist
+	}
+	byName := make(map[string]DirEntry, len(children))
+	for _, ent := range children {
+		byName[ent.Name] = DirEntry{
 			Name:    ent.Name,
 			Mode:    linuxModeToGo(uint32(ent.Mode)),
 			Size:    ent.Size,
 			ModTime: time.Unix(ent.Mtime, ent.MtimeNS),
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
-	if !foundDir {
-		return nil, os.ErrNotExist
-	}
-	out := make([]DirEntry, 0, len(children))
-	for _, entry := range children {
+	out := make([]DirEntry, 0, len(byName))
+	for _, entry := range byName {
 		out = append(out, entry)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -835,20 +840,9 @@ func (r *repository) Stat(nodePath string) (Entry, error) {
 		}
 		return Entry{Path: "/", Mode: fs.ModeDir | 0o555}, nil
 	}
-	var found *catalogEntry
-	err := r.walkPrefix(nodePath, func(ent catalogEntry) error {
-		if ent.FullPath != nodePath {
-			return nil
-		}
-		copy := ent
-		found = &copy
-		return errStopWalk
-	})
-	if err != nil && !errors.Is(err, errStopWalk) {
+	found, err := r.lookupIndexedEntry(nodePath)
+	if err != nil {
 		return Entry{}, err
-	}
-	if found == nil {
-		return Entry{}, os.ErrNotExist
 	}
 	return Entry{
 		Path: found.FullPath, Mode: linuxModeToGo(uint32(found.Mode)), Size: found.Size,
@@ -859,20 +853,9 @@ func (r *repository) Stat(nodePath string) (Entry, error) {
 
 func (r *repository) ReadFile(filePath string) ([]byte, error) {
 	filePath = path.Clean("/" + strings.TrimPrefix(filePath, "/"))
-	var found *catalogEntry
-	err := r.walkPrefix(filePath, func(ent catalogEntry) error {
-		if ent.FullPath != filePath {
-			return nil
-		}
-		copy := ent
-		found = &copy
-		return errStopWalk
-	})
-	if err != nil && !errors.Is(err, errStopWalk) {
+	found, err := r.lookupIndexedEntry(filePath)
+	if err != nil {
 		return nil, err
-	}
-	if found == nil {
-		return nil, os.ErrNotExist
 	}
 	if found.isDir() {
 		return nil, fmt.Errorf("%q is a directory", filePath)
@@ -1417,20 +1400,9 @@ func maxInt64(a, b int64) int64 {
 }
 
 func (r *repository) lookupFileEntry(filePath string) (*catalogEntry, error) {
-	var found *catalogEntry
-	err := r.walkPrefix(filePath, func(ent catalogEntry) error {
-		if ent.FullPath != filePath {
-			return nil
-		}
-		copy := ent
-		found = &copy
-		return errStopWalk
-	})
-	if err != nil && !errors.Is(err, errStopWalk) {
+	found, err := r.lookupIndexedEntry(filePath)
+	if err != nil {
 		return nil, err
-	}
-	if found == nil {
-		return nil, os.ErrNotExist
 	}
 	if found.isDir() {
 		return nil, fmt.Errorf("%q is a directory", filePath)
@@ -1439,6 +1411,117 @@ func (r *repository) lookupFileEntry(filePath string) (*catalogEntry, error) {
 		return nil, fmt.Errorf("%q is a symlink", filePath)
 	}
 	return found, nil
+}
+
+func (r *repository) lookupIndexedEntry(entryPath string) (*catalogEntry, error) {
+	entryPath = path.Clean("/" + strings.TrimPrefix(entryPath, "/"))
+	if err := r.ensurePrefixIndexed(entryPath); err != nil {
+		return nil, err
+	}
+	r.indexMu.RLock()
+	entry, ok := r.entriesByPath[entryPath]
+	r.indexMu.RUnlock()
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return &entry, nil
+}
+
+func (r *repository) ensurePrefixIndexed(prefix string) error {
+	root, err := r.rootCatalog()
+	if err != nil {
+		return err
+	}
+	return r.ensureCatalogPrefixIndexed(root, "/", prefix)
+}
+
+func (r *repository) ensureCatalogPrefixIndexed(cat *catalog, baseParent, prefix string) error {
+	if err := r.indexCatalog(cat, baseParent); err != nil {
+		return err
+	}
+	for _, nested := range cat.nested {
+		nestedPath := path.Clean("/" + strings.TrimPrefix(nested.Path, "/"))
+		if !shouldWalkNestedCatalog(nestedPath, prefix) {
+			continue
+		}
+		child, err := r.openCatalog(nested.Sha1)
+		if err != nil {
+			return err
+		}
+		if err := r.ensureCatalogPrefixIndexed(child, path.Dir(nestedPath), prefix); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *repository) indexCatalog(cat *catalog, baseParent string) error {
+	r.indexMu.Lock()
+	defer r.indexMu.Unlock()
+	if r.indexedCatalogs == nil {
+		r.indexedCatalogs = make(map[*catalog]bool)
+	}
+	if r.globalPaths == nil {
+		r.globalPaths = map[string]string{"0:0": "/"}
+	}
+	if r.entriesByPath == nil {
+		r.entriesByPath = make(map[string]catalogEntry)
+	}
+	if r.childrenByPath == nil {
+		r.childrenByPath = make(map[string][]catalogEntry)
+	}
+	if r.indexedCatalogs[cat] {
+		return nil
+	}
+	local := make(map[string]catalogEntry, len(cat.entries))
+	for _, ent := range cat.entries {
+		local[ent.pathHash()] = ent
+	}
+	memo := make(map[string]string, len(cat.entries))
+	resolving := make(map[string]bool)
+	var resolve func(catalogEntry) (string, error)
+	resolve = func(ent catalogEntry) (string, error) {
+		hash := ent.pathHash()
+		if full, ok := memo[hash]; ok {
+			return full, nil
+		}
+		if resolving[hash] {
+			return "", fmt.Errorf("catalog parent cycle at %q in repo %q", ent.Name, r.repo)
+		}
+		resolving[hash] = true
+		defer delete(resolving, hash)
+		parentPath, ok := r.globalPaths[ent.parentHash()]
+		if !ok {
+			if ent.parentHash() == "0:0" {
+				parentPath = baseParent
+			} else if parent, exists := local[ent.parentHash()]; exists {
+				full, err := resolve(parent)
+				if err != nil {
+					return "", err
+				}
+				parentPath = full
+			} else {
+				return "", fmt.Errorf("parent not found for %q in repo %q", ent.Name, r.repo)
+			}
+		}
+		full := path.Clean(path.Join(parentPath, ent.Name))
+		memo[hash] = full
+		r.globalPaths[hash] = full
+		return full, nil
+	}
+	for index := range cat.entries {
+		full, err := resolve(cat.entries[index])
+		if err != nil {
+			return err
+		}
+		cat.entries[index].FullPath = full
+		entry := cat.entries[index]
+		r.entriesByPath[full] = entry
+		parent := path.Dir(full)
+		r.childrenByPath[parent] = append(r.childrenByPath[parent], entry)
+	}
+	r.indexedCatalogs[cat] = true
+	return nil
 }
 
 func (r *repository) walkPrefix(prefix string, visit func(ent catalogEntry) error) error {
@@ -1455,42 +1538,12 @@ func (r *repository) walkPrefixWithNested(prefix string, shouldWalkNested func(s
 }
 
 func (r *repository) walkCatalog(cat *catalog, baseParent, prefix string, globalPaths map[string]string, shouldWalkNested func(string, string) bool, visit func(ent catalogEntry) error) error {
-	local := make(map[string]catalogEntry, len(cat.entries))
-	for _, ent := range cat.entries {
-		local[ent.pathHash()] = ent
-	}
-	memo := map[string]string{}
-	var resolve func(catalogEntry) (string, error)
-	resolve = func(ent catalogEntry) (string, error) {
-		if full, ok := memo[ent.pathHash()]; ok {
-			return full, nil
-		}
-		parentPath, ok := globalPaths[ent.parentHash()]
-		if !ok {
-			if ent.parentHash() == "0:0" {
-				parentPath = baseParent
-			} else if parent, ok := local[ent.parentHash()]; ok {
-				full, err := resolve(parent)
-				if err != nil {
-					return "", err
-				}
-				parentPath = full
-			} else {
-				return "", fmt.Errorf("parent not found for %q in repo %q", ent.Name, r.repo)
-			}
-		}
-		full := path.Clean(path.Join(parentPath, ent.Name))
-		memo[ent.pathHash()] = full
-		globalPaths[ent.pathHash()] = full
-		return full, nil
+	if err := r.indexCatalog(cat, baseParent); err != nil {
+		return err
 	}
 	for i := range cat.entries {
-		full, err := resolve(cat.entries[i])
-		if err != nil {
-			return err
-		}
-		cat.entries[i].FullPath = full
-		if hasCommonFragment(full, prefix) {
+		globalPaths[cat.entries[i].pathHash()] = cat.entries[i].FullPath
+		if hasCommonFragment(cat.entries[i].FullPath, prefix) {
 			if err := visit(cat.entries[i]); err != nil {
 				return err
 			}

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -123,6 +123,9 @@ type WalkEntry struct {
 	Symlink string
 }
 
+// Entry describes one logical node in a CVMFS repository.
+type Entry = WalkEntry
+
 type Client struct {
 	HTTPClient             *http.Client
 	Context                context.Context
@@ -130,6 +133,7 @@ type Client struct {
 	CacheDir               string
 	TraceLogPath           string
 	OnActivity             func(ActivityEvent)
+	OnTransfer             func(TransferEvent)
 	Mirrors                []string
 
 	mu           sync.Mutex
@@ -154,6 +158,19 @@ type ActivityEvent struct {
 	CachePath string
 }
 
+type TransferEvent struct {
+	Time       time.Time
+	ID         uint64
+	State      string
+	Repo       string
+	Path       string
+	URL        string
+	Mirror     string
+	Bytes      int64
+	TotalBytes int64
+	Error      string
+}
+
 type traceEvent struct {
 	Time       string  `json:"time"`
 	ID         uint64  `json:"id"`
@@ -169,6 +186,7 @@ type traceEvent struct {
 }
 
 var traceID atomic.Uint64
+var transferID atomic.Uint64
 
 type manifest struct {
 	RootCatalogHash string
@@ -328,6 +346,26 @@ func (c *Client) ReadDir(target string) ([]DirEntry, error) {
 	entries, err := repo.ReadDir(parsed.Path)
 	c.traceDone(id, started, "ReadDir", target, "", "", len(entries), 0, err)
 	return entries, err
+}
+
+// Stat resolves a single logical CVMFS path without reading its contents.
+func (c *Client) Stat(target string) (Entry, error) {
+	parsed, err := ParseTarget(target)
+	if err != nil {
+		return Entry{}, err
+	}
+	if !parsed.Remote {
+		info, err := os.Lstat(parsed.LocalPath)
+		if err != nil {
+			return Entry{}, err
+		}
+		entry := Entry{Path: parsed.LocalPath, Mode: info.Mode(), Size: info.Size(), ModTime: info.ModTime()}
+		if info.Mode()&fs.ModeSymlink != 0 {
+			entry.Symlink, err = os.Readlink(parsed.LocalPath)
+		}
+		return entry, err
+	}
+	return c.newRepository(parsed).Stat(parsed.Path)
 }
 
 func (c *Client) ReadFile(target string) ([]byte, error) {
@@ -770,6 +808,36 @@ func (r *repository) ReadDir(dirPath string) ([]DirEntry, error) {
 	return out, nil
 }
 
+func (r *repository) Stat(nodePath string) (Entry, error) {
+	nodePath = path.Clean("/" + strings.TrimPrefix(nodePath, "/"))
+	if nodePath == "/" {
+		if _, err := r.rootCatalog(); err != nil {
+			return Entry{}, err
+		}
+		return Entry{Path: "/", Mode: fs.ModeDir | 0o555}, nil
+	}
+	var found *catalogEntry
+	err := r.walkPrefix(nodePath, func(ent catalogEntry) error {
+		if ent.FullPath != nodePath {
+			return nil
+		}
+		copy := ent
+		found = &copy
+		return errStopWalk
+	})
+	if err != nil && !errors.Is(err, errStopWalk) {
+		return Entry{}, err
+	}
+	if found == nil {
+		return Entry{}, os.ErrNotExist
+	}
+	return Entry{
+		Path: found.FullPath, Mode: linuxModeToGo(uint32(found.Mode)), Size: found.Size,
+		ModTime: time.Unix(found.Mtime, found.MtimeNS), UID: uint32(found.UID), GID: uint32(found.GID),
+		Symlink: found.Symlink,
+	}, nil
+}
+
 func (r *repository) ReadFile(filePath string) ([]byte, error) {
 	filePath = path.Clean("/" + strings.TrimPrefix(filePath, "/"))
 	var found *catalogEntry
@@ -874,7 +942,7 @@ func (r *repository) orderedMirrors() []string {
 	ranked := make([]rankedMirror, 0, len(r.mirrors))
 	for i, mirror := range r.mirrors {
 		stat := r.client.mirrorStats[mirror]
-		if stat == nil || stat.successes == 0 {
+		if stat == nil {
 			ranked = append(ranked, rankedMirror{
 				mirror: mirror,
 				index:  int((uint64(i) + cursor) % uint64(len(r.mirrors))),
@@ -937,7 +1005,7 @@ func (c *Client) recordMirrorResult(mirror string, duration time.Duration, err e
 	}
 }
 
-func (r *repository) getFromMirrors(op string, urlFor func(string) string, handle func(url string, resp *http.Response, id uint64, started time.Time) error) error {
+func (r *repository) getFromMirrors(op, logicalPath string, urlFor func(string) string, handle func(url string, resp *http.Response, id uint64, started time.Time) error) error {
 	var lastErr error
 	for _, mirror := range r.orderedMirrors() {
 		url := urlFor(mirror)
@@ -981,12 +1049,37 @@ func (r *repository) getFromMirrors(op string, urlFor func(string) string, handl
 			lastErr = err
 			continue
 		}
+		var transfer *transferReader
+		if logicalPath != "" && r.client != nil && r.client.OnTransfer != nil {
+			total := resp.ContentLength
+			if total < 0 {
+				total = 0
+			}
+			transfer = &transferReader{
+				reader: resp.Body, client: r.client,
+				event: TransferEvent{ID: transferID.Add(1), Repo: r.repo, Path: logicalPath, URL: url, Mirror: mirror, TotalBytes: total},
+			}
+			transfer.emit("started", "")
+			resp.Body = struct {
+				io.Reader
+				io.Closer
+			}{Reader: transfer, Closer: resp.Body}
+		}
 		err = handle(url, resp, id, started)
 		closeErr := resp.Body.Close()
 		if err == nil {
 			err = closeErr
 		}
 		r.client.recordMirrorResult(mirror, time.Since(started), err, resp.StatusCode)
+		if transfer != nil {
+			state := "completed"
+			detail := ""
+			if err != nil {
+				state = "failed"
+				detail = err.Error()
+			}
+			transfer.emit(state, detail)
+		}
 		if err == nil {
 			return nil
 		}
@@ -996,6 +1089,32 @@ func (r *repository) getFromMirrors(op string, urlFor func(string) string, handl
 		lastErr = fmt.Errorf("no CVMFS mirrors configured for %s", r.repo)
 	}
 	return lastErr
+}
+
+type transferReader struct {
+	reader io.Reader
+	client *Client
+	event  TransferEvent
+}
+
+func (r *transferReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.event.Bytes += int64(n)
+		r.emit("progress", "")
+	}
+	return n, err
+}
+
+func (r *transferReader) emit(state, detail string) {
+	if r == nil || r.client == nil || r.client.OnTransfer == nil {
+		return
+	}
+	event := r.event
+	event.Time = time.Now()
+	event.State = state
+	event.Error = detail
+	r.client.OnTransfer(event)
 }
 
 func (r *repository) Walk(rootPath string, visit func(WalkEntry) error) error {
@@ -1043,7 +1162,7 @@ func (r *repository) readEntryData(ent catalogEntry) ([]byte, error) {
 
 func (r *repository) streamEntryData(ent catalogEntry, dst io.Writer, cacheCompressed bool) error {
 	if ent.Flags&flagExternalFile == 0 && !ent.isChunked() {
-		return r.streamDataObject(stringifyHash(ent.Hash), false, dst, cacheCompressed)
+		return r.streamDataObject(stringifyHash(ent.Hash), false, ent.FullPath, dst, cacheCompressed)
 	}
 	if len(ent.Chunks) == 0 {
 		return fmt.Errorf("chunk metadata missing for %q", ent.FullPath)
@@ -1059,7 +1178,7 @@ func (r *repository) streamEntryData(ent catalogEntry, dst io.Writer, cacheCompr
 			chunkWriter = &limitedWriter{w: dst, n: remaining}
 		}
 		counting := &countingWriter{w: chunkWriter}
-		if err := r.streamDataObject(stringifyHash(chunk.Hash), true, counting, cacheCompressed); err != nil {
+		if err := r.streamDataObject(stringifyHash(chunk.Hash), true, ent.FullPath, counting, cacheCompressed); err != nil {
 			return err
 		}
 		written += counting.n
@@ -1072,7 +1191,7 @@ func (r *repository) streamEntryDataRange(ent catalogEntry, offset, length int64
 		return nil
 	}
 	if ent.Flags&flagExternalFile == 0 && !ent.isChunked() {
-		return r.streamDataObjectRange(stringifyHash(ent.Hash), false, offset, length, dst)
+		return r.streamDataObjectRange(stringifyHash(ent.Hash), false, ent.FullPath, offset, length, dst)
 	}
 	if len(ent.Chunks) == 0 {
 		return fmt.Errorf("chunk metadata missing for %q", ent.FullPath)
@@ -1099,6 +1218,7 @@ func (r *repository) streamEntryDataRange(ent catalogEntry, offset, length int64
 		if err := r.streamDataObjectRange(
 			stringifyHash(chunk.Hash),
 			true,
+			ent.FullPath,
 			overlapStart-chunkStart,
 			overlapEnd-overlapStart,
 			dst,
@@ -1109,7 +1229,7 @@ func (r *repository) streamEntryDataRange(ent catalogEntry, offset, length int64
 	return nil
 }
 
-func (r *repository) streamDataObject(hash string, partial bool, dst io.Writer, cacheCompressed bool) error {
+func (r *repository) streamDataObject(hash string, partial bool, logicalPath string, dst io.Writer, cacheCompressed bool) error {
 	suffix := ""
 	if partial {
 		suffix = "P"
@@ -1127,7 +1247,7 @@ func (r *repository) streamDataObject(hash string, partial bool, dst io.Writer, 
 	}
 
 	cachePath := cvmfsObjectCachePath(r.client.CacheDir, hash, suffix)
-	return r.getFromMirrors("HTTPObject", func(mirror string) string {
+	return r.getFromMirrors("HTTPObject", logicalPath, func(mirror string) string {
 		return r.objectURL(mirror, hash, suffix)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
 		reader := r.client.activityReader("HTTPObject", "", url, cachePath, resp.Body)
@@ -1169,7 +1289,7 @@ func (r *repository) streamDataObject(hash string, partial bool, dst io.Writer, 
 	})
 }
 
-func (r *repository) streamDataObjectRange(hash string, partial bool, offset, length int64, dst io.Writer) error {
+func (r *repository) streamDataObjectRange(hash string, partial bool, logicalPath string, offset, length int64, dst io.Writer) error {
 	suffix := ""
 	if partial {
 		suffix = "P"
@@ -1186,7 +1306,7 @@ func (r *repository) streamDataObjectRange(hash string, partial bool, offset, le
 	}
 
 	cachePath := cvmfsObjectCachePath(r.client.CacheDir, hash, suffix)
-	return r.getFromMirrors("HTTPObjectRange", func(mirror string) string {
+	return r.getFromMirrors("HTTPObjectRange", logicalPath, func(mirror string) string {
 		return r.objectURL(mirror, hash, suffix)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
 		reader := r.client.activityReader("HTTPObjectRange", "", url, cachePath, resp.Body)
@@ -1386,7 +1506,7 @@ func (r *repository) getManifest() (*manifest, error) {
 
 func (r *repository) fetchManifest() ([]byte, error) {
 	var body []byte
-	err := r.getFromMirrors("HTTPManifest", func(mirror string) string {
+	err := r.getFromMirrors("HTTPManifest", "", func(mirror string) string {
 		return fmt.Sprintf("%s/%s/.cvmfspublished", mirror, r.repo)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
 		ctx := r.client.Context
@@ -1504,7 +1624,7 @@ func (r *repository) fetchCompressedObject(hash, suffix string) ([]byte, error) 
 	}
 
 	var buf bytes.Buffer
-	err := r.getFromMirrors("HTTPObject", func(mirror string) string {
+	err := r.getFromMirrors("HTTPObject", "", func(mirror string) string {
 		return r.objectURL(mirror, hash, suffix)
 	}, func(url string, resp *http.Response, id uint64, started time.Time) error {
 		buf.Reset()

--- a/internal/cvmfs/cvmfs.go
+++ b/internal/cvmfs/cvmfs.go
@@ -140,6 +140,7 @@ type Client struct {
 	repos        map[string]*repository
 	mirrorStats  map[string]*mirrorStat
 	mirrorCursor uint64
+	preferred    string
 }
 
 func (c *Client) expandedObjectBudget() int64 {
@@ -681,9 +682,13 @@ func (c *Client) newRepository(target Target) *repository {
 }
 
 func (c *Client) candidateMirrors(primary string) []string {
+	c.mu.Lock()
+	preferred := c.preferred
+	configured := append([]string(nil), c.Mirrors...)
+	c.mu.Unlock()
 	seen := map[string]bool{}
-	candidates := make([]string, 0, len(c.Mirrors)+1)
-	for _, raw := range append([]string{primary}, c.Mirrors...) {
+	candidates := make([]string, 0, len(configured)+2)
+	for _, raw := range append([]string{preferred, primary}, configured...) {
 		mirror := normalizeMirror(raw)
 		if mirror == "" || seen[mirror] {
 			continue
@@ -697,7 +702,8 @@ func (c *Client) candidateMirrors(primary string) []string {
 	return candidates
 }
 
-func normalizeMirror(raw string) string {
+// NormalizeMirror returns the canonical CVMFS HTTP base used by the client.
+func NormalizeMirror(raw string) string {
 	raw = strings.TrimSpace(strings.TrimRight(raw, "/"))
 	if raw == "" {
 		return ""
@@ -712,6 +718,19 @@ func normalizeMirror(raw string) string {
 		u.Path = strings.TrimRight(u.Path, "/") + "/cvmfs"
 	}
 	return strings.TrimRight(u.String(), "/")
+}
+
+func normalizeMirror(raw string) string { return NormalizeMirror(raw) }
+
+// SetPreferredMirror makes a measured or user-selected mirror the first
+// choice for future repository operations while retaining failover mirrors.
+func (c *Client) SetPreferredMirror(mirror string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.preferred = normalizeMirror(mirror)
+	c.mu.Unlock()
 }
 
 func readLocalDir(dir string) ([]DirEntry, error) {
@@ -974,6 +993,19 @@ func (r *repository) orderedMirrors() []string {
 	out := make([]string, 0, len(ranked))
 	for _, item := range ranked {
 		out = append(out, item.mirror)
+	}
+	preferred := r.client.preferred
+	if preferred != "" {
+		stat := r.client.mirrorStats[preferred]
+		if stat == nil || stat.failures == 0 {
+			for index, mirror := range out {
+				if mirror == preferred {
+					copy(out[1:index+1], out[:index])
+					out[0] = preferred
+					break
+				}
+			}
+		}
 	}
 	return out
 }

--- a/internal/cvmfs/imagefs.go
+++ b/internal/cvmfs/imagefs.go
@@ -1,0 +1,100 @@
+package cvmfs
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"time"
+
+	"j5.nz/cc/internal/imagefs"
+)
+
+// NewImageFS exposes a CVMFS target as a lazy imagefs tree. Directory and file
+// data are resolved only when the guest looks them up or reads them.
+func NewImageFS(client *Client, target string) (imagefs.Directory, error) {
+	if client == nil {
+		return nil, fmt.Errorf("CVMFS client is required")
+	}
+	parsed, err := ParseTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	// Keep mount creation offline-safe. The first lookup validates the remote
+	// repository and reports any network or catalog error to the guest.
+	entry := Entry{Path: parsed.Path, Mode: fs.ModeDir | 0o555}
+	return &imageDirectory{client: client, target: parsed, entry: entry}, nil
+}
+
+type imageDirectory struct {
+	client *Client
+	target Target
+	entry  Entry
+}
+
+func (d *imageDirectory) Stat() fs.FileMode       { return d.entry.Mode }
+func (d *imageDirectory) ModTime() time.Time      { return d.entry.ModTime }
+func (d *imageDirectory) Owner() (uint32, uint32) { return d.entry.UID, d.entry.GID }
+func (d *imageDirectory) RDev() uint32            { return d.entry.RDev }
+
+func (d *imageDirectory) ReadDir() ([]imagefs.DirEnt, error) {
+	target, err := FormatTarget(d.target)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := d.client.ReadDir(target)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]imagefs.DirEnt, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, imagefs.DirEnt{Name: entry.Name, Mode: entry.Mode})
+	}
+	return out, nil
+}
+
+func (d *imageDirectory) Lookup(name string) (imagefs.Entry, error) {
+	if name == "" || name == "." || name == ".." || path.Base(name) != name {
+		return imagefs.Entry{}, fs.ErrNotExist
+	}
+	child := d.target
+	child.Path = path.Join(d.target.Path, name)
+	target, err := FormatTarget(child)
+	if err != nil {
+		return imagefs.Entry{}, err
+	}
+	entry, err := d.client.Stat(target)
+	if err != nil {
+		return imagefs.Entry{}, err
+	}
+	switch {
+	case entry.Mode.IsDir():
+		return imagefs.Entry{Dir: &imageDirectory{client: d.client, target: child, entry: entry}}, nil
+	case entry.Mode&fs.ModeSymlink != 0:
+		return imagefs.Entry{Symlink: imageSymlink{entry: entry}}, nil
+	default:
+		return imagefs.Entry{File: &imageFile{client: d.client, target: target, entry: entry}}, nil
+	}
+}
+
+type imageFile struct {
+	client *Client
+	target string
+	entry  Entry
+}
+
+func (f *imageFile) Stat() (uint64, fs.FileMode) { return uint64(max(0, f.entry.Size)), f.entry.Mode }
+func (f *imageFile) ModTime() time.Time          { return f.entry.ModTime }
+func (f *imageFile) Owner() (uint32, uint32)     { return f.entry.UID, f.entry.GID }
+func (f *imageFile) RDev() uint32                { return f.entry.RDev }
+func (f *imageFile) ReadAt(off uint64, size uint32) ([]byte, error) {
+	data, _, err := f.client.ReadFileRange(f.target, int64(off), int64(size))
+	return data, err
+}
+
+type imageSymlink struct{ entry Entry }
+
+func (s imageSymlink) Stat() fs.FileMode       { return s.entry.Mode }
+func (s imageSymlink) ModTime() time.Time      { return s.entry.ModTime }
+func (s imageSymlink) Target() string          { return s.entry.Symlink }
+func (s imageSymlink) Owner() (uint32, uint32) { return s.entry.UID, s.entry.GID }
+func (s imageSymlink) RDev() uint32            { return s.entry.RDev }

--- a/internal/cvmfs/mirror_test.go
+++ b/internal/cvmfs/mirror_test.go
@@ -1,0 +1,49 @@
+package cvmfs
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestMirrorSelectionExploresNewMirrorsAndDemotesFailures(t *testing.T) {
+	client := NewClient()
+	client.mirrorStats = map[string]*mirrorStat{
+		"failed": {failures: 1},
+		"fast":   {successes: 1, ewma: 100 * time.Millisecond},
+	}
+	repo := &repository{client: client, mirrors: []string{"failed", "fast", "untried"}}
+
+	ordered := repo.orderedMirrors()
+	if len(ordered) != 3 || ordered[0] != "untried" || ordered[1] != "fast" || ordered[2] != "failed" {
+		t.Fatalf("mirror order = %v, want untried then healthy then failed", ordered)
+	}
+}
+
+func TestMirrorDownloadReportsLogicalTransfer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "payload")
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	var events []TransferEvent
+	client.OnTransfer = func(event TransferEvent) { events = append(events, event) }
+	repo := &repository{client: client, repo: "repo.example", mirrors: []string{server.URL}}
+	err := repo.getFromMirrors("test", "/containers/tool.sif", func(mirror string) string { return mirror }, func(_ string, response *http.Response, _ uint64, _ time.Time) error {
+		_, err := io.Copy(io.Discard, response.Body)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) < 3 || events[0].State != "started" || events[len(events)-1].State != "completed" {
+		t.Fatalf("transfer events = %+v", events)
+	}
+	completed := events[len(events)-1]
+	if completed.Repo != "repo.example" || completed.Path != "/containers/tool.sif" || completed.Bytes != int64(len("payload")) {
+		t.Fatalf("completed transfer = %+v", completed)
+	}
+}

--- a/internal/cvmfs/mirror_test.go
+++ b/internal/cvmfs/mirror_test.go
@@ -47,3 +47,23 @@ func TestMirrorDownloadReportsLogicalTransfer(t *testing.T) {
 		t.Fatalf("completed transfer = %+v", completed)
 	}
 }
+
+func TestCatalogPathIndexIsBuiltOnceWithoutDuplicateChildren(t *testing.T) {
+	repo := &repository{repo: "repo.example"}
+	cat := &catalog{entries: []catalogEntry{
+		{Md5Path1: 1, Md5Path2: 1, Name: "containers"},
+		{Md5Path1: 2, Md5Path2: 2, Parent1: 1, Parent2: 1, Name: "tool"},
+	}}
+	if err := repo.indexCatalog(cat, "/"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.indexCatalog(cat, "/"); err != nil {
+		t.Fatal(err)
+	}
+	if got := repo.entriesByPath["/containers/tool"].Name; got != "tool" {
+		t.Fatalf("indexed tool name = %q", got)
+	}
+	if got := len(repo.childrenByPath["/containers"]); got != 1 {
+		t.Fatalf("indexed child count = %d, want 1", got)
+	}
+}

--- a/internal/cvmfs/probe.go
+++ b/internal/cvmfs/probe.go
@@ -120,21 +120,33 @@ func probeRootCatalog(ctx context.Context, httpClient *http.Client, repo string,
 	if result == nil || len(result.rootHash) < 3 {
 		return
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 12*time.Second)
-	defer cancel()
-	started := time.Now()
-	url := fmt.Sprintf("%s/%s/data/%s/%sC?cvmfs_probe=%d", result.Mirror, repo, result.rootHash[:2], result.rootHash[2:], started.UnixNano())
-	body, err := probeDownload(probeCtx, httpClient, url, catalogProbeLimit)
-	result.RootCatalogDuration = time.Since(started)
-	if err != nil {
-		result.Error = err.Error()
-		return
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		probeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+		started := time.Now()
+		url := fmt.Sprintf("%s/%s/data/%s/%sC?cvmfs_probe=%d-%d", result.Mirror, repo, result.rootHash[:2], result.rootHash[2:], started.UnixNano(), attempt)
+		body, err := probeDownload(probeCtx, httpClient, url, catalogProbeLimit)
+		duration := time.Since(started)
+		cancel()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		bytes := int64(len(body))
+		rate := float64(0)
+		if seconds := duration.Seconds(); seconds > 0 && bytes > 0 {
+			rate = float64(bytes) / seconds
+		}
+		if rate > result.RootCatalogBytesPerSec {
+			result.RootCatalogDuration = duration
+			result.RootCatalogBytes = bytes
+			result.RootCatalogBytesPerSec = rate
+		}
 	}
-	result.Error = ""
-	result.RootCatalogBytes = int64(len(body))
-	seconds := result.RootCatalogDuration.Seconds()
-	if seconds > 0 && result.RootCatalogBytes > 0 {
-		result.RootCatalogBytesPerSec = float64(result.RootCatalogBytes) / seconds
+	if result.RootCatalogBytesPerSec > 0 {
+		result.Error = ""
+	} else if lastErr != nil {
+		result.Error = lastErr.Error()
 	}
 }
 

--- a/internal/cvmfs/probe.go
+++ b/internal/cvmfs/probe.go
@@ -1,0 +1,163 @@
+package cvmfs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	manifestProbeLimit = int64(16 << 20)
+	catalogProbeLimit  = int64(64 << 20)
+	probeFinalists     = 5
+)
+
+type MirrorProbeResult struct {
+	Mirror                 string
+	ManifestLatency        time.Duration
+	RootCatalogDuration    time.Duration
+	RootCatalogBytes       int64
+	RootCatalogBytesPerSec float64
+	Error                  string
+	rootHash               string
+}
+
+// ProbeMirrors measures repository-manifest latency in parallel, then measures
+// root-catalog throughput sequentially for the quickest reachable finalists.
+func ProbeMirrors(ctx context.Context, httpClient *http.Client, repo string, mirrors []string) (string, []MirrorProbeResult, error) {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || strings.Contains(repo, "/") {
+		return "", nil, fmt.Errorf("invalid CVMFS repository %q", repo)
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	candidates := uniqueProbeMirrors(mirrors)
+	if len(candidates) == 0 {
+		return "", nil, fmt.Errorf("no CVMFS mirrors configured")
+	}
+	results := make([]MirrorProbeResult, len(candidates))
+	var group sync.WaitGroup
+	for index, mirror := range candidates {
+		group.Add(1)
+		go func(index int, mirror string) {
+			defer group.Done()
+			results[index] = probeManifest(ctx, httpClient, repo, mirror)
+		}(index, mirror)
+	}
+	group.Wait()
+
+	var reachable []int
+	for index := range results {
+		if results[index].rootHash != "" {
+			reachable = append(reachable, index)
+		}
+	}
+	sort.Slice(reachable, func(i, j int) bool {
+		return results[reachable[i]].ManifestLatency < results[reachable[j]].ManifestLatency
+	})
+	if len(reachable) > probeFinalists {
+		reachable = reachable[:probeFinalists]
+	}
+	selected := ""
+	bestRate := float64(0)
+	for _, index := range reachable {
+		probeRootCatalog(ctx, httpClient, repo, &results[index])
+		if results[index].RootCatalogBytesPerSec > bestRate {
+			bestRate = results[index].RootCatalogBytesPerSec
+			selected = results[index].Mirror
+		}
+	}
+	for index := range results {
+		results[index].rootHash = ""
+	}
+	if selected == "" {
+		return "", results, fmt.Errorf("no CVMFS mirror served the root catalog for %s", repo)
+	}
+	return selected, results, nil
+}
+
+func uniqueProbeMirrors(mirrors []string) []string {
+	seen := make(map[string]bool, len(mirrors))
+	out := make([]string, 0, len(mirrors))
+	for _, raw := range mirrors {
+		mirror := normalizeMirror(raw)
+		if mirror == "" || seen[mirror] {
+			continue
+		}
+		seen[mirror] = true
+		out = append(out, mirror)
+	}
+	return out
+}
+
+func probeManifest(ctx context.Context, httpClient *http.Client, repo, mirror string) MirrorProbeResult {
+	result := MirrorProbeResult{Mirror: mirror}
+	probeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	started := time.Now()
+	body, err := probeDownload(probeCtx, httpClient, fmt.Sprintf("%s/%s/.cvmfspublished?cvmfs_probe=%d", mirror, repo, started.UnixNano()), manifestProbeLimit)
+	result.ManifestLatency = time.Since(started)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	manifest, err := parseManifest(body)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.rootHash = manifest.RootCatalogHash
+	return result
+}
+
+func probeRootCatalog(ctx context.Context, httpClient *http.Client, repo string, result *MirrorProbeResult) {
+	if result == nil || len(result.rootHash) < 3 {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 12*time.Second)
+	defer cancel()
+	started := time.Now()
+	url := fmt.Sprintf("%s/%s/data/%s/%sC?cvmfs_probe=%d", result.Mirror, repo, result.rootHash[:2], result.rootHash[2:], started.UnixNano())
+	body, err := probeDownload(probeCtx, httpClient, url, catalogProbeLimit)
+	result.RootCatalogDuration = time.Since(started)
+	if err != nil {
+		result.Error = err.Error()
+		return
+	}
+	result.Error = ""
+	result.RootCatalogBytes = int64(len(body))
+	seconds := result.RootCatalogDuration.Seconds()
+	if seconds > 0 && result.RootCatalogBytes > 0 {
+		result.RootCatalogBytesPerSec = float64(result.RootCatalogBytes) / seconds
+	}
+}
+
+func probeDownload(ctx context.Context, httpClient *http.Client, url string, limit int64) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 32<<10))
+		return nil, fmt.Errorf("HTTP %s", response.Status)
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("response exceeds %d bytes", limit)
+	}
+	return data, nil
+}

--- a/internal/cvmfs/probe_test.go
+++ b/internal/cvmfs/probe_test.go
@@ -1,0 +1,56 @@
+package cvmfs
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeMirrorsSelectsFastestRootCatalog(t *testing.T) {
+	const rootHash = "0123456789abcdef0123456789abcdef01234567"
+	server := func(rootDelay time.Duration) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/.cvmfspublished"):
+				_, _ = fmt.Fprintf(w, "C%s\n", rootHash)
+			case strings.Contains(r.URL.Path, "/data/01/23456789abcdef0123456789abcdef01234567C"):
+				time.Sleep(rootDelay)
+				_, _ = w.Write(make([]byte, 1024))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	}
+	slow := server(80 * time.Millisecond)
+	defer slow.Close()
+	fast := server(5 * time.Millisecond)
+	defer fast.Close()
+
+	selected, results, err := ProbeMirrors(t.Context(), http.DefaultClient, "repo.example", []string{slow.URL, fast.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected != normalizeMirror(fast.URL) {
+		t.Fatalf("selected mirror = %q, want %q; results=%+v", selected, normalizeMirror(fast.URL), results)
+	}
+	if len(results) != 2 || results[1].RootCatalogBytes != 1024 || results[1].RootCatalogBytesPerSec <= results[0].RootCatalogBytesPerSec {
+		t.Fatalf("probe results = %+v", results)
+	}
+}
+
+func TestPreferredMirrorLeadsUntilItFails(t *testing.T) {
+	client := NewClient()
+	client.SetPreferredMirror("http://preferred.example")
+	preferred := normalizeMirror("http://preferred.example")
+	repo := &repository{client: client, mirrors: []string{"http://fallback.example/cvmfs", preferred}}
+	if ordered := repo.orderedMirrors(); len(ordered) != 2 || ordered[0] != preferred {
+		t.Fatalf("preferred mirror order = %v", ordered)
+	}
+	client.recordMirrorResult(preferred, time.Second, fmt.Errorf("unreachable"), 0)
+	if ordered := repo.orderedMirrors(); len(ordered) != 2 || ordered[0] == preferred {
+		t.Fatalf("failed preferred mirror was not demoted: %v", ordered)
+	}
+}

--- a/internal/vm/backend_darwin_arm64.go
+++ b/internal/vm/backend_darwin_arm64.go
@@ -589,6 +589,8 @@ func (b *runtimeBackend) buildStartRequest(ctx context.Context, req client.Creat
 		return vmruntime.RunRequest{}, err
 	}
 	runReq.Mounts = append(runReq.Mounts, persistentMounts...)
+	runReq.Mounts = append(runReq.Mounts, hostMountsFromContext(ctx)...)
+	runReq.Env = append([]string(nil), req.Env...)
 	runReq.DisplayWidth = displayWidthDarwin(req.Display)
 	runReq.DisplayHeight = displayHeightDarwin(req.Display)
 	timing.Since(ctx, "backend.convert_share_mounts", shareStart)
@@ -624,6 +626,7 @@ func (b *runtimeBackend) buildBlankStartRequest(ctx context.Context, req client.
 			Modules:           append([]alpine.Module(nil), bundle.Modules...),
 			Image:             sidecarBundleImage(bundle),
 			InitSystem:        req.InitSystem,
+			Env:               append([]string(nil), req.Env...),
 			RootFS:            rootFS,
 			Shares:            shares,
 			MemoryMB:          req.MemoryMB,
@@ -712,9 +715,10 @@ func (b *runtimeBackend) buildBlankStartRequest(ctx context.Context, req client.
 		Modules:           modules,
 		Image:             image,
 		InitSystem:        req.InitSystem,
+		Env:               append([]string(nil), req.Env...),
 		RootFS:            rootFS,
 		Shares:            shares,
-		Mounts:            persistentMounts,
+		Mounts:            append(persistentMounts, hostMountsFromContext(ctx)...),
 		MemoryMB:          req.MemoryMB,
 		BalloonMB:         req.BalloonMB,
 		CPUs:              req.CPUs,
@@ -772,9 +776,10 @@ func (b *runtimeBackend) buildBlankRestoreRequest(ctx context.Context, req clien
 	return vmruntime.RunRequest{
 		Image:           image,
 		InitSystem:      req.InitSystem,
+		Env:             append([]string(nil), req.Env...),
 		RootFS:          rootFS,
 		Shares:          shares,
-		Mounts:          persistentMounts,
+		Mounts:          append(persistentMounts, hostMountsFromContext(ctx)...),
 		MemoryMB:        req.MemoryMB,
 		BalloonMB:       req.BalloonMB,
 		CPUs:            req.CPUs,

--- a/internal/vm/backend_linux_amd64.go
+++ b/internal/vm/backend_linux_amd64.go
@@ -100,7 +100,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	fsdevs, rootFS, err := amd64vm.BuildFSDevices(vmruntime.RunRequest{
 		RootFS: kvmhost.RuntimeImageFS(image),
 		Shares: mounts.ConvertShareMounts(req.Shares),
-		Mounts: persistentMounts,
+		Mounts: append(persistentMounts, hostMountsFromContext(ctx)...),
 	}, nil)
 	if err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	initCfg := linuxGuestInitConfig(modules, true, req.Network, network)
 	initCfg.InitSystem = req.InitSystem
 	initCfg.RootFSTag = vmruntime.RootFSTag
-	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
+	initCfg.Env = vmruntime.WithDefaultEnv(vmruntime.MergeEnv(image.Config.Env, req.Env))
 	initCfg.WorkDir = workDir
 	if strings.TrimSpace(req.SnapshotDir) != "" {
 		initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
@@ -159,7 +159,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 			osName:         "Linux",
 			session:        started.Session,
 			root:           image.RootFS,
-			baseEnv:        vmruntime.WithDefaultEnv(image.Config.Env),
+			baseEnv:        vmruntime.WithDefaultEnv(vmruntime.MergeEnv(image.Config.Env, req.Env)),
 			defaultUser:    req.DefaultUser,
 			workDir:        workDir,
 			network:        network,
@@ -201,6 +201,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Display:          req.Display,
 			SharedMemory:     req.SharedMemory,
 			KernelModules:    append([]string(nil), req.KernelModules...),
+			Env:              append([]string(nil), req.Env...),
 			MemoryMB:         req.MemoryMB,
 			BalloonMB:        req.BalloonMB,
 			CPUs:             req.CPUs,
@@ -255,6 +256,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	rootFSBackend := virtio.NewImageFS(blankLinuxRuntimeRootFS(), "")
 	fsdevs, rootFS, err := amd64vm.BuildFSDevices(vmruntime.RunRequest{
 		RootFS: rootFSBackend,
+		Mounts: hostMountsFromContext(ctx),
 	}, nil)
 	if err != nil {
 		return nil, err
@@ -265,7 +267,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	initCfg := linuxGuestInitConfig(modules, true, req.Network, network)
 	initCfg.RootFSTag = vmruntime.RootFSTag
-	initCfg.Env = vmruntime.WithDefaultEnv(nil)
+	initCfg.Env = vmruntime.WithDefaultEnv(req.Env)
 	initCfg.WorkDir = "/"
 	if strings.TrimSpace(req.SnapshotDir) != "" {
 		initCfg.SnapshotMMIOBase = amd64vm.SnapshotBase
@@ -300,7 +302,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		managedInstance: &managedInstance{
 			osName:         "Linux",
 			session:        started.Session,
-			baseEnv:        vmruntime.WithDefaultEnv(nil),
+			baseEnv:        vmruntime.WithDefaultEnv(req.Env),
 			workDir:        "/",
 			network:        network,
 			caps:           managedguest.LinuxProfile.Caps,

--- a/internal/vm/backend_windows_amd64.go
+++ b/internal/vm/backend_windows_amd64.go
@@ -83,6 +83,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	fsdevs, rootFS, err := amd64vm.BuildFSDevices(vmruntime.RunRequest{
 		Image:  image,
 		Shares: mounts.ConvertShareMounts(req.Shares),
+		Mounts: hostMountsFromContext(ctx),
 	}, nil)
 	if err != nil {
 		return nil, err
@@ -112,7 +113,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 			return nil, err
 		}
 		return &windowsInstance{
-			managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(image.Config.Env), workDir),
+			managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(vmruntime.MergeEnv(image.Config.Env, req.Env)), workDir),
 			image:               image,
 			rootFS:              rootFS,
 			fsdevs:              fsdevs,
@@ -138,7 +139,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 	}
 	initCfg := windowsGuestInitConfig(modules, true, req.InitSystem)
 	initCfg.RootFSTag = vmruntime.RootFSTag
-	initCfg.Env = vmruntime.WithDefaultEnv(image.Config.Env)
+	initCfg.Env = vmruntime.WithDefaultEnv(vmruntime.MergeEnv(image.Config.Env, req.Env))
 	initCfg.WorkDir = workDir
 	initCfg.Network = windowsNetworkGuestInitConfig(network)
 	if strings.TrimSpace(req.SnapshotDir) != "" {
@@ -172,7 +173,7 @@ func (b *runtimeBackend) StartStream(ctx context.Context, req client.CreateInsta
 		return nil, err
 	}
 	return &windowsInstance{
-		managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(image.Config.Env), workDir),
+		managedInstanceCore: newWindowsManagedCore(started.Session, image, vmruntime.WithDefaultEnv(vmruntime.MergeEnv(image.Config.Env, req.Env)), workDir),
 		image:               image,
 		rootFS:              rootFS,
 		fsdevs:              fsdevs,
@@ -206,6 +207,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			Network:         req.Network,
 			Display:         req.Display,
 			KernelModules:   append([]string(nil), req.KernelModules...),
+			Env:             append([]string(nil), req.Env...),
 			MemoryMB:        req.MemoryMB,
 			BalloonMB:       req.BalloonMB,
 			CPUs:            req.CPUs,
@@ -230,6 +232,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	rootFSBackend := virtio.NewImageFS(blankWindowsRuntimeRootFS(), "")
 	fsdevs, rootFS, err := amd64vm.BuildFSDevices(vmruntime.RunRequest{
 		RootFS: rootFSBackend,
+		Mounts: hostMountsFromContext(ctx),
 	}, nil)
 	if err != nil {
 		return nil, err
@@ -256,7 +259,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 			return nil, err
 		}
 		return &windowsInstance{
-			managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(nil), "/"),
+			managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(req.Env), "/"),
 			rootFS:              rootFS,
 			fsdevs:              fsdevs,
 			network:             network,
@@ -280,7 +283,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 	}
 	initCfg := windowsGuestInitConfig(modules, true, req.InitSystem)
 	initCfg.RootFSTag = vmruntime.RootFSTag
-	initCfg.Env = vmruntime.WithDefaultEnv(nil)
+	initCfg.Env = vmruntime.WithDefaultEnv(req.Env)
 	initCfg.WorkDir = "/"
 	initCfg.Network = windowsNetworkGuestInitConfig(network)
 	if strings.TrimSpace(req.SnapshotDir) != "" {
@@ -314,7 +317,7 @@ func (b *runtimeBackend) StartBlankStream(ctx context.Context, req client.StartI
 		return nil, err
 	}
 	return &windowsInstance{
-		managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(nil), "/"),
+		managedInstanceCore: newWindowsManagedCore(started.Session, nil, vmruntime.WithDefaultEnv(req.Env), "/"),
 		rootFS:              rootFS,
 		fsdevs:              fsdevs,
 		network:             network,

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -29,6 +29,25 @@ func TestInstanceStatusPreservesSubsecondStartIdentity(t *testing.T) {
 	}
 }
 
+func TestManagerMakesHostMountsAvailableDuringVMStart(t *testing.T) {
+	ctx := context.Background()
+	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 1})
+	host.queueInstance(newFakeInstance())
+	manager := testManager(host)
+	manager.SetHostMountProvider(func(context.Context, string) ([]virtio.ShareMount, error) {
+		return []virtio.ShareMount{{GuestPath: "/cvmfs/repo"}}, nil
+	})
+	defer manager.ShutdownAll(ctx)
+	if _, err := manager.Start(ctx, client.CreateInstanceRequest{ID: "mounted", Image: "image"}); err != nil {
+		t.Fatal(err)
+	}
+	host.mu.Lock()
+	defer host.mu.Unlock()
+	if len(host.hostMounts) != 1 || len(host.hostMounts[0]) != 1 || host.hostMounts[0][0].GuestPath != "/cvmfs/repo" {
+		t.Fatalf("host mounts observed at start = %+v", host.hostMounts)
+	}
+}
+
 func TestManagerStartRoutesExistingInstanceOperations(t *testing.T) {
 	ctx := context.Background()
 	host := newFakeHost(VMHostCapabilities{Backend: "fake", MaxVMs: 2, SupportsL2: true})
@@ -1339,6 +1358,7 @@ type fakeHost struct {
 	execInStreams     []fakeExecInCall
 	closeCalled       bool
 	hostCapabilitiesN int
+	hostMounts        [][]virtio.ShareMount
 }
 
 type blockingStartHost struct {
@@ -1435,9 +1455,10 @@ func (h *fakeHost) Start(ctx context.Context, req client.CreateInstanceRequest) 
 	return h.StartStream(ctx, req, nil)
 }
 
-func (h *fakeHost) StartStream(_ context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
+func (h *fakeHost) StartStream(ctx context.Context, req client.CreateInstanceRequest, onEvent func(client.BootEvent) error) (Instance, error) {
 	h.mu.Lock()
 	h.starts = append(h.starts, req)
+	h.hostMounts = append(h.hostMounts, hostMountsFromContext(ctx))
 	inst := h.popInstanceLocked()
 	h.mu.Unlock()
 	if controller, ok := inst.(interface{ SetBalloonMB(uint64) error }); ok {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -123,6 +123,16 @@ type Manager struct {
 	maxCPUs       int
 	closing       bool
 	sharedMemory  *shmem.Registry
+	hostMounts    func(context.Context, string) ([]virtio.ShareMount, error)
+}
+
+// SetHostMountProvider configures read-only host-managed filesystems that are
+// attached to every newly started instance. It must be called before starts
+// are accepted.
+func (m *Manager) SetHostMountProvider(provider func(context.Context, string) ([]virtio.ShareMount, error)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hostMounts = provider
 }
 
 type resourceReservation struct {
@@ -555,6 +565,12 @@ func (m *Manager) StartInstanceStream(ctx context.Context, id string, req client
 	if attachment != nil {
 		startCtx = shmem.WithAttachment(startCtx, attachment)
 	}
+	startCtx, err = m.prepareHostMountContext(startCtx, id)
+	if err != nil {
+		_ = attachment.Release()
+		m.finishStart(id, start)
+		return client.InstanceState{}, err
+	}
 	inst, err := m.host.StartStream(startCtx, req, onEvent)
 	if err != nil {
 		_ = attachment.Release()
@@ -723,6 +739,12 @@ func (m *Manager) StartBlankInstanceStream(
 	}
 	if attachment != nil {
 		startCtx = shmem.WithAttachment(startCtx, attachment)
+	}
+	startCtx, err = m.prepareHostMountContext(startCtx, id)
+	if err != nil {
+		_ = attachment.Release()
+		m.finishStart(id, start)
+		return client.InstanceState{}, err
 	}
 	inst, err := m.host.StartBlankStream(startCtx, req, onEvent)
 	if err != nil {
@@ -1093,6 +1115,33 @@ func addInstanceShares(ctx context.Context, instance vmhost.Instance, shares []c
 	return nil
 }
 
+type hostMountContextKey struct{}
+
+func withHostMounts(ctx context.Context, mounts []virtio.ShareMount) context.Context {
+	if len(mounts) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, hostMountContextKey{}, append([]virtio.ShareMount(nil), mounts...))
+}
+
+func hostMountsFromContext(ctx context.Context) []virtio.ShareMount {
+	mounts, _ := ctx.Value(hostMountContextKey{}).([]virtio.ShareMount)
+	return append([]virtio.ShareMount(nil), mounts...)
+}
+
+func (m *Manager) prepareHostMountContext(ctx context.Context, id string) (context.Context, error) {
+	m.mu.Lock()
+	provider := m.hostMounts
+	m.mu.Unlock()
+	if provider == nil {
+		return ctx, nil
+	}
+	mounts, err := provider(ctx, id)
+	if err != nil {
+		return ctx, fmt.Errorf("prepare host-managed filesystems: %w", err)
+	}
+	return withHostMounts(ctx, mounts), nil
+}
 func validateRuntimeShares(shares []client.ShareMount) error {
 	seen := make(map[string]client.ShareMount, len(shares))
 	for _, share := range shares {


### PR DESCRIPTION
## What changed

- expose lazy, read-only host CVMFS repositories inside guests through virtio-fs
- add logical-path transfer monitoring and a status API
- enforce a shared CVMFS cache-size limit while preserving repository state
- improve adaptive mirror ordering and demote failed mirrors
- benchmark configured mirrors using manifest latency and repeated root-catalog throughput measurements
- add pre-boot mirror probing and runtime preferred-mirror selection APIs
- accept both mirror origins and normalized `/cvmfs` mirror URLs when preparing host mounts
- index catalog paths and directory children once per loaded catalog instead of rebuilding them for every filesystem operation
- allow VM startup environment overrides so Neurodesktop can skip its guest CVMFS daemon

## Why

NeurodeskAppX should serve CVMFS from its long-lived host daemon, select a healthy fast mirror before boot, report recognizable download paths, and keep cache growth bounded. Reusing the catalog path index also removes repeated full-catalog scans from demand-driven container startup.

## Validation

- `go test ./...`
- `go test ./internal/cvmfs ./internal/ccvmd -count=1`
- Linux/amd64 VM backend cross-compile
- Windows/amd64 VM backend cross-compile
- macOS/arm64 native tests
- local Neurodesk workflow: `ml niimath` followed by `niimath`
- first `niimath` startup reduced from about 15 seconds to about 1.2 seconds on the test system