### PR TITLE
Add OCI-native delta image support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -276,6 +276,10 @@ func (c *Client) PullImageStreamContext(ctx context.Context, name string, req Pu
 	return c.postJSONProgressStreamContext(ctx, "/image/"+imagePathName(name), req, onEvent, progressStatusDownloaded)
 }
 
+func (c *Client) ActivateStagedImageContext(ctx context.Context, name, stagedName string) error {
+	return c.postJSONExpectOKContext(ctx, "/image/"+imagePathName(name), PullImageRequest{ActivateFrom: stagedName}, nil)
+}
+
 func (c *Client) DeleteImage(name string) error {
 	return c.DeleteImageContext(context.Background(), name)
 }

--- a/client/protocol.go
+++ b/client/protocol.go
@@ -128,6 +128,8 @@ type PullImageRequest struct {
 	Prefetch        bool         `json:"prefetch,omitempty"`
 	PrefetchWorkers int          `json:"prefetch_workers,omitempty"`
 	Refresh         bool         `json:"refresh,omitempty"`
+	KeepCompressed  bool         `json:"keep_compressed,omitempty"`
+	ActivateFrom    string       `json:"activate_from,omitempty"`
 }
 
 type ImageSource struct {
@@ -200,6 +202,12 @@ func (r PullImageRequest) MarshalJSON() ([]byte, error) {
 	if r.Refresh {
 		payload["refresh"] = true
 	}
+	if r.KeepCompressed {
+		payload["keep_compressed"] = true
+	}
+	if r.ActivateFrom != "" {
+		payload["activate_from"] = r.ActivateFrom
+	}
 	return json.Marshal(payload)
 }
 
@@ -211,6 +219,8 @@ func (r *PullImageRequest) UnmarshalJSON(data []byte) error {
 		Prefetch        bool            `json:"prefetch,omitempty"`
 		PrefetchWorkers int             `json:"prefetch_workers,omitempty"`
 		Refresh         bool            `json:"refresh,omitempty"`
+		KeepCompressed  bool            `json:"keep_compressed,omitempty"`
+		ActivateFrom    string          `json:"activate_from,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -222,6 +232,8 @@ func (r *PullImageRequest) UnmarshalJSON(data []byte) error {
 	r.Prefetch = raw.Prefetch
 	r.PrefetchWorkers = raw.PrefetchWorkers
 	r.Refresh = raw.Refresh
+	r.KeepCompressed = raw.KeepCompressed
+	r.ActivateFrom = raw.ActivateFrom
 	if len(raw.Source) == 0 || string(raw.Source) == "null" {
 		return nil
 	}

--- a/client/protocol_test.go
+++ b/client/protocol_test.go
@@ -1,6 +1,9 @@
 package client
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestPullImageRequestSourceStringRootFSTar(t *testing.T) {
 	req := PullImageRequest{SourceRef: &ImageSource{
@@ -13,5 +16,26 @@ func TestPullImageRequestSourceStringRootFSTar(t *testing.T) {
 	}
 	if source != "rootfs-tar:https://example.test/rootfs.tar.xz" {
 		t.Fatalf("source = %q", source)
+	}
+}
+
+func TestPullImageRequestRoundTripsExperimentalImageControls(t *testing.T) {
+	want := PullImageRequest{
+		Source:         "registry.example.test/team/neuro:latest",
+		Architecture:   "amd64",
+		Refresh:        true,
+		KeepCompressed: true,
+		ActivateFrom:   "ndappx/neuro-staged",
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got PullImageRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != want.Source || got.Architecture != want.Architecture || !got.Refresh || !got.KeepCompressed || got.ActivateFrom != want.ActivateFrom {
+		t.Fatalf("round-tripped request = %+v", got)
 	}
 }

--- a/cmd/estargz-repack-image/main.go
+++ b/cmd/estargz-repack-image/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"j5.nz/cc/internal/oci"
+)
+
+func main() {
+	var chunkSize int
+	var minChunkSize int
+	flag.IntVar(&chunkSize, "chunk-size", 256<<10, "uncompressed bytes per large-file chunk")
+	flag.IntVar(&minChunkSize, "min-chunk-size", 256<<10, "minimum bytes grouped into one gzip member")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] INPUT-OCI-LAYOUT OUTPUT-OCI-LAYOUT\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() != 2 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	err := oci.RepackOCIImageLayout(context.Background(), flag.Arg(0), flag.Arg(1), chunkSize, minChunkSize, func(event oci.OCIImageRepackEvent) {
+		fmt.Printf("manifest=%d layer=%d/%d input=%s output=%s size=%d members=%d\n",
+			event.Manifest,
+			event.Layer+1,
+			event.Layers,
+			event.InputDigest,
+			event.Result.BlobDigest,
+			event.Result.BlobSize,
+			event.Result.Members,
+		)
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "estargz-repack-image: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/estargz-repack/main.go
+++ b/cmd/estargz-repack/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"j5.nz/cc/internal/oci"
+)
+
+func main() {
+	var chunkSize int
+	var minChunkSize int
+	flag.IntVar(&chunkSize, "chunk-size", 256<<10, "uncompressed bytes per large-file chunk")
+	flag.IntVar(&minChunkSize, "min-chunk-size", 256<<10, "minimum bytes grouped into one gzip member")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] INPUT-LAYER OUTPUT-LAYER\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() != 2 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	result, err := oci.RepackStargzLayerFile(context.Background(), flag.Arg(0), flag.Arg(1), chunkSize, minChunkSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "estargz-repack: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("blob=%s\nsize=%d\ndiff_id=%s\ntoc=%s\nmembers=%d\n",
+		result.BlobDigest,
+		result.BlobSize,
+		result.DiffID,
+		result.TOCJSONDigest,
+		result.Members,
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/containerd/stargz-snapshotter/estargz v0.18.2
 	github.com/getkin/kin-openapi v0.140.0
 	github.com/klauspost/compress v1.18.6
 	github.com/ulikunitz/xz v0.5.15
@@ -22,6 +23,9 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/oasdiff/yaml v0.1.0 // indirect
 	github.com/oasdiff/yaml3 v0.0.13 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/vbatts/tar-split v0.12.2 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
+github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -25,6 +27,8 @@ github.com/oasdiff/yaml v0.1.0 h1:0bqZjfKc/8S9urj4JuwepX41WX9EoA6ifhU3SV06cXg=
 github.com/oasdiff/yaml v0.1.0/go.mod h1:kOlRmMdL2X3vucLCEQO5u61SU22RysnfXvcttrZA1O0=
 github.com/oasdiff/yaml3 v0.0.13 h1:06svmvOHOVBqF81+sY2EUScvUI/iS/vl2VIeUUxZQwg=
 github.com/oasdiff/yaml3 v0.0.13/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -36,8 +40,12 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
+github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -1535,8 +1535,9 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 			return
 		}
 		plan, err := srvState.images.PlanPull(r.Context(), imageName, source, oci.PullOptions{
-			Architecture: req.Architecture,
-			CVMFSMirrors: cvmfsSourceMirrors(req.SourceRef),
+			Architecture:         req.Architecture,
+			CVMFSMirrors:         cvmfsSourceMirrors(req.SourceRef),
+			KeepCompressedLayers: req.KeepCompressed,
 		})
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err)

--- a/internal/ccvmd/ccvmd.go
+++ b/internal/ccvmd/ccvmd.go
@@ -1597,6 +1597,15 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
+		if req.ActivateFrom != "" {
+			state, err := srvState.images.ActivateStaged(imageName, req.ActivateFrom)
+			if err != nil {
+				writeError(w, http.StatusConflict, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, state)
+			return
+		}
 		source, err := req.SourceString()
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err)
@@ -1614,11 +1623,12 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 			go func() {
 				defer close(events)
 				_, err := srvState.images.Pull(r.Context(), imageName, source, oci.PullOptions{
-					Architecture:    req.Architecture,
-					Prefetch:        req.Prefetch,
-					PrefetchWorkers: req.PrefetchWorkers,
-					CVMFSMirrors:    cvmfsSourceMirrors(req.SourceRef),
-					Refresh:         req.Refresh,
+					Architecture:         req.Architecture,
+					Prefetch:             req.Prefetch,
+					PrefetchWorkers:      req.PrefetchWorkers,
+					CVMFSMirrors:         cvmfsSourceMirrors(req.SourceRef),
+					Refresh:              req.Refresh,
+					KeepCompressedLayers: req.KeepCompressed,
 					Report: func(event client.ProgressEvent) {
 						if event.Artifact == "" {
 							event.Artifact = imageName
@@ -1647,11 +1657,12 @@ func newMuxWithRoutes(srvState *server, watchdog *watchdogController, shutdown f
 			return
 		}
 		state, err := srvState.images.Pull(r.Context(), imageName, source, oci.PullOptions{
-			Architecture:    req.Architecture,
-			Prefetch:        req.Prefetch,
-			PrefetchWorkers: req.PrefetchWorkers,
-			CVMFSMirrors:    cvmfsSourceMirrors(req.SourceRef),
-			Refresh:         req.Refresh,
+			Architecture:         req.Architecture,
+			Prefetch:             req.Prefetch,
+			PrefetchWorkers:      req.PrefetchWorkers,
+			CVMFSMirrors:         cvmfsSourceMirrors(req.SourceRef),
+			Refresh:              req.Refresh,
+			KeepCompressedLayers: req.KeepCompressed,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err)

--- a/internal/oci/indexedfs.go
+++ b/internal/oci/indexedfs.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
+	"container/list"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/stargz-snapshotter/estargz"
 	intcvmfs "j5.nz/cc/internal/cvmfs"
 	"j5.nz/cc/internal/download"
 	"j5.nz/cc/internal/fsmeta"
@@ -76,6 +78,8 @@ func buildIndexedRootFS(baseDir string, nodes []indexedNode) (imagefs.Directory,
 	root := newIndexedDir(fs.ModeDir|0o755, 0, 0, 0, time.Unix(0, 0))
 	byPath := map[string]*indexedDir{"/": root}
 	tarPaths := make(map[string]string)
+	stargzReaders := make(map[string]*estargz.Reader)
+	stargzCache := newStargzBlockCache(64 << 20)
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Path < nodes[j].Path })
 	for _, node := range nodes {
 		if node.Path == "/" {
@@ -102,7 +106,7 @@ func buildIndexedRootFS(baseDir string, nodes []indexedNode) (imagefs.Directory,
 			parent.entries[name] = imagefs.Entry{Dir: dir}
 			byPath[node.Path] = dir
 		case indexedKindFile:
-			file, err := buildIndexedFile(baseDir, "", node, modTime, nil, tarPaths)
+			file, err := buildIndexedFile(baseDir, "", node, modTime, nil, tarPaths, stargzReaders, stargzCache)
 			if err != nil {
 				return nil, err
 			}
@@ -157,7 +161,7 @@ func buildCVMFSIndexedRootFS(client *intcvmfs.Client, packedPath string, nodes [
 			parent.entries[name] = imagefs.Entry{Dir: dir}
 			byPath[node.Path] = dir
 		case indexedKindFile:
-			file, err := buildIndexedFile("", packedPath, node, modTime, client, nil)
+			file, err := buildIndexedFile("", packedPath, node, modTime, client, nil, nil, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -197,7 +201,7 @@ func attachIndexedNamespace(namespace *imagefs.Namespace) {
 	}
 }
 
-func buildIndexedFile(baseDir string, packedPath string, node indexedNode, modTime time.Time, cvmfsClient *intcvmfs.Client, tarPaths map[string]string) (imagefs.File, error) {
+func buildIndexedFile(baseDir string, packedPath string, node indexedNode, modTime time.Time, cvmfsClient *intcvmfs.Client, tarPaths map[string]string, stargzReaders map[string]*estargz.Reader, stargzCache *stargzBlockCache) (imagefs.File, error) {
 	if node.Packed {
 		if packedPath == "" {
 			return nil, fmt.Errorf("packed path is required for %q", node.Path)
@@ -226,6 +230,37 @@ func buildIndexedFile(baseDir string, packedPath string, node indexedNode, modTi
 			modTime: modTime,
 			target:  node.CVMFSTarget,
 			client:  cvmfsClient,
+		}, nil
+	}
+	if strings.HasPrefix(node.TarPath, stargzContentsPrefix) {
+		if stargzReaders == nil {
+			return nil, fmt.Errorf("eStargz reader cache is required for %q", node.Path)
+		}
+		rel := strings.TrimPrefix(node.TarPath, stargzContentsPrefix)
+		blobPath := filepath.Join(baseDir, rel)
+		reader := stargzReaders[blobPath]
+		if reader == nil {
+			var err error
+			reader, err = openStargzReader(blobPath)
+			if err != nil {
+				return nil, fmt.Errorf("open eStargz layer for %q: %w", node.Path, err)
+			}
+			stargzReaders[blobPath] = reader
+		}
+		contents, err := reader.OpenFile(node.Path)
+		if err != nil {
+			return nil, fmt.Errorf("open %q in eStargz layer: %w", node.Path, err)
+		}
+		return &indexedStargzFile{
+			mode:     imagefsMode(node.Mode, 0o644),
+			uid:      node.UID,
+			gid:      node.GID,
+			rdev:     node.RDev,
+			size:     node.Size,
+			modTime:  modTime,
+			contents: contents,
+			cache:    stargzCache,
+			cacheKey: blobPath + "\x00" + node.Path,
 		}, nil
 	}
 	tarPath := filepath.Join(baseDir, node.TarPath)
@@ -350,6 +385,78 @@ type indexedPackedFile struct {
 	offset       uint64
 }
 
+type indexedStargzFile struct {
+	mode     fs.FileMode
+	uid      uint32
+	gid      uint32
+	rdev     uint32
+	size     uint64
+	modTime  time.Time
+	contents *io.SectionReader
+	cache    *stargzBlockCache
+	cacheKey string
+}
+
+const stargzReadBlockSize = uint64(256 << 10)
+
+type stargzCacheEntry struct {
+	key  string
+	data []byte
+}
+
+// stargzBlockCache prevents the VM's page-sized reads from repeatedly
+// inflating the same compressed chunk. It is shared by all layers in one open
+// image and bounded independently of the image's uncompressed size.
+type stargzBlockCache struct {
+	mu       sync.Mutex
+	maximum  int
+	used     int
+	entries  map[string]*list.Element
+	recently *list.List
+}
+
+func newStargzBlockCache(maximum int) *stargzBlockCache {
+	return &stargzBlockCache{maximum: maximum, entries: make(map[string]*list.Element), recently: list.New()}
+}
+
+func (c *stargzBlockCache) get(key string) []byte {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	element := c.entries[key]
+	if element == nil {
+		return nil
+	}
+	c.recently.MoveToFront(element)
+	return element.Value.(stargzCacheEntry).data
+}
+
+func (c *stargzBlockCache) put(key string, data []byte) []byte {
+	if c == nil || len(data) > c.maximum {
+		return data
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if element := c.entries[key]; element != nil {
+		c.recently.MoveToFront(element)
+		return element.Value.(stargzCacheEntry).data
+	}
+	owned := append([]byte(nil), data...)
+	element := c.recently.PushFront(stargzCacheEntry{key: key, data: owned})
+	c.entries[key] = element
+	c.used += len(owned)
+	for c.used > c.maximum {
+		oldest := c.recently.Back()
+		entry := oldest.Value.(stargzCacheEntry)
+		delete(c.entries, entry.key)
+		c.used -= len(entry.data)
+		c.recently.Remove(oldest)
+	}
+	return owned
+}
+
 type indexedCVMFSFile struct {
 	mode    fs.FileMode
 	uid     uint32
@@ -429,6 +536,74 @@ func (f *indexedPackedFile) ReadAt(off uint64, size uint32) ([]byte, error) {
 	}
 	return buf[:n], nil
 }
+
+func (f *indexedStargzFile) Stat() (uint64, fs.FileMode) { return f.size, f.mode }
+func (f *indexedStargzFile) ModTime() time.Time          { return f.modTime }
+func (f *indexedStargzFile) Owner() (uint32, uint32)     { return f.uid, f.gid }
+func (f *indexedStargzFile) RDev() uint32                { return f.rdev }
+func (f *indexedStargzFile) OpenReader() (io.ReaderAt, io.Closer, error) {
+	return indexedStargzReaderAt{file: f}, noOpCloser{}, nil
+}
+func (f *indexedStargzFile) ReadAt(off uint64, size uint32) ([]byte, error) {
+	if off >= f.size || size == 0 {
+		return nil, nil
+	}
+	remaining := min(f.size-off, uint64(size))
+	buf := make([]byte, remaining)
+	n, err := f.readAt(buf, int64(off))
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+type indexedStargzReaderAt struct{ file *indexedStargzFile }
+
+func (r indexedStargzReaderAt) ReadAt(buf []byte, offset int64) (int, error) {
+	return r.file.readAt(buf, offset)
+}
+
+func (f *indexedStargzFile) readAt(buf []byte, offset int64) (int, error) {
+	if offset < 0 {
+		return 0, fmt.Errorf("negative eStargz read offset")
+	}
+	if offset >= int64(f.size) {
+		return 0, io.EOF
+	}
+	requested := len(buf)
+	buf = buf[:min(uint64(len(buf)), f.size-uint64(offset))]
+	total := 0
+	for len(buf) > 0 {
+		blockOffset := uint64(offset) / stargzReadBlockSize * stargzReadBlockSize
+		key := fmt.Sprintf("%s\x00%d", f.cacheKey, blockOffset)
+		block := f.cache.get(key)
+		if block == nil {
+			blockLength := min(stargzReadBlockSize, f.size-blockOffset)
+			block = make([]byte, blockLength)
+			n, err := f.contents.ReadAt(block, int64(blockOffset))
+			if err != nil && err != io.EOF {
+				return total, err
+			}
+			block = f.cache.put(key, block[:n])
+		}
+		within := uint64(offset) - blockOffset
+		if within >= uint64(len(block)) {
+			return total, io.ErrUnexpectedEOF
+		}
+		n := copy(buf, block[within:])
+		total += n
+		offset += int64(n)
+		buf = buf[n:]
+	}
+	if total < requested {
+		return total, io.EOF
+	}
+	return total, nil
+}
+
+type noOpCloser struct{}
+
+func (noOpCloser) Close() error { return nil }
 
 type offsetReaderAt struct {
 	reader io.ReaderAt

--- a/internal/oci/layerarchive.go
+++ b/internal/oci/layerarchive.go
@@ -553,6 +553,18 @@ func linkOrCopyLayerContents(srcPath, dstPath string) error {
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 		return err
 	}
+	if dstInfo, err := os.Stat(dstPath); err == nil {
+		srcInfo, err := os.Stat(srcPath)
+		if err != nil {
+			return err
+		}
+		if os.SameFile(srcInfo, dstInfo) {
+			return nil
+		}
+		return fmt.Errorf("layer contents destination already exists: %s", dstPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
 	if err := os.Link(srcPath, dstPath); err == nil {
 		return nil
 	}

--- a/internal/oci/layerarchive_test.go
+++ b/internal/oci/layerarchive_test.go
@@ -117,6 +117,7 @@ func TestUncachedLayerIndexesWhileItDownloads(t *testing.T) {
 					close(indexStarted)
 				}
 			},
+			false,
 		)
 	}()
 

--- a/internal/oci/layerarchive_test.go
+++ b/internal/oci/layerarchive_test.go
@@ -476,4 +476,27 @@ func TestFinalizedBinaryIndexOpensWithoutDuplicateMetadata(t *testing.T) {
 	}
 }
 
+func TestLinkOrCopyLayerContentsReusesExistingHardLink(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "cached-layer")
+	dstPath := filepath.Join(dir, "image", "layer")
+	want := []byte("compressed layer contents")
+	if err := os.WriteFile(srcPath, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkOrCopyLayerContents(srcPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkOrCopyLayerContents(srcPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("cached layer contents = %q, want %q", got, want)
+	}
+}
+
 var _ io.Reader = failOnRead{}

--- a/internal/oci/layerarchive_test.go
+++ b/internal/oci/layerarchive_test.go
@@ -110,7 +110,7 @@ func TestUncachedLayerIndexesWhileItDownloads(t *testing.T) {
 			"test/image",
 			"test",
 			layer,
-			func(int64) {},
+			func(int64, float64) {},
 			func(current int64) {
 				if current > 0 && !reported {
 					reported = true

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -1297,10 +1297,15 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 		missingLayers++
 	}
 	close(prepareJobs)
-	// Downloading, decompressing, and writing layer contents all share the same
-	// stream. Bound that combined work so large images do not saturate host CPU,
-	// disk, or network.
-	for range min(2, missingLayers) {
+	// Ordinary layers are decompressed and indexed while they download, so keep
+	// that CPU and disk-heavy pipeline conservative. Enhanced layers remain
+	// compressed and are predominantly independent registry I/O, where four
+	// workers avoid idle gaps between layer and range requests.
+	prepareWorkers := 2
+	if options.KeepCompressedLayers {
+		prepareWorkers = 4
+	}
+	for range min(prepareWorkers, missingLayers) {
 		go func() {
 			for layerIndex := range prepareJobs {
 				layer := mani.Layers[layerIndex]

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -1208,6 +1208,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 	prepareStarted := time.Now()
 	downloadedByLayer := make([]int64, len(mani.Layers))
 	indexedByLayer := make([]int64, len(mani.Layers))
+	downloadRateByLayer := make([]float64, len(mani.Layers))
 	for layerIndex, layer := range mani.Layers {
 		switch {
 		case s.cachedLayerArchiveAvailable(layer) || s.cachedStargzLayerAvailable(layer):
@@ -1222,7 +1223,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 			}
 		}
 	}
-	reportPipeline := func(layerIndex int, layer descriptor, downloaded, indexed *int64) {
+	reportPipeline := func(layerIndex int, layer descriptor, downloaded, indexed *int64, downloadRate *float64) {
 		pipelineMu.Lock()
 		if downloaded != nil {
 			downloadedByLayer[layerIndex] = min(layer.Size, max(0, *downloaded))
@@ -1230,10 +1231,15 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 		if indexed != nil {
 			indexedByLayer[layerIndex] = min(layer.Size, max(0, *indexed))
 		}
+		if downloadRate != nil {
+			downloadRateByLayer[layerIndex] = max(0, *downloadRate)
+		}
 		var downloadedBytes, indexedBytes, indexedLayers int64
+		var rateBytesPerSecond float64
 		for index := range mani.Layers {
 			downloadedBytes += downloadedByLayer[index]
 			indexedBytes += indexedByLayer[index]
+			rateBytesPerSecond += downloadRateByLayer[index]
 			if indexedByLayer[index] >= mani.Layers[index].Size {
 				indexedLayers++
 			}
@@ -1252,17 +1258,18 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 			status = "downloading"
 		}
 		report(client.ProgressEvent{
-			Status:           status,
-			Artifact:         name,
-			Blob:             layer.Digest,
-			Progress:         progress,
-			DownloadProgress: downloadProgress,
-			IndexProgress:    indexProgress,
-			BytesDownloaded:  downloadedBytes,
-			BytesTotal:       totalLayerBytes,
-			FilesDownloaded:  indexedLayers,
-			FilesTotal:       int64(len(mani.Layers)),
-			ETASeconds:       eta,
+			Status:             status,
+			Artifact:           name,
+			Blob:               layer.Digest,
+			Progress:           progress,
+			DownloadProgress:   downloadProgress,
+			IndexProgress:      indexProgress,
+			BytesDownloaded:    downloadedBytes,
+			BytesTotal:         totalLayerBytes,
+			RateBytesPerSecond: rateBytesPerSecond,
+			FilesDownloaded:    indexedLayers,
+			FilesTotal:         int64(len(mani.Layers)),
+			ETASeconds:         eta,
 		})
 	}
 	prepareCtx, cancelPrepare := context.WithCancel(ctx)
@@ -1303,11 +1310,11 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 					imageName,
 					name,
 					layer,
-					func(current int64) {
-						reportPipeline(layerIndex, layer, &current, nil)
+					func(current int64, rate float64) {
+						reportPipeline(layerIndex, layer, &current, nil, &rate)
 					},
 					func(current int64) {
-						reportPipeline(layerIndex, layer, nil, &current)
+						reportPipeline(layerIndex, layer, nil, &current, nil)
 					},
 					options.KeepCompressedLayers,
 				)
@@ -1337,7 +1344,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 			return fmt.Errorf("apply layer %s: %w", layer.Digest, err)
 		}
 		complete := layer.Size
-		reportPipeline(layerIndex, layer, &complete, &complete)
+		reportPipeline(layerIndex, layer, &complete, &complete, nil)
 	}
 	report(client.ProgressEvent{
 		Status:           "processing",
@@ -2249,22 +2256,22 @@ func (s *Store) ensureLayerArchive(
 	imageName string,
 	artifact string,
 	layer descriptor,
-	reportDownload func(int64),
+	reportDownload func(int64, float64),
 	reportIndex func(int64),
 	keepCompressed bool,
 ) error {
 	if keepCompressed && s.cachedStargzLayerAvailable(layer) {
-		reportDownload(layer.Size)
+		reportDownload(layer.Size, 0)
 		reportIndex(layer.Size)
 		return nil
 	}
 	if s.cachedLayerArchiveAvailable(layer) {
-		reportDownload(layer.Size)
+		reportDownload(layer.Size, 0)
 		reportIndex(layer.Size)
 		return nil
 	}
 	if s.cachedLayerBlobAvailable(layer) {
-		reportDownload(layer.Size)
+		reportDownload(layer.Size, 0)
 		if keepCompressed {
 			recognized, err := s.prepareStargzLayerFromBlob(layer)
 			if err != nil {
@@ -2278,7 +2285,9 @@ func (s *Store) ensureLayerArchive(
 		return s.prepareLayerArchiveFromBlob(layer, reportIndex)
 	}
 	if keepCompressed {
-		reconstructed, err := s.tryReconstructStargzLayer(ctx, reg, imageName, layer, reportDownload)
+		reconstructed, err := s.tryReconstructStargzLayer(ctx, reg, imageName, layer, func(current int64) {
+			reportDownload(current, 0)
+		})
 		if err != nil {
 			return err
 		}
@@ -2290,17 +2299,17 @@ func (s *Store) ensureLayerArchive(
 			if !recognized {
 				return fmt.Errorf("reconstructed layer %s is not valid eStargz", layer.Digest)
 			}
-			reportDownload(layer.Size)
+			reportDownload(layer.Size, 0)
 			reportIndex(layer.Size)
 			return nil
 		}
 		progress := newParallelBlobProgress(artifact, layer.Size, func(event client.ProgressEvent) {
-			reportDownload(event.BytesDownloaded)
+			reportDownload(event.BytesDownloaded, event.RateBytesPerSecond)
 		})
 		if err := s.cacheLayerBlob(ctx, reg, imageName, layer, progress); err != nil {
 			return err
 		}
-		reportDownload(layer.Size)
+		reportDownload(layer.Size, 0)
 		recognized, err := s.prepareStargzLayerFromBlob(layer)
 		if err != nil {
 			return err
@@ -2327,11 +2336,11 @@ func (s *Store) ensureLayerArchive(
 	}
 	if errors.Is(partialErr, os.ErrNotExist) {
 		err := s.downloadAndPrepareLayer(ctx, reg, imageName, layer, func(current int64) {
-			reportDownload(current)
+			reportDownload(current, 0)
 			reportIndex(current)
 		})
 		if err == nil {
-			reportDownload(layer.Size)
+			reportDownload(layer.Size, 0)
 			reportIndex(layer.Size)
 			return nil
 		}
@@ -2345,12 +2354,12 @@ func (s *Store) ensureLayerArchive(
 	}
 
 	resumeProgress := newParallelBlobProgress(artifact, layer.Size, func(event client.ProgressEvent) {
-		reportDownload(event.BytesDownloaded)
+		reportDownload(event.BytesDownloaded, event.RateBytesPerSecond)
 	})
 	if err := s.cacheLayerBlob(ctx, reg, imageName, layer, resumeProgress); err != nil {
 		return err
 	}
-	reportDownload(layer.Size)
+	reportDownload(layer.Size, 0)
 	if err := s.prepareLayerArchiveFromBlob(layer, reportIndex); err != nil {
 		return err
 	}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -671,6 +671,11 @@ func (s *Store) PlanPull(ctx context.Context, name, source string, options ...Pu
 		} else if info, statErr := os.Stat(blobPath); statErr == nil && info.Mode().IsRegular() && info.Size() == layer.Size {
 			plan.LayersCached++
 			plan.BytesCached += layer.Size
+		} else if info, statErr := os.Stat(blobPath + ".partial"); statErr == nil && info.Mode().IsRegular() {
+			// A normal partial blob is a verified prefix that cacheLayerBlob will
+			// resume. Delta partials are intentionally excluded because they are
+			// sparse, target-sized assembly files rather than downloaded prefixes.
+			plan.BytesCached += min(layer.Size, max(int64(0), info.Size()))
 		}
 	}
 	plan.BytesToDownload = max(0, plan.BytesTotal-plan.BytesCached)

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -2285,8 +2285,8 @@ func (s *Store) ensureLayerArchive(
 		return s.prepareLayerArchiveFromBlob(layer, reportIndex)
 	}
 	if keepCompressed {
-		reconstructed, err := s.tryReconstructStargzLayer(ctx, reg, imageName, layer, func(current int64) {
-			reportDownload(current, 0)
+		reconstructed, err := s.tryReconstructStargzLayer(ctx, reg, imageName, layer, func(current int64, rate float64) {
+			reportDownload(current, rate)
 		})
 		if err != nil {
 			return err

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -115,12 +115,13 @@ type SourceSpec struct {
 }
 
 type PullOptions struct {
-	Architecture    string
-	Prefetch        bool
-	PrefetchWorkers int
-	CVMFSMirrors    []string
-	Report          func(client.ProgressEvent)
-	Refresh         bool
+	Architecture         string
+	Prefetch             bool
+	PrefetchWorkers      int
+	CVMFSMirrors         []string
+	Report               func(client.ProgressEvent)
+	Refresh              bool
+	KeepCompressedLayers bool
 }
 
 type SaveOptions struct {
@@ -559,6 +560,43 @@ func (s *Store) Pull(ctx context.Context, name, source string, options ...PullOp
 	return state, nil
 }
 
+// ActivateStaged replaces a named image with an already prepared image in the
+// same store. Store readers see either the old or new image because activation
+// is serialized by the store lock. Callers must ensure no running VM still
+// uses name.
+func (s *Store) ActivateStaged(name, stagedName string) (client.ImageState, error) {
+	if name == "" || stagedName == "" || name == stagedName {
+		return client.ImageState{}, fmt.Errorf("distinct active and staged image names are required")
+	}
+	stagedMeta, err := s.readMetadata(stagedName)
+	if err != nil {
+		return client.ImageState{}, fmt.Errorf("read staged image: %w", err)
+	}
+	spec := SourceSpec{Kind: stagedMeta.SourceKind, Raw: stagedMeta.Source}
+	if spec.Kind == "" || spec.Raw == "" {
+		return client.ImageState{}, fmt.Errorf("staged image metadata is incomplete")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.downloading[name] || s.downloading[stagedName] {
+		return client.ImageState{}, fmt.Errorf("image preparation is still in progress")
+	}
+	delete(s.opened, name)
+	if err := s.cloneFromStore(s, stagedName, name, spec); err != nil {
+		return client.ImageState{}, err
+	}
+	state, err := s.getLocked(name)
+	if err != nil {
+		return client.ImageState{}, err
+	}
+	// The stage is no longer addressable through a client while the store is
+	// locked. Removing it directly avoids recursively taking s.mu.
+	delete(s.opened, stagedName)
+	delete(s.lastErr, stagedName)
+	_ = os.RemoveAll(s.imageDir(stagedName))
+	return state, nil
+}
+
 func (s *Store) PlanPull(ctx context.Context, name, source string, options ...PullOptions) (client.ImagePullPlan, error) {
 	if name == "" {
 		return client.ImagePullPlan{}, fmt.Errorf("image name is required")
@@ -627,7 +665,7 @@ func (s *Store) PlanPull(ctx context.Context, name, source string, options ...Pu
 		plan.LayersTotal++
 		plan.BytesTotal += layer.Size
 		blobPath := filepath.Join(shared.root, "_blobs", digestToFileName(layer.Digest))
-		if shared.cachedLayerArchiveAvailable(layer) {
+		if shared.cachedLayerArchiveAvailable(layer) || shared.cachedStargzLayerAvailable(layer) {
 			plan.LayersCached++
 			plan.BytesCached += layer.Size
 		} else if info, statErr := os.Stat(blobPath); statErr == nil && info.Mode().IsRegular() && info.Size() == layer.Size {
@@ -1172,7 +1210,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 	indexedByLayer := make([]int64, len(mani.Layers))
 	for layerIndex, layer := range mani.Layers {
 		switch {
-		case s.cachedLayerArchiveAvailable(layer):
+		case s.cachedLayerArchiveAvailable(layer) || s.cachedStargzLayerAvailable(layer):
 			downloadedByLayer[layerIndex] = layer.Size
 			indexedByLayer[layerIndex] = layer.Size
 		case s.cachedLayerBlobAvailable(layer):
@@ -1238,7 +1276,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 	prepareJobs := make(chan int, len(mani.Layers))
 	missingLayers := 0
 	for layerIndex, layer := range mani.Layers {
-		if s.cachedLayerArchiveAvailable(layer) {
+		if s.cachedLayerArchiveAvailable(layer) || s.cachedStargzLayerAvailable(layer) {
 			continue
 		}
 		if existing := resultsByDigest[layer.Digest]; existing != nil {
@@ -1271,6 +1309,7 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 					func(current int64) {
 						reportPipeline(layerIndex, layer, nil, &current)
 					},
+					options.KeepCompressedLayers,
 				)
 				result := prepareResults[layerIndex]
 				result.err = err
@@ -1280,8 +1319,6 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 	}
 
 	for layerIndex, layer := range mani.Layers {
-		layerContentsRel := filepath.Join("layers", digestToFileName(layer.Digest)+".contents")
-		layerContentsPath := filepath.Join(tmpDir, layerContentsRel)
 		if result := prepareResults[layerIndex]; result != nil {
 			<-result.done
 			if err := result.err; err != nil {
@@ -1289,6 +1326,12 @@ func (s *Store) pullOCIDirect(ctx context.Context, name string, spec SourceSpec,
 				return fmt.Errorf("prepare layer %s: %w", layer.Digest, err)
 			}
 		}
+		layerSuffix := ".contents"
+		if s.cachedStargzLayerAvailable(layer) {
+			layerSuffix = ".stargz"
+		}
+		layerContentsRel := filepath.Join("layers", digestToFileName(layer.Digest)+layerSuffix)
+		layerContentsPath := filepath.Join(tmpDir, layerContentsRel)
 		if err := s.writeAndApplyCachedLayer(layer, layerContentsPath, layerContentsRel, build.merged, build.fsEntries, nil); err != nil {
 			cancelPrepare()
 			return fmt.Errorf("apply layer %s: %w", layer.Digest, err)
@@ -1503,11 +1546,30 @@ func (s *Store) cloneFromStore(src *Store, srcName, dstName string, spec SourceS
 	if err := os.WriteFile(filepath.Join(tmpDir, "image.json"), buf, 0o644); err != nil {
 		return fmt.Errorf("write image metadata: %w", err)
 	}
-	if err := os.RemoveAll(dstDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove old image dir: %w", err)
+	return replaceImageDir(tmpDir, dstDir)
+}
+
+// replaceImageDir keeps the previous complete directory available for
+// rollback until the prepared directory has been installed.
+func replaceImageDir(tmpDir, dstDir string) error {
+	previousDir := dstDir + ".previous"
+	if err := os.RemoveAll(previousDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove previous image backup: %w", err)
+	}
+	hadPrevious := false
+	if err := os.Rename(dstDir, previousDir); err == nil {
+		hadPrevious = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("preserve old image dir: %w", err)
 	}
 	if err := os.Rename(tmpDir, dstDir); err != nil {
+		if hadPrevious {
+			_ = os.Rename(previousDir, dstDir)
+		}
 		return fmt.Errorf("activate image dir: %w", err)
+	}
+	if hadPrevious {
+		_ = os.RemoveAll(previousDir)
 	}
 	return nil
 }
@@ -2189,7 +2251,13 @@ func (s *Store) ensureLayerArchive(
 	layer descriptor,
 	reportDownload func(int64),
 	reportIndex func(int64),
+	keepCompressed bool,
 ) error {
+	if keepCompressed && s.cachedStargzLayerAvailable(layer) {
+		reportDownload(layer.Size)
+		reportIndex(layer.Size)
+		return nil
+	}
 	if s.cachedLayerArchiveAvailable(layer) {
 		reportDownload(layer.Size)
 		reportIndex(layer.Size)
@@ -2197,7 +2265,55 @@ func (s *Store) ensureLayerArchive(
 	}
 	if s.cachedLayerBlobAvailable(layer) {
 		reportDownload(layer.Size)
+		if keepCompressed {
+			recognized, err := s.prepareStargzLayerFromBlob(layer)
+			if err != nil {
+				return err
+			}
+			if recognized {
+				reportIndex(layer.Size)
+				return nil
+			}
+		}
 		return s.prepareLayerArchiveFromBlob(layer, reportIndex)
+	}
+	if keepCompressed {
+		reconstructed, err := s.tryReconstructStargzLayer(ctx, reg, imageName, layer, reportDownload)
+		if err != nil {
+			return err
+		}
+		if reconstructed {
+			recognized, err := s.prepareStargzLayerFromBlob(layer)
+			if err != nil {
+				return err
+			}
+			if !recognized {
+				return fmt.Errorf("reconstructed layer %s is not valid eStargz", layer.Digest)
+			}
+			reportDownload(layer.Size)
+			reportIndex(layer.Size)
+			return nil
+		}
+		progress := newParallelBlobProgress(artifact, layer.Size, func(event client.ProgressEvent) {
+			reportDownload(event.BytesDownloaded)
+		})
+		if err := s.cacheLayerBlob(ctx, reg, imageName, layer, progress); err != nil {
+			return err
+		}
+		reportDownload(layer.Size)
+		recognized, err := s.prepareStargzLayerFromBlob(layer)
+		if err != nil {
+			return err
+		}
+		if recognized {
+			reportIndex(layer.Size)
+			return nil
+		}
+		if err := s.prepareLayerArchiveFromBlob(layer, reportIndex); err != nil {
+			return err
+		}
+		reportIndex(layer.Size)
+		return nil
 	}
 
 	partialPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest)) + ".partial"
@@ -2249,6 +2365,13 @@ func (s *Store) writeAndApplyCachedLayer(
 	entries map[string]fsmeta.Entry,
 	progress func(int64),
 ) error {
+	if s.cachedStargzLayerAvailable(layer) {
+		blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
+		if err := linkOrCopyLayerContents(blobPath, dstPath); err != nil {
+			return fmt.Errorf("link cached eStargz layer: %w", err)
+		}
+		return applyLayerArchive(s.stargzLayerIndexPath(layer.Digest), stargzContentsPrefix+tarRef, merged, entries)
+	}
 	indexPath, contentsPath := s.layerArchivePaths(layer.Digest)
 	if s.cachedLayerArchiveAvailable(layer) {
 		if err := linkOrCopyLayerContents(contentsPath, dstPath); err != nil {

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -102,6 +102,52 @@ func TestStoreSharedCacheCanBeKeptInsidePortableRoot(t *testing.T) {
 	}
 }
 
+func TestActivateStagedImageReplacesActiveOnlyAfterStageIsComplete(t *testing.T) {
+	store := NewStore(t.TempDir())
+	for _, item := range []struct {
+		name     string
+		resolved string
+		marker   string
+	}{
+		{name: "active", resolved: "example/image@sha256:old", marker: "old"},
+		{name: "active-staged", resolved: "example/image@sha256:new", marker: "new"},
+	} {
+		dir := store.imageDir(item.name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "marker"), []byte(item.marker), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.writeMetadata(item.name, metadata{
+			Name:           item.name,
+			Source:         "example/image:latest",
+			ResolvedSource: item.resolved,
+			SourceKind:     SourceKindOCI,
+			RootFSDir:      dir,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	state, err := store.ActivateStaged("active", "active-staged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.ResolvedSource != "example/image@sha256:new" {
+		t.Fatalf("activated source = %q", state.ResolvedSource)
+	}
+	marker, err := os.ReadFile(filepath.Join(store.imageDir("active"), "marker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(marker) != "new" {
+		t.Fatalf("active marker = %q", marker)
+	}
+	if _, err := os.Stat(store.imageDir("active-staged")); !os.IsNotExist(err) {
+		t.Fatalf("staged image remains after activation: %v", err)
+	}
+}
+
 func TestAggregateLayerProgressReportsWholeImageBytes(t *testing.T) {
 	var events []client.ProgressEvent
 	reader := newAggregateDownloadProgressReader(

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -212,6 +212,9 @@ func TestPlanPullReportsOnlyUncachedOCILayerBytes(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(shared, "_blobs", digestToFileName(firstDigest)), make([]byte, 100), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(shared, "_blobs", digestToFileName(secondDigest))+".partial", make([]byte, 50), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	store := NewStore(filepath.Join(t.TempDir(), "store"))
 	store.httpClient = server.Client()
 	source := strings.TrimPrefix(server.URL, "https://") + "/team/squad:edge"
@@ -219,7 +222,7 @@ func TestPlanPullReportsOnlyUncachedOCILayerBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Available || plan.BytesTotal != 350 || plan.BytesCached != 100 || plan.BytesToDownload != 250 {
+	if plan.Available || plan.BytesTotal != 350 || plan.BytesCached != 150 || plan.BytesToDownload != 200 {
 		t.Fatalf("pull plan = %+v", plan)
 	}
 	if plan.LayersTotal != 2 || plan.LayersCached != 1 {
@@ -244,7 +247,7 @@ func TestPlanPullReportsOnlyUncachedOCILayerBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !update.Installed || update.Available || update.BytesToDownload != 250 {
+	if !update.Installed || update.Available || update.BytesToDownload != 200 {
 		t.Fatalf("update plan = %+v", update)
 	}
 

--- a/internal/oci/stargzdelta.go
+++ b/internal/oci/stargzdelta.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"j5.nz/cc/internal/download"
@@ -40,7 +41,7 @@ func (s *Store) tryReconstructStargzLayer(
 	reg *registryContext,
 	imageName string,
 	layer descriptor,
-	progress func(int64),
+	progress func(int64, float64),
 ) (bool, error) {
 	document, tocOffset, err := fetchRemoteStargzTOCDocument(ctx, reg, imageName, layer)
 	if err != nil {
@@ -100,6 +101,18 @@ func (s *Store) tryReconstructStargzLayer(
 	}
 
 	var reconstructed int64
+	var networkBytes int64
+	networkStarted := time.Now()
+	report := func(current int64) {
+		if progress == nil {
+			return
+		}
+		var rate float64
+		if elapsed := time.Since(networkStarted).Seconds(); elapsed > 0 {
+			rate = float64(networkBytes) / elapsed
+		}
+		progress(current, rate)
+	}
 	for index := 0; index < len(planned); {
 		item := planned[index]
 		if item.local != nil {
@@ -107,9 +120,7 @@ func (s *Store) tryReconstructStargzLayer(
 				return false, err
 			}
 			reconstructed += item.target.Size
-			if progress != nil {
-				progress(reconstructed)
-			}
+			report(reconstructed)
 			index++
 			continue
 		}
@@ -120,16 +131,19 @@ func (s *Store) tryReconstructStargzLayer(
 			end += planned[index].target.Size
 			index++
 		}
-		if err := copyRemoteBlobRange(ctx, reg, "/"+imageName+"/blobs/"+layer.Digest, out, start, end-1, layer.Size); err != nil {
+		rangeBase := networkBytes
+		if err := copyRemoteBlobRange(ctx, reg, "/"+imageName+"/blobs/"+layer.Digest, out, start, end-1, layer.Size, func(downloaded int64) {
+			networkBytes = rangeBase + downloaded
+			report(reconstructed + downloaded)
+		}); err != nil {
 			if errors.Is(err, errRegistryRangeUnsupported) {
 				return false, nil
 			}
 			return false, err
 		}
 		reconstructed += end - start
-		if progress != nil {
-			progress(reconstructed)
-		}
+		networkBytes = rangeBase + end - start
+		report(reconstructed)
 	}
 	if err := out.Sync(); err != nil {
 		return false, err
@@ -245,7 +259,7 @@ func copyFileRange(dst *os.File, dstOffset int64, srcPath string, srcOffset, siz
 	return nil
 }
 
-func copyRemoteBlobRange(ctx context.Context, reg *registryContext, path string, dst *os.File, start, end, total int64) error {
+func copyRemoteBlobRange(ctx context.Context, reg *registryContext, path string, dst *os.File, start, end, total int64, progress func(int64)) error {
 	resp, err := reg.doByteRange(ctx, path, start, end)
 	if err != nil {
 		return err
@@ -255,8 +269,30 @@ func copyRemoteBlobRange(ctx context.Context, reg *registryContext, path string,
 		return err
 	}
 	size := end - start + 1
-	_, err = download.Copy(ctx, io.NewOffsetWriter(dst, start), resp, download.Budget{MaxBytes: size, ExpectedBytes: size})
+	writer := &stargzRangeProgressWriter{dst: io.NewOffsetWriter(dst, start), report: progress}
+	_, err = download.Copy(ctx, writer, resp, download.Budget{MaxBytes: size, ExpectedBytes: size})
+	if err == nil && progress != nil {
+		progress(size)
+	}
 	return err
+}
+
+type stargzRangeProgressWriter struct {
+	dst        io.Writer
+	written    int64
+	lastReport time.Time
+	report     func(int64)
+}
+
+func (w *stargzRangeProgressWriter) Write(p []byte) (int, error) {
+	n, err := w.dst.Write(p)
+	w.written += int64(n)
+	now := time.Now()
+	if n > 0 && w.report != nil && (w.lastReport.IsZero() || now.Sub(w.lastReport) >= 200*time.Millisecond) {
+		w.lastReport = now
+		w.report(w.written)
+	}
+	return n, err
 }
 
 func readRemoteBlobRange(ctx context.Context, reg *registryContext, path string, start, end, total, maxBytes int64) ([]byte, error) {

--- a/internal/oci/stargzdelta.go
+++ b/internal/oci/stargzdelta.go
@@ -1,0 +1,340 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"j5.nz/cc/internal/download"
+)
+
+const maxRemoteStargzTOCBytes int64 = 128 << 20
+
+var errRegistryRangeUnsupported = errors.New("registry does not support bounded blob ranges")
+
+type localStargzMember struct {
+	path   string
+	offset int64
+	size   int64
+}
+
+type plannedStargzMember struct {
+	target stargzDeltaMember
+	local  *localStargzMember
+}
+
+// tryReconstructStargzLayer attempts to assemble the exact target OCI blob
+// using members from older local eStargz layers and missing byte ranges from
+// the registry. A false result means the normal full-blob path should be used.
+func (s *Store) tryReconstructStargzLayer(
+	ctx context.Context,
+	reg *registryContext,
+	imageName string,
+	layer descriptor,
+	progress func(int64),
+) (bool, error) {
+	document, tocOffset, err := fetchRemoteStargzTOCDocument(ctx, reg, imageName, layer)
+	if err != nil {
+		if errors.Is(err, errRegistryRangeUnsupported) || errors.Is(err, errNotStargzLayer) {
+			return false, nil
+		}
+		// Delta metadata is optional. A malformed or unavailable index must not
+		// make an otherwise valid OCI layer unusable.
+		return false, nil
+	}
+	if err := validateStargzDeltaIndex(document.VMSHDelta, tocOffset); err != nil {
+		return false, nil
+	}
+	available, err := s.localStargzMembers(layer.Digest)
+	if err != nil {
+		return false, err
+	}
+	planned := make([]plannedStargzMember, 0, len(document.VMSHDelta.Members)+1)
+	var reusedBytes int64
+	for _, member := range document.VMSHDelta.Members {
+		item := plannedStargzMember{target: member}
+		if local := available[member.Digest]; local != nil && local.size == member.Size {
+			copy := *local
+			item.local = &copy
+			reusedBytes += member.Size
+		}
+		planned = append(planned, item)
+	}
+	// The TOC contains target-specific offsets and the complete member list, so
+	// fetch it and the footer as one final range.
+	planned = append(planned, plannedStargzMember{target: stargzDeltaMember{
+		Offset: tocOffset,
+		Size:   layer.Size - tocOffset,
+	}})
+	if reusedBytes == 0 {
+		return false, nil
+	}
+
+	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		return false, err
+	}
+	partialPath := blobPath + ".delta.partial"
+	out, err := os.OpenFile(partialPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
+	if err != nil {
+		return false, err
+	}
+	completed := false
+	defer func() {
+		_ = out.Close()
+		if !completed {
+			_ = os.Remove(partialPath)
+		}
+	}()
+	if err := out.Truncate(layer.Size); err != nil {
+		return false, err
+	}
+
+	var reconstructed int64
+	for index := 0; index < len(planned); {
+		item := planned[index]
+		if item.local != nil {
+			if err := copyFileRange(out, item.target.Offset, item.local.path, item.local.offset, item.target.Size); err != nil {
+				return false, err
+			}
+			reconstructed += item.target.Size
+			if progress != nil {
+				progress(reconstructed)
+			}
+			index++
+			continue
+		}
+		start := item.target.Offset
+		end := start + item.target.Size
+		index++
+		for index < len(planned) && planned[index].local == nil && planned[index].target.Offset == end {
+			end += planned[index].target.Size
+			index++
+		}
+		if err := copyRemoteBlobRange(ctx, reg, "/"+imageName+"/blobs/"+layer.Digest, out, start, end-1, layer.Size); err != nil {
+			if errors.Is(err, errRegistryRangeUnsupported) {
+				return false, nil
+			}
+			return false, err
+		}
+		reconstructed += end - start
+		if progress != nil {
+			progress(reconstructed)
+		}
+	}
+	if err := out.Sync(); err != nil {
+		return false, err
+	}
+	if err := out.Close(); err != nil {
+		return false, err
+	}
+	actual, err := fileSHA256Digest(partialPath)
+	if err != nil {
+		return false, err
+	}
+	if !strings.EqualFold(actual, layer.Digest) {
+		// A producer/compressor mismatch cannot corrupt the active cache. Use the
+		// full download path, which independently verifies the descriptor.
+		return false, nil
+	}
+	if err := os.Rename(partialPath, blobPath); err != nil {
+		return false, err
+	}
+	completed = true
+	return true, nil
+}
+
+func fetchRemoteStargzTOCDocument(ctx context.Context, reg *registryContext, imageName string, layer descriptor) (*stargzTOCDocument, int64, error) {
+	if layer.Size <= estargz.FooterSize {
+		return nil, 0, errNotStargzLayer
+	}
+	path := "/" + imageName + "/blobs/" + layer.Digest
+	footer, err := readRemoteBlobRange(ctx, reg, path, layer.Size-estargz.FooterSize, layer.Size-1, layer.Size, estargz.FooterSize)
+	if err != nil {
+		return nil, 0, err
+	}
+	_, tocOffset, _, err := (&estargz.GzipDecompressor{}).ParseFooter(footer)
+	if err != nil || tocOffset < 0 || tocOffset >= layer.Size-estargz.FooterSize {
+		return nil, 0, errNotStargzLayer
+	}
+	tocBytes := layer.Size - tocOffset
+	if tocBytes > maxRemoteStargzTOCBytes {
+		return nil, 0, fmt.Errorf("compressed eStargz TOC is too large: %d", tocBytes)
+	}
+	tail, err := readRemoteBlobRange(ctx, reg, path, tocOffset, layer.Size-1, layer.Size, tocBytes)
+	if err != nil {
+		return nil, 0, err
+	}
+	document, err := decodeStargzTOCDocument(bytes.NewReader(tail))
+	if err != nil {
+		return nil, 0, err
+	}
+	return document, tocOffset, nil
+}
+
+func validateStargzDeltaIndex(index *stargzDeltaIndex, payloadSize int64) error {
+	if index == nil || index.Version != stargzDeltaIndexVersion || len(index.Members) == 0 {
+		return fmt.Errorf("missing supported vmsh delta index")
+	}
+	var offset int64
+	for _, member := range index.Members {
+		if member.Offset != offset || member.Size <= 0 || !validSHA256Digest(member.Digest) {
+			return fmt.Errorf("invalid vmsh delta member at offset %d", member.Offset)
+		}
+		offset += member.Size
+		if offset > payloadSize {
+			return fmt.Errorf("vmsh delta members exceed eStargz payload")
+		}
+	}
+	if offset != payloadSize {
+		return fmt.Errorf("vmsh delta members cover %d bytes, want %d", offset, payloadSize)
+	}
+	return nil
+}
+
+func (s *Store) localStargzMembers(excludeDigest string) (map[string]*localStargzMember, error) {
+	dir := filepath.Join(s.root, "_blobs")
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]*localStargzMember{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	available := make(map[string]*localStargzMember)
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == digestToFileName(excludeDigest) || strings.HasSuffix(entry.Name(), ".partial") {
+			continue
+		}
+		blobPath := filepath.Join(dir, entry.Name())
+		document, tocOffset, err := readStargzTOCDocument(blobPath)
+		if err != nil || validateStargzDeltaIndex(document.VMSHDelta, tocOffset) != nil {
+			continue
+		}
+		for _, member := range document.VMSHDelta.Members {
+			if available[member.Digest] == nil {
+				available[member.Digest] = &localStargzMember{path: blobPath, offset: member.Offset, size: member.Size}
+			}
+		}
+	}
+	return available, nil
+}
+
+func copyFileRange(dst *os.File, dstOffset int64, srcPath string, srcOffset, size int64) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	n, err := io.Copy(io.NewOffsetWriter(dst, dstOffset), io.NewSectionReader(src, srcOffset, size))
+	if err != nil {
+		return err
+	}
+	if n != size {
+		return &download.LengthError{Expected: size, Actual: n}
+	}
+	return nil
+}
+
+func copyRemoteBlobRange(ctx context.Context, reg *registryContext, path string, dst *os.File, start, end, total int64) error {
+	resp, err := reg.doByteRange(ctx, path, start, end)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if err := validateBoundedBlobContentRange(resp, start, end, total); err != nil {
+		return err
+	}
+	size := end - start + 1
+	_, err = download.Copy(ctx, io.NewOffsetWriter(dst, start), resp, download.Budget{MaxBytes: size, ExpectedBytes: size})
+	return err
+}
+
+func readRemoteBlobRange(ctx context.Context, reg *registryContext, path string, start, end, total, maxBytes int64) ([]byte, error) {
+	resp, err := reg.doByteRange(ctx, path, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := validateBoundedBlobContentRange(resp, start, end, total); err != nil {
+		return nil, err
+	}
+	return download.ReadAll(ctx, resp, download.Budget{MaxBytes: maxBytes, ExpectedBytes: end - start + 1})
+}
+
+func (reg *registryContext) doByteRange(ctx context.Context, path string, start, end int64) (*http.Response, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reg.registry+path, nil)
+		if err != nil {
+			return nil, err
+		}
+		if token := reg.bearerToken(); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+		resp, err := reg.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("registry request: %w", err)
+		}
+		if resp.StatusCode == http.StatusUnauthorized && attempt == 0 {
+			if err := reg.authorize(ctx, resp.Header.Get("www-authenticate")); err != nil {
+				resp.Body.Close()
+				return nil, err
+			}
+			resp.Body.Close()
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil, errRegistryRangeUnsupported
+		}
+		if resp.StatusCode != http.StatusPartialContent {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+			resp.Body.Close()
+			return nil, &registryStatusError{code: resp.StatusCode, status: resp.Status, body: strings.TrimSpace(string(body))}
+		}
+		return resp, nil
+	}
+	return nil, fmt.Errorf("registry authorization failed")
+}
+
+func validateBoundedBlobContentRange(resp *http.Response, start, end, total int64) error {
+	var actualStart, actualEnd, actualTotal int64
+	if _, err := fmt.Sscanf(resp.Header.Get("Content-Range"), "bytes %d-%d/%d", &actualStart, &actualEnd, &actualTotal); err != nil {
+		return fmt.Errorf("invalid OCI blob Content-Range %q", resp.Header.Get("Content-Range"))
+	}
+	if actualStart != start || actualEnd != end || actualTotal != total {
+		return fmt.Errorf("unexpected OCI blob Content-Range %q", resp.Header.Get("Content-Range"))
+	}
+	return nil
+}
+
+func fileSHA256Digest(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func validSHA256Digest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+64 {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:"))
+	return err == nil
+}

--- a/internal/oci/stargzimagerepack.go
+++ b/internal/oci/stargzimagerepack.go
@@ -1,0 +1,272 @@
+package oci
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ociImageManifestMediaType    = "application/vnd.oci.image.manifest.v1+json"
+	dockerImageManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json"
+	ociGzipLayerMediaType        = "application/vnd.oci.image.layer.v1.tar+gzip"
+	dockerGzipLayerMediaType     = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	ociLayoutVersion             = "1.0.0"
+)
+
+type OCIImageRepackEvent struct {
+	Manifest    int
+	Layer       int
+	Layers      int
+	InputDigest string
+	InputSize   int64
+	Result      StargzRepackResult
+}
+
+type ociLayoutDescriptor struct {
+	MediaType    string            `json:"mediaType"`
+	Digest       string            `json:"digest"`
+	Size         int64             `json:"size"`
+	URLs         []string          `json:"urls,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	Data         []byte            `json:"data,omitempty"`
+	Platform     *platform         `json:"platform,omitempty"`
+	ArtifactType string            `json:"artifactType,omitempty"`
+}
+
+type ociLayoutIndex struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	MediaType     string                `json:"mediaType,omitempty"`
+	ArtifactType  string                `json:"artifactType,omitempty"`
+	Manifests     []ociLayoutDescriptor `json:"manifests"`
+	Subject       *ociLayoutDescriptor  `json:"subject,omitempty"`
+	Annotations   map[string]string     `json:"annotations,omitempty"`
+}
+
+type ociLayoutManifest struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	MediaType     string                `json:"mediaType,omitempty"`
+	ArtifactType  string                `json:"artifactType,omitempty"`
+	Config        ociLayoutDescriptor   `json:"config"`
+	Layers        []ociLayoutDescriptor `json:"layers"`
+	Subject       *ociLayoutDescriptor  `json:"subject,omitempty"`
+	Annotations   map[string]string     `json:"annotations,omitempty"`
+}
+
+type ociRootFS struct {
+	Type    string   `json:"type"`
+	DiffIDs []string `json:"diff_ids"`
+}
+
+// RepackOCIImageLayout converts every gzip layer in a single-platform OCI
+// image layout to enhanced eStargz. It writes a new, self-contained layout and
+// leaves the conventional input layout unchanged.
+func RepackOCIImageLayout(ctx context.Context, inputDir, outputDir string, chunkSize, minChunkSize int, report func(OCIImageRepackEvent)) error {
+	if ctx == nil {
+		return fmt.Errorf("repack context is required")
+	}
+	if _, err := os.Stat(outputDir); err == nil {
+		return fmt.Errorf("output OCI layout already exists: %s", outputDir)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	indexData, err := os.ReadFile(filepath.Join(inputDir, "index.json"))
+	if err != nil {
+		return fmt.Errorf("read OCI index: %w", err)
+	}
+	var index ociLayoutIndex
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return fmt.Errorf("decode OCI index: %w", err)
+	}
+	if index.SchemaVersion != 2 || len(index.Manifests) == 0 {
+		return fmt.Errorf("OCI layout must contain at least one schema-2 manifest")
+	}
+
+	parent := filepath.Dir(outputDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp(parent, ".estargz-layout-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, "blobs", "sha256"), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "oci-layout"), []byte("{\"imageLayoutVersion\":\""+ociLayoutVersion+"\"}\n"), 0o644); err != nil {
+		return err
+	}
+
+	for manifestIndex := range index.Manifests {
+		desc := index.Manifests[manifestIndex]
+		if desc.MediaType != ociImageManifestMediaType && desc.MediaType != dockerImageManifestMediaType {
+			return fmt.Errorf("unsupported OCI layout descriptor media type %q", desc.MediaType)
+		}
+		updated, err := repackOCILayoutManifest(ctx, inputDir, tmpDir, manifestIndex, desc, chunkSize, minChunkSize, report)
+		if err != nil {
+			return err
+		}
+		index.Manifests[manifestIndex] = updated
+	}
+	updatedIndex, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	updatedIndex = append(updatedIndex, '\n')
+	if err := os.WriteFile(filepath.Join(tmpDir, "index.json"), updatedIndex, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpDir, outputDir); err != nil {
+		return fmt.Errorf("activate enhanced OCI layout: %w", err)
+	}
+	return nil
+}
+
+func repackOCILayoutManifest(ctx context.Context, inputDir, outputDir string, manifestIndex int, desc ociLayoutDescriptor, chunkSize, minChunkSize int, report func(OCIImageRepackEvent)) (ociLayoutDescriptor, error) {
+	manifestData, err := readOCILayoutBlob(inputDir, desc.Digest)
+	if err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("read manifest %s: %w", desc.Digest, err)
+	}
+	var manifest ociLayoutManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("decode manifest %s: %w", desc.Digest, err)
+	}
+	configData, err := readOCILayoutBlob(inputDir, manifest.Config.Digest)
+	if err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("read image config: %w", err)
+	}
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(configData, &config); err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("decode image config: %w", err)
+	}
+	var rootFS ociRootFS
+	if err := json.Unmarshal(config["rootfs"], &rootFS); err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("decode image rootfs: %w", err)
+	}
+	if len(rootFS.DiffIDs) != len(manifest.Layers) {
+		return ociLayoutDescriptor{}, fmt.Errorf("image has %d layers but %d DiffIDs", len(manifest.Layers), len(rootFS.DiffIDs))
+	}
+
+	for layerIndex := range manifest.Layers {
+		layer := manifest.Layers[layerIndex]
+		inputLayer := layer
+		if layer.MediaType != ociGzipLayerMediaType && layer.MediaType != dockerGzipLayerMediaType {
+			if err := copyOCILayoutBlob(inputDir, outputDir, layer.Digest); err != nil {
+				return ociLayoutDescriptor{}, err
+			}
+			continue
+		}
+		inputPath, err := ociLayoutBlobPath(inputDir, layer.Digest)
+		if err != nil {
+			return ociLayoutDescriptor{}, err
+		}
+		provisional := filepath.Join(outputDir, "blobs", "sha256", fmt.Sprintf(".layer-%d-%d", manifestIndex, layerIndex))
+		result, err := RepackStargzLayerFile(ctx, inputPath, provisional, chunkSize, minChunkSize)
+		if err != nil {
+			return ociLayoutDescriptor{}, fmt.Errorf("repack layer %d (%s): %w", layerIndex, layer.Digest, err)
+		}
+		outputPath, err := ociLayoutBlobPath(outputDir, result.BlobDigest)
+		if err != nil {
+			return ociLayoutDescriptor{}, err
+		}
+		if err := os.Rename(provisional, outputPath); err != nil {
+			return ociLayoutDescriptor{}, err
+		}
+		layer.Digest = result.BlobDigest
+		layer.Size = result.BlobSize
+		manifest.Layers[layerIndex] = layer
+		rootFS.DiffIDs[layerIndex] = result.DiffID
+		if report != nil {
+			report(OCIImageRepackEvent{Manifest: manifestIndex, Layer: layerIndex, Layers: len(manifest.Layers), InputDigest: inputLayer.Digest, InputSize: inputLayer.Size, Result: result})
+		}
+	}
+	rootFSData, err := json.Marshal(rootFS)
+	if err != nil {
+		return ociLayoutDescriptor{}, err
+	}
+	config["rootfs"] = rootFSData
+	configDesc, err := writeOCIJSONBlob(outputDir, config)
+	if err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("write enhanced image config: %w", err)
+	}
+	originalConfig := manifest.Config
+	configDesc.MediaType = originalConfig.MediaType
+	configDesc.Annotations = originalConfig.Annotations
+	configDesc.URLs = originalConfig.URLs
+	configDesc.ArtifactType = originalConfig.ArtifactType
+	manifest.Config = configDesc
+	manifestDesc, err := writeOCIJSONBlob(outputDir, manifest)
+	if err != nil {
+		return ociLayoutDescriptor{}, fmt.Errorf("write enhanced manifest: %w", err)
+	}
+	manifestDesc.MediaType = desc.MediaType
+	manifestDesc.Annotations = desc.Annotations
+	manifestDesc.Platform = desc.Platform
+	manifestDesc.URLs = desc.URLs
+	manifestDesc.ArtifactType = desc.ArtifactType
+	return manifestDesc, nil
+}
+
+func readOCILayoutBlob(layoutDir, digest string) ([]byte, error) {
+	path, err := ociLayoutBlobPath(layoutDir, digest)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+func copyOCILayoutBlob(inputDir, outputDir, digest string) error {
+	source, err := ociLayoutBlobPath(inputDir, digest)
+	if err != nil {
+		return err
+	}
+	target, err := ociLayoutBlobPath(outputDir, digest)
+	if err != nil {
+		return err
+	}
+	return linkOrCopyLayerContents(source, target)
+}
+
+func ociLayoutBlobPath(layoutDir, digest string) (string, error) {
+	if !validSHA256Digest(digest) {
+		return "", fmt.Errorf("unsupported OCI blob digest %q", digest)
+	}
+	return filepath.Join(layoutDir, "blobs", "sha256", strings.TrimPrefix(digest, "sha256:")), nil
+}
+
+func writeOCIJSONBlob(layoutDir string, value any) (ociLayoutDescriptor, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ociLayoutDescriptor{}, err
+	}
+	hash := sha256.Sum256(data)
+	digest := "sha256:" + hex.EncodeToString(hash[:])
+	path, err := ociLayoutBlobPath(layoutDir, digest)
+	if err != nil {
+		return ociLayoutDescriptor{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return ociLayoutDescriptor{}, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return ociLayoutDescriptor{Digest: digest, Size: int64(len(data))}, nil
+		}
+		return ociLayoutDescriptor{}, err
+	}
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return ociLayoutDescriptor{}, err
+	}
+	if err := file.Close(); err != nil {
+		return ociLayoutDescriptor{}, err
+	}
+	return ociLayoutDescriptor{Digest: digest, Size: int64(len(data))}, nil
+}

--- a/internal/oci/stargzimagerepack_test.go
+++ b/internal/oci/stargzimagerepack_test.go
@@ -1,0 +1,144 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepackOCIImageLayoutProducesIndependentEnhancedImage(t *testing.T) {
+	inputDir := filepath.Join(t.TempDir(), "input")
+	outputDir := filepath.Join(t.TempDir(), "output")
+	if err := os.MkdirAll(filepath.Join(inputDir, "blobs", "sha256"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := deterministicTestBytes(700 << 10)
+	var uncompressed bytes.Buffer
+	tw := tar.NewWriter(&uncompressed)
+	if err := tw.WriteHeader(&tar.Header{Name: "usr/share/demo.bin", Mode: 0o644, Size: int64(len(payload))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	if _, err := gzw.Write(uncompressed.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	layerDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(compressed.Bytes()))
+	layerPath, err := ociLayoutBlobPath(inputDir, layerDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(layerPath, compressed.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diffID := fmt.Sprintf("sha256:%x", sha256.Sum256(uncompressed.Bytes()))
+	configDesc, err := writeOCIJSONBlob(inputDir, map[string]any{
+		"architecture": "amd64",
+		"os":           "linux",
+		"rootfs":       ociRootFS{Type: "layers", DiffIDs: []string{diffID}},
+		"config":       map[string]any{"User": "root"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	configDesc.MediaType = "application/vnd.oci.image.config.v1+json"
+	manifestDesc, err := writeOCIJSONBlob(inputDir, ociLayoutManifest{
+		SchemaVersion: 2,
+		MediaType:     ociImageManifestMediaType,
+		Config:        configDesc,
+		Layers: []ociLayoutDescriptor{{
+			MediaType: ociGzipLayerMediaType,
+			Digest:    layerDigest,
+			Size:      int64(compressed.Len()),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDesc.MediaType = ociImageManifestMediaType
+	indexData, err := json.Marshal(ociLayoutIndex{SchemaVersion: 2, MediaType: "application/vnd.oci.image.index.v1+json", Manifests: []ociLayoutDescriptor{manifestDesc}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "index.json"), indexData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []OCIImageRepackEvent
+	if err := RepackOCIImageLayout(t.Context(), inputDir, outputDir, 64<<10, 64<<10, func(event OCIImageRepackEvent) {
+		events = append(events, event)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].InputDigest != layerDigest || events[0].Result.BlobDigest == layerDigest {
+		t.Fatalf("repack events = %+v", events)
+	}
+	if _, err := os.Stat(layerPath); err != nil {
+		t.Fatalf("conventional input image changed: %v", err)
+	}
+
+	outputIndexData, err := os.ReadFile(filepath.Join(outputDir, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outputIndex ociLayoutIndex
+	if err := json.Unmarshal(outputIndexData, &outputIndex); err != nil {
+		t.Fatal(err)
+	}
+	manifestData, err := readOCILayoutBlob(outputDir, outputIndex.Manifests[0].Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outputManifest ociLayoutManifest
+	if err := json.Unmarshal(manifestData, &outputManifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(outputManifest.Layers) != 1 || outputManifest.Layers[0].Digest != events[0].Result.BlobDigest {
+		t.Fatalf("enhanced manifest layers = %+v", outputManifest.Layers)
+	}
+	enhancedPath, err := ociLayoutBlobPath(outputDir, outputManifest.Layers[0].Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, _, err := readStargzTOCDocument(enhancedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.VMSHDelta == nil || len(document.VMSHDelta.Members) < 2 {
+		t.Fatalf("enhanced layer delta index = %+v", document.VMSHDelta)
+	}
+	outputConfigData, err := readOCILayoutBlob(outputDir, outputManifest.Config.Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outputConfig map[string]json.RawMessage
+	if err := json.Unmarshal(outputConfigData, &outputConfig); err != nil {
+		t.Fatal(err)
+	}
+	var outputRootFS ociRootFS
+	if err := json.Unmarshal(outputConfig["rootfs"], &outputRootFS); err != nil {
+		t.Fatal(err)
+	}
+	if len(outputRootFS.DiffIDs) != 1 || outputRootFS.DiffIDs[0] != events[0].Result.DiffID {
+		t.Fatalf("enhanced DiffIDs = %v", outputRootFS.DiffIDs)
+	}
+}

--- a/internal/oci/stargzlayer.go
+++ b/internal/oci/stargzlayer.go
@@ -1,0 +1,290 @@
+package oci
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"j5.nz/cc/internal/fsmeta"
+)
+
+const (
+	stargzLayerDirName    = "_stargz_v1"
+	stargzLayerIndexName  = "layer.index"
+	stargzContentsPrefix  = "estargz:"
+	maxStargzTOCJSONBytes = 128 << 20
+)
+
+func (s *Store) stargzLayerIndexPath(digest string) string {
+	return filepath.Join(s.root, stargzLayerDirName, digestToFileName(digest), stargzLayerIndexName)
+}
+
+func (s *Store) cachedStargzLayerAvailable(layer descriptor) bool {
+	index, err := os.Open(s.stargzLayerIndexPath(layer.Digest))
+	if err != nil {
+		return false
+	}
+	defer index.Close()
+	magic := make([]byte, len(layerArchiveMagic))
+	if _, err := io.ReadFull(index, magic); err != nil || string(magic) != layerArchiveMagic {
+		return false
+	}
+	return s.cachedLayerBlobAvailable(layer)
+}
+
+// prepareStargzLayerFromBlob recognizes an eStargz layer and creates the
+// overlay index without expanding file contents. It returns false without an
+// error when the blob is an ordinary OCI layer.
+func (s *Store) prepareStargzLayerFromBlob(layer descriptor) (bool, error) {
+	if s.cachedStargzLayerAvailable(layer) {
+		return true, nil
+	}
+	blobPath := filepath.Join(s.root, "_blobs", digestToFileName(layer.Digest))
+	toc, err := readStargzTOC(blobPath)
+	if err != nil {
+		if errors.Is(err, errNotStargzLayer) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Open with the upstream reader as well. Besides validating the footer and
+	// TOC, this catches invalid chunk relationships before the image is cached.
+	if _, err := openStargzReader(blobPath); err != nil {
+		return false, fmt.Errorf("validate eStargz layer: %w", err)
+	}
+
+	indexPath := s.stargzLayerIndexPath(layer.Digest)
+	parent := filepath.Dir(filepath.Dir(indexPath))
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return false, err
+	}
+	tmpDir, err := os.MkdirTemp(parent, ".stargz-")
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpIndex := filepath.Join(tmpDir, stargzLayerIndexName)
+	if err := writeStargzLayerIndex(tmpIndex, toc); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmpDir, filepath.Dir(indexPath)); err != nil && !s.cachedStargzLayerAvailable(layer) {
+		return false, err
+	}
+	return true, nil
+}
+
+var errNotStargzLayer = errors.New("not an eStargz layer")
+
+func readStargzTOC(blobPath string) (*estargz.JTOC, error) {
+	file, err := os.Open(blobPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	sr := io.NewSectionReader(file, 0, info.Size())
+	tocOffset, _, err := estargz.OpenFooter(sr)
+	if err != nil || tocOffset < 0 || tocOffset >= info.Size() {
+		return nil, errNotStargzLayer
+	}
+	gzr, err := gzip.NewReader(io.NewSectionReader(file, tocOffset, info.Size()-tocOffset))
+	if err != nil {
+		return nil, fmt.Errorf("open eStargz TOC gzip member: %w", err)
+	}
+	defer gzr.Close()
+	tr := tar.NewReader(gzr)
+	hdr, err := tr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("read eStargz TOC tar header: %w", err)
+	}
+	if path.Clean(strings.TrimPrefix(hdr.Name, "/")) != estargz.TOCTarName {
+		return nil, fmt.Errorf("unexpected eStargz TOC entry %q", hdr.Name)
+	}
+	if hdr.Size < 0 || hdr.Size > maxStargzTOCJSONBytes {
+		return nil, fmt.Errorf("eStargz TOC size %d exceeds limit", hdr.Size)
+	}
+	data, err := io.ReadAll(io.LimitReader(tr, hdr.Size+1))
+	if err != nil {
+		return nil, fmt.Errorf("read eStargz TOC: %w", err)
+	}
+	if int64(len(data)) != hdr.Size {
+		return nil, fmt.Errorf("eStargz TOC length mismatch: expected %d, got %d", hdr.Size, len(data))
+	}
+	var toc estargz.JTOC
+	if err := json.Unmarshal(data, &toc); err != nil {
+		return nil, fmt.Errorf("decode eStargz TOC: %w", err)
+	}
+	if toc.Version != 1 {
+		return nil, fmt.Errorf("unsupported eStargz TOC version %d", toc.Version)
+	}
+	return &toc, nil
+}
+
+func writeStargzLayerIndex(indexPath string, toc *estargz.JTOC) error {
+	index, err := os.OpenFile(indexPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer index.Close()
+	w := bufio.NewWriterSize(index, 64<<10)
+	if _, err := w.WriteString(layerArchiveMagic); err != nil {
+		return err
+	}
+	for _, entry := range toc.Entries {
+		if entry == nil || entry.Type == "chunk" || isStargzLandmark(entry.Name) {
+			continue
+		}
+		name, err := sanitizeArchivePath(entry.Name)
+		if err != nil {
+			return err
+		}
+		base := path.Base(name)
+		dir := path.Dir(name)
+		if base == ".wh..wh..opq" {
+			if err := writeLayerRecord(w, layerRecord{
+				op:   layerRecordOpaque,
+				node: indexedNode{Path: fsmeta.Normalize(dir)},
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(base, ".wh.") {
+			if err := writeLayerRecord(w, layerRecord{
+				op: layerRecordDelete,
+				node: indexedNode{
+					Path: fsmeta.Normalize(path.Join(dir, strings.TrimPrefix(base, ".wh."))),
+				},
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		hdr, err := stargzTarHeader(entry)
+		if err != nil {
+			return err
+		}
+		node := indexedNode{
+			Path:      fsmeta.Normalize(name),
+			UID:       uint32(entry.UID),
+			GID:       uint32(entry.GID),
+			Mode:      fsmeta.LinuxModeFromTarHeader(hdr),
+			Size:      uint64(max(0, entry.Size)),
+			ModTimeNS: hdr.ModTime.UnixNano(),
+			RDev:      uint32(entry.DevMajor<<8 | entry.DevMinor),
+		}
+		record := layerRecord{op: layerRecordAdd, node: node}
+		switch entry.Type {
+		case "dir":
+			record.node.Kind = indexedKindDir
+			record.node.Size = 0
+		case "reg":
+			record.node.Kind = indexedKindFile
+		case "char", "block", "fifo":
+			record.node.Kind = indexedKindFile
+			record.node.Size = 0
+		case "symlink":
+			record.node.Kind = indexedKindSymlink
+			record.node.LinkTarget = fsmeta.NormalizeSymlinkTarget(entry.LinkName)
+			record.node.Size = uint64(len(entry.LinkName))
+		case "hardlink":
+			target, err := sanitizeArchivePath(entry.LinkName)
+			if err != nil {
+				return err
+			}
+			record.op = layerRecordHardlink
+			record.node.Kind = indexedKindFile
+			record.node.Size = 0
+			record.hardlinkTarget = fsmeta.Normalize(target)
+		default:
+			return fmt.Errorf("unsupported eStargz entry type %q for %s", entry.Type, name)
+		}
+		if err := writeLayerRecord(w, record); err != nil {
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	return index.Sync()
+}
+
+func stargzTarHeader(entry *estargz.TOCEntry) (*tar.Header, error) {
+	modTime := time.Unix(0, 0)
+	if entry.ModTime3339 != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, entry.ModTime3339)
+		if err != nil {
+			return nil, fmt.Errorf("invalid eStargz mtime for %q: %w", entry.Name, err)
+		}
+		modTime = parsed
+	}
+	hdr := &tar.Header{
+		Name:     entry.Name,
+		Linkname: entry.LinkName,
+		Size:     entry.Size,
+		Mode:     entry.Mode,
+		Uid:      entry.UID,
+		Gid:      entry.GID,
+		ModTime:  modTime,
+		Devmajor: int64(entry.DevMajor),
+		Devminor: int64(entry.DevMinor),
+	}
+	switch entry.Type {
+	case "dir":
+		hdr.Typeflag = tar.TypeDir
+	case "reg":
+		hdr.Typeflag = tar.TypeReg
+	case "symlink":
+		hdr.Typeflag = tar.TypeSymlink
+	case "hardlink":
+		hdr.Typeflag = tar.TypeLink
+	case "char":
+		hdr.Typeflag = tar.TypeChar
+	case "block":
+		hdr.Typeflag = tar.TypeBlock
+	case "fifo":
+		hdr.Typeflag = tar.TypeFifo
+	default:
+		return nil, fmt.Errorf("unsupported eStargz entry type %q", entry.Type)
+	}
+	return hdr, nil
+}
+
+func isStargzLandmark(name string) bool {
+	clean := path.Clean(strings.TrimPrefix(name, "/"))
+	return clean == estargz.PrefetchLandmark || clean == estargz.NoPrefetchLandmark
+}
+
+type filePathReaderAt string
+
+func (p filePathReaderAt) ReadAt(buf []byte, offset int64) (int, error) {
+	file, err := os.Open(string(p))
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	return file.ReadAt(buf, offset)
+}
+
+func openStargzReader(blobPath string) (*estargz.Reader, error) {
+	info, err := os.Stat(blobPath)
+	if err != nil {
+		return nil, err
+	}
+	return estargz.Open(io.NewSectionReader(filePathReaderAt(blobPath), 0, info.Size()))
+}

--- a/internal/oci/stargzlayer_real_test.go
+++ b/internal/oci/stargzlayer_real_test.go
@@ -1,0 +1,180 @@
+package oci
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"j5.nz/cc/internal/imagefs"
+)
+
+// TestRealStargzLayerRuntimeRead provides a repeatable integration check for a
+// large producer-generated layer without committing that layer as a fixture.
+// Set CC_TEST_ESTARGZ_LAYER to an enhanced eStargz blob to enable it.
+func TestRealStargzLayerRuntimeRead(t *testing.T) {
+	sourcePath := os.Getenv("CC_TEST_ESTARGZ_LAYER")
+	if sourcePath == "" {
+		t.Skip("CC_TEST_ESTARGZ_LAYER is not set")
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := fileSHA256Digest(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layer := descriptor{Digest: digest, Size: info.Size(), MediaType: "application/vnd.oci.image.layer.v1.tar+gzip"}
+	store := NewStore(t.TempDir())
+	blobPath := filepath.Join(store.root, "_blobs", digestToFileName(digest))
+	if err := linkOrCopyLayerContents(sourcePath, blobPath); err != nil {
+		t.Fatal(err)
+	}
+	recognized, err := store.prepareStargzLayerFromBlob(layer)
+	if err != nil || !recognized {
+		t.Fatalf("prepare real eStargz layer: recognized=%t err=%v", recognized, err)
+	}
+
+	document, _, err := readStargzTOCDocument(blobPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var candidatePath string
+	var candidateSize int64
+	for _, entry := range document.Entries {
+		if entry != nil && entry.Type == "reg" && entry.Size >= 512<<10 {
+			candidatePath, candidateSize = entry.Name, entry.Size
+			break
+		}
+	}
+	if candidatePath == "" {
+		t.Fatal("real layer has no regular file large enough for a chunk-crossing read")
+	}
+
+	imageDir := t.TempDir()
+	layerRel := filepath.Join("layers", digestToFileName(digest)+".stargz")
+	if err := linkOrCopyLayerContents(blobPath, filepath.Join(imageDir, layerRel)); err != nil {
+		t.Fatal(err)
+	}
+	build := newIndexedBuildState()
+	if err := applyLayerArchive(store.stargzLayerIndexPath(digest), stargzContentsPrefix+layerRel, build.merged, build.fsEntries); err != nil {
+		t.Fatal(err)
+	}
+	ensureIndexedParents(build.merged, build.fsEntries)
+	nodes := make([]indexedNode, 0, len(build.merged))
+	for _, node := range build.merged {
+		nodes = append(nodes, *node)
+	}
+	root, err := buildIndexedRootFS(imageDir, nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := imagefs.LookupPath(root, "/"+candidatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offset := uint64(255 << 10)
+	readSize := uint32(32 << 10)
+	if offset+uint64(readSize) > uint64(candidateSize) {
+		t.Fatalf("selected file %q is unexpectedly too small", candidatePath)
+	}
+	got, err := entry.File.ReadAt(offset, readSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	standardReader, err := openStargzReader(blobPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	standardFile, err := standardReader.OpenFile(candidatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := make([]byte, readSize)
+	if _, err := standardFile.ReadAt(want, int64(offset)); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("runtime read differs from standard eStargz reader for %s", candidatePath)
+	}
+	if _, err := os.Stat(filepath.Join(store.root, layerArchiveDirName, digestToFileName(digest), layerContentsName)); !os.IsNotExist(err) {
+		t.Fatalf("real layer was expanded on disk: %v", err)
+	}
+	t.Logf("verified %s (%s) directly from %d compressed bytes", candidatePath, fmt.Sprint(candidateSize), info.Size())
+}
+
+// TestRealStargzLayerDeltaReconstruction uses two locally supplied enhanced
+// layers while serving the target through an OCI-like Range endpoint. It
+// verifies the exact downloader path and reports actual transfer reuse.
+func TestRealStargzLayerDeltaReconstruction(t *testing.T) {
+	basePath := os.Getenv("CC_TEST_ESTARGZ_BASE")
+	targetPath := os.Getenv("CC_TEST_ESTARGZ_TARGET")
+	if basePath == "" || targetPath == "" {
+		t.Skip("CC_TEST_ESTARGZ_BASE and CC_TEST_ESTARGZ_TARGET are not set")
+	}
+	targetFile, err := os.Open(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer targetFile.Close()
+	targetInfo, err := targetFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseInfo, err := os.Stat(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseDigest, err := fileSHA256Digest(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetDigest, err := fileSHA256Digest(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(t.TempDir())
+	baseBlobPath := filepath.Join(store.root, "_blobs", digestToFileName(baseDigest))
+	if err := linkOrCopyLayerContents(basePath, baseBlobPath); err != nil {
+		t.Fatal(err)
+	}
+	if recognized, err := store.prepareStargzLayerFromBlob(descriptor{Digest: baseDigest, Size: baseInfo.Size()}); err != nil || !recognized {
+		t.Fatalf("prepare base layer: recognized=%t err=%v", recognized, err)
+	}
+
+	var served atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var start, end int64
+		if _, err := fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end); err != nil || start < 0 || end < start || end >= targetInfo.Size() {
+			http.Error(w, "invalid range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		size := end - start + 1
+		served.Add(size)
+		w.Header().Set("Content-Length", fmt.Sprint(size))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, targetInfo.Size()))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = io.CopyN(w, io.NewSectionReader(targetFile, start, size), size)
+	}))
+	defer server.Close()
+	target := descriptor{Digest: targetDigest, Size: targetInfo.Size()}
+	reconstructed, err := store.tryReconstructStargzLayer(t.Context(), &registryContext{client: server.Client(), registry: server.URL}, "demo/neuro", target, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reconstructed {
+		t.Fatal("real target layer was not reconstructed")
+	}
+	downloaded := served.Load()
+	if downloaded >= target.Size {
+		t.Fatalf("delta downloaded %d bytes for a %d-byte target", downloaded, target.Size)
+	}
+	t.Logf("reconstructed %d bytes after downloading %d bytes (%.4f%%)", target.Size, downloaded, float64(downloaded)*100/float64(target.Size))
+}

--- a/internal/oci/stargzlayer_test.go
+++ b/internal/oci/stargzlayer_test.go
@@ -1,0 +1,488 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"j5.nz/cc/internal/imagefs"
+)
+
+func TestStargzLayerRemainsCompressedAndServesIndexedReads(t *testing.T) {
+	body := make([]byte, 700<<10)
+	for i := range body {
+		body[i] = byte((i*31 + i/4093) % 251)
+	}
+	layerBlob := buildTestStargzLayer(t,
+		testStargzEntry{name: "usr", mode: 0o755, typeflag: tar.TypeDir},
+		testStargzEntry{name: "usr/share", mode: 0o755, typeflag: tar.TypeDir},
+		testStargzEntry{name: "usr/share/payload.bin", mode: 0o640, body: body},
+		testStargzEntry{name: "obsolete", mode: 0o644, body: []byte("old")},
+	)
+
+	store := NewStore(t.TempDir())
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(layerBlob))
+	layer := descriptor{
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Digest:    digest,
+		Size:      int64(len(layerBlob)),
+	}
+	blobPath := filepath.Join(store.root, "_blobs", digestToFileName(digest))
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blobPath, layerBlob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recognized, err := store.prepareStargzLayerFromBlob(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recognized || !store.cachedStargzLayerAvailable(layer) {
+		t.Fatal("valid eStargz layer was not retained in the compressed cache")
+	}
+	if info, err := os.Stat(blobPath); err != nil || info.Size() != int64(len(layerBlob)) {
+		t.Fatalf("compressed layer blob was not retained: info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(filepath.Join(store.root, layerArchiveDirName, digestToFileName(digest), layerContentsName)); !os.IsNotExist(err) {
+		t.Fatalf("eStargz layer unexpectedly created expanded contents: %v", err)
+	}
+
+	imageDir := t.TempDir()
+	layerRel := filepath.Join("layers", digestToFileName(digest)+".stargz")
+	imageBlob := filepath.Join(imageDir, layerRel)
+	if err := linkOrCopyLayerContents(blobPath, imageBlob); err != nil {
+		t.Fatal(err)
+	}
+	build := newIndexedBuildState()
+	if err := applyLayerArchive(
+		store.stargzLayerIndexPath(digest),
+		stargzContentsPrefix+layerRel,
+		build.merged,
+		build.fsEntries,
+	); err != nil {
+		t.Fatal(err)
+	}
+	ensureIndexedParents(build.merged, build.fsEntries)
+	nodes := make([]indexedNode, 0, len(build.merged))
+	for _, node := range build.merged {
+		nodes = append(nodes, *node)
+	}
+	root, err := buildIndexedRootFS(imageDir, nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := imagefs.LookupPath(root, "/usr/share/payload.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.File == nil {
+		t.Fatal("payload is not an indexed file")
+	}
+	const offset = 60 << 10
+	got, err := entry.File.ReadAt(offset, 24<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, body[offset:offset+len(got)]) {
+		t.Fatal("read crossing an eStargz chunk boundary returned incorrect bytes")
+	}
+}
+
+func TestOrdinaryGzipLayerDoesNotEnterStargzCache(t *testing.T) {
+	store := NewStore(t.TempDir())
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gzw)
+	if err := tw.WriteHeader(&tar.Header{Name: "plain", Mode: 0o644, Size: 5}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte("plain")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(compressed.Bytes()))
+	layer := descriptor{Digest: digest, Size: int64(compressed.Len())}
+	blobPath := filepath.Join(store.root, "_blobs", digestToFileName(digest))
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blobPath, compressed.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recognized, err := store.prepareStargzLayerFromBlob(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recognized {
+		t.Fatal("ordinary gzip layer was recognized as eStargz")
+	}
+}
+
+func TestRepackStargzLayerAddsExactCompressedMemberIndex(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "input.tar")
+	outputPath := filepath.Join(t.TempDir(), "output.tar.gz")
+	input, err := os.Create(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(input)
+	for _, entry := range []testStargzEntry{
+		{name: "etc", mode: 0o755, typeflag: tar.TypeDir},
+		{name: "etc/config", mode: 0o644, body: bytes.Repeat([]byte("configuration\n"), 40<<10)},
+		{name: "usr", mode: 0o755, typeflag: tar.TypeDir},
+		{name: "usr/tool", mode: 0o755, body: bytes.Repeat([]byte("tool payload\n"), 50<<10)},
+	} {
+		typeflag := entry.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		hdr := &tar.Header{Name: entry.name, Mode: entry.mode, Typeflag: typeflag, Size: int64(len(entry.body))}
+		if typeflag == tar.TypeDir {
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(entry.body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := input.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RepackStargzLayerFile(t.Context(), inputPath, outputPath, 64<<10, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.BlobDigest == "" || result.DiffID == "" || result.TOCJSONDigest == "" || result.Members < 2 {
+		t.Fatalf("incomplete repack result: %+v", result)
+	}
+	document, tocOffset, err := readStargzTOCDocument(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.VMSHDelta == nil || document.VMSHDelta.Version != stargzDeltaIndexVersion {
+		t.Fatalf("missing vmsh delta index: %+v", document.VMSHDelta)
+	}
+	members, err := hashStargzPayloadMembers(outputPath, document.Entries, tocOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStargzMembers(document.VMSHDelta.Members, members) {
+		t.Fatalf("embedded member hashes do not describe output payload\nembedded=%+v\nactual=%+v", document.VMSHDelta.Members, members)
+	}
+	reader, err := openStargzReader(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := reader.OpenFile("usr/tool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, 32<<10)
+	if _, err := file.ReadAt(got, 48<<10); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("tool payload\n"), 50<<10)[48<<10:80<<10]) {
+		t.Fatal("enhanced eStargz layer returned incorrect file contents")
+	}
+}
+
+func TestStargzDeltaReconstructionFetchesOnlyMissingTargetRanges(t *testing.T) {
+	oldBody := deterministicTestBytes(2 << 20)
+	newBody := append([]byte(nil), oldBody...)
+	copy(newBody[900<<10:932<<10], deterministicTestBytes(32<<10))
+	oldInput := filepath.Join(t.TempDir(), "old.tar")
+	newInput := filepath.Join(t.TempDir(), "new.tar")
+	writeSingleFileLayer(t, oldInput, oldBody)
+	writeSingleFileLayer(t, newInput, newBody)
+	oldBlob := filepath.Join(t.TempDir(), "old.tar.gz")
+	newBlob := filepath.Join(t.TempDir(), "new.tar.gz")
+	oldResult, err := RepackStargzLayerFile(t.Context(), oldInput, oldBlob, 64<<10, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newResult, err := RepackStargzLayerFile(t.Context(), newInput, newBlob, 64<<10, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetData, err := os.ReadFile(newBlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(t.TempDir())
+	oldCachePath := filepath.Join(store.root, "_blobs", digestToFileName(oldResult.BlobDigest))
+	if err := os.MkdirAll(filepath.Dir(oldCachePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(oldBlob, oldCachePath); err != nil {
+		if err := copyFile(oldBlob, oldCachePath, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldInfo, err := os.Stat(oldBlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recognized, err := store.prepareStargzLayerFromBlob(descriptor{Digest: oldResult.BlobDigest, Size: oldInfo.Size()}); err != nil || !recognized {
+		t.Fatalf("prepare old layer: recognized=%t err=%v", recognized, err)
+	}
+
+	var served int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var start, end int64
+		if _, err := fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end); err != nil || start < 0 || end < start || end >= int64(len(targetData)) {
+			http.Error(w, "invalid range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		chunk := targetData[start : end+1]
+		served += int64(len(chunk))
+		w.Header().Set("Content-Length", fmt.Sprint(len(chunk)))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(targetData)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(chunk)
+	}))
+	defer server.Close()
+	target := descriptor{Digest: newResult.BlobDigest, Size: int64(len(targetData))}
+	reconstructed, err := store.tryReconstructStargzLayer(
+		t.Context(),
+		&registryContext{client: server.Client(), registry: server.URL},
+		"test/image",
+		target,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reconstructed {
+		t.Fatal("target layer was not reconstructed from reusable members")
+	}
+	got, err := os.ReadFile(filepath.Join(store.root, "_blobs", digestToFileName(target.Digest)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, targetData) {
+		t.Fatal("delta reconstruction did not reproduce exact target OCI blob")
+	}
+	if served >= int64(len(targetData))/2 {
+		t.Fatalf("delta fetched %d of %d bytes; expected substantial member reuse", served, len(targetData))
+	}
+}
+
+func TestPullEnhancedStargzImageKeepsCompressedLayerAndOpensFilesystem(t *testing.T) {
+	payload := deterministicTestBytes(700 << 10)
+	inputPath := filepath.Join(t.TempDir(), "layer.tar")
+	outputPath := filepath.Join(t.TempDir(), "layer.tar.gz")
+	writeSingleFileLayer(t, inputPath, payload)
+	repacked, err := RepackStargzLayerFile(t.Context(), inputPath, outputPath, 64<<10, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configData := []byte(`{"architecture":"amd64","config":{"User":"root"}}`)
+	configSum := sha256.Sum256(configData)
+	configDigest := fmt.Sprintf("sha256:%x", configSum)
+	manifestData, err := json.Marshal(manifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.manifest.v1+json",
+		Config: descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    configDigest,
+			Size:      int64(len(configData)),
+		},
+		Layers: []descriptor{{
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+			Digest:    repacked.BlobDigest,
+			Size:      int64(len(layerData)),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/team/neuro/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			_, _ = w.Write(manifestData)
+		case r.URL.Path == "/v2/team/neuro/blobs/"+configDigest:
+			_, _ = w.Write(configData)
+		case r.URL.Path == "/v2/team/neuro/blobs/"+repacked.BlobDigest:
+			// Returning 200 to the optional bounded probe exercises the safe
+			// fallback to a complete, descriptor-verified blob download.
+			w.Header().Set("Content-Length", fmt.Sprint(len(layerData)))
+			_, _ = w.Write(layerData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	sharedRoot := filepath.Join(t.TempDir(), "shared")
+	store := NewStoreWithSharedCache(filepath.Join(t.TempDir(), "images"), sharedRoot)
+	store.httpClient = server.Client()
+	source := strings.TrimPrefix(server.URL, "https://") + "/team/neuro:latest"
+	if _, err := store.Pull(t.Context(), "neuro", source, PullOptions{
+		Architecture:         "amd64",
+		KeepCompressedLayers: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	image, err := store.Open("neuro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := imagefs.LookupPath(image.RootFS, "/usr/share/payload.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := entry.File.ReadAt(63<<10, 8<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload[63<<10:71<<10]) {
+		t.Fatal("pulled image returned incorrect bytes across a compressed chunk boundary")
+	}
+	imageLayers, err := filepath.Glob(filepath.Join(image.RootFSDir, "layers", "*.stargz"))
+	if err != nil || len(imageLayers) != 1 {
+		allLayers, _ := filepath.Glob(filepath.Join(image.RootFSDir, "layers", "*"))
+		t.Fatalf("compressed image layers = %v, all layers=%v, root=%q, err=%v", imageLayers, allLayers, image.RootFSDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(sharedRoot, layerArchiveDirName, digestToFileName(repacked.BlobDigest), layerContentsName)); !os.IsNotExist(err) {
+		t.Fatalf("pull expanded the enhanced layer: %v", err)
+	}
+}
+
+func equalStargzMembers(a, b []stargzDeltaMember) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func deterministicTestBytes(size int) []byte {
+	out := make([]byte, size)
+	state := uint64(0x9e3779b97f4a7c15)
+	for i := range out {
+		state ^= state << 13
+		state ^= state >> 7
+		state ^= state << 17
+		out[i] = byte(state)
+	}
+	return out
+}
+
+func writeSingleFileLayer(t *testing.T, path string, body []byte) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(file)
+	for _, hdr := range []*tar.Header{
+		{Name: "usr", Mode: 0o755, Typeflag: tar.TypeDir},
+		{Name: "usr/share", Mode: 0o755, Typeflag: tar.TypeDir},
+		{Name: "usr/share/payload.bin", Mode: 0o644, Typeflag: tar.TypeReg, Size: int64(len(body))},
+	} {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Size > 0 {
+			if _, err := tw.Write(body); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type testStargzEntry struct {
+	name     string
+	mode     int64
+	typeflag byte
+	body     []byte
+}
+
+func buildTestStargzLayer(t *testing.T, entries ...testStargzEntry) []byte {
+	t.Helper()
+	var raw bytes.Buffer
+	tw := tar.NewWriter(&raw)
+	for _, entry := range entries {
+		typeflag := entry.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     entry.name,
+			Mode:     entry.mode,
+			Typeflag: typeflag,
+			Size:     int64(len(entry.body)),
+		}
+		if typeflag == tar.TypeDir {
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if len(entry.body) > 0 {
+			if _, err := tw.Write(entry.body); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	blob, err := estargz.Build(
+		io.NewSectionReader(bytes.NewReader(raw.Bytes()), 0, int64(raw.Len())),
+		estargz.WithChunkSize(64<<10),
+		estargz.WithMinChunkSize(64<<10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := blob.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/internal/oci/stargzlayer_test.go
+++ b/internal/oci/stargzlayer_test.go
@@ -293,6 +293,35 @@ func TestStargzDeltaReconstructionFetchesOnlyMissingTargetRanges(t *testing.T) {
 	}
 }
 
+func TestCopyRemoteBlobRangeReportsIntermediateProgress(t *testing.T) {
+	data := deterministicTestBytes(1 << 20)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(data)-1, len(data)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(data)
+	}))
+	defer server.Close()
+
+	dst, err := os.CreateTemp(t.TempDir(), "range-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	var reports []int64
+	if err := copyRemoteBlobRange(t.Context(), &registryContext{client: server.Client(), registry: server.URL}, "/blob", dst, 0, int64(len(data)-1), int64(len(data)), func(current int64) {
+		reports = append(reports, current)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(reports) < 2 || reports[0] <= 0 || reports[0] >= int64(len(data)) {
+		t.Fatalf("range progress reports = %v, want an intermediate update", reports)
+	}
+	if got := reports[len(reports)-1]; got != int64(len(data)) {
+		t.Fatalf("final range progress = %d, want %d", got, len(data))
+	}
+}
+
 func TestPullEnhancedStargzImageKeepsCompressedLayerAndOpensFilesystem(t *testing.T) {
 	payload := deterministicTestBytes(700 << 10)
 	inputPath := filepath.Join(t.TempDir(), "layer.tar")

--- a/internal/oci/stargzlayer_test.go
+++ b/internal/oci/stargzlayer_test.go
@@ -13,7 +13,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"j5.nz/cc/client"
@@ -415,6 +418,96 @@ func TestPullEnhancedStargzImageKeepsCompressedLayerAndOpensFilesystem(t *testin
 	}
 	if _, err := os.Stat(filepath.Join(sharedRoot, layerArchiveDirName, digestToFileName(repacked.BlobDigest), layerContentsName)); !os.IsNotExist(err) {
 		t.Fatalf("pull expanded the enhanced layer: %v", err)
+	}
+}
+
+func TestPullCompressedImageDownloadsLayersInParallel(t *testing.T) {
+	configData := []byte(`{"architecture":"amd64","config":{"User":"root"}}`)
+	configSum := sha256.Sum256(configData)
+	configDigest := fmt.Sprintf("sha256:%x", configSum)
+	layerData := make(map[string][]byte)
+	layers := make([]descriptor, 0, 4)
+	for index := range 4 {
+		data := compressedTestLayer(t, testLayerEntry{
+			header: tar.Header{Name: fmt.Sprintf("layer-%d", index), Mode: 0o644},
+			body:   deterministicTestBytes((index + 1) * 64 << 10),
+		})
+		digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+		layerData[digest] = data
+		layers = append(layers, descriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+			Digest:    digest,
+			Size:      int64(len(data)),
+		})
+	}
+	manifestData, err := json.Marshal(manifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.manifest.v1+json",
+		Config: descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    configDigest,
+			Size:      int64(len(configData)),
+		},
+		Layers: layers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	timeout := time.AfterFunc(2*time.Second, func() { releaseOnce.Do(func() { close(release) }) })
+	defer timeout.Stop()
+	var active atomic.Int64
+	var maximum atomic.Int64
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/team/parallel/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			_, _ = w.Write(manifestData)
+		case r.URL.Path == "/v2/team/parallel/blobs/"+configDigest:
+			_, _ = w.Write(configData)
+		default:
+			digest := strings.TrimPrefix(r.URL.Path, "/v2/team/parallel/blobs/")
+			data := layerData[digest]
+			if data == nil {
+				http.NotFound(w, r)
+				return
+			}
+			if r.Header.Get("Range") != "" {
+				w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+				_, _ = w.Write(data)
+				return
+			}
+			current := active.Add(1)
+			defer active.Add(-1)
+			for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
+			}
+			if current == 4 {
+				releaseOnce.Do(func() { close(release) })
+			}
+			select {
+			case <-release:
+			case <-r.Context().Done():
+				return
+			}
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+			_, _ = w.Write(data)
+		}
+	}))
+	defer server.Close()
+
+	store := NewStoreWithSharedCache(filepath.Join(t.TempDir(), "images"), filepath.Join(t.TempDir(), "shared"))
+	store.httpClient = server.Client()
+	source := strings.TrimPrefix(server.URL, "https://") + "/team/parallel:latest"
+	if _, err := store.Pull(t.Context(), "parallel", source, PullOptions{
+		Architecture:         "amd64",
+		KeepCompressedLayers: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := maximum.Load(); got < 4 {
+		t.Fatalf("maximum concurrent layer downloads = %d, want at least 4", got)
 	}
 }
 

--- a/internal/oci/stargzlayer_test.go
+++ b/internal/oci/stargzlayer_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/containerd/stargz-snapshotter/estargz"
+	"j5.nz/cc/client"
 	"j5.nz/cc/internal/imagefs"
 )
 
@@ -348,11 +349,20 @@ func TestPullEnhancedStargzImageKeepsCompressedLayerAndOpensFilesystem(t *testin
 	store := NewStoreWithSharedCache(filepath.Join(t.TempDir(), "images"), sharedRoot)
 	store.httpClient = server.Client()
 	source := strings.TrimPrefix(server.URL, "https://") + "/team/neuro:latest"
+	var reportedDownloadRate bool
 	if _, err := store.Pull(t.Context(), "neuro", source, PullOptions{
 		Architecture:         "amd64",
 		KeepCompressedLayers: true,
+		Report: func(event client.ProgressEvent) {
+			if event.Status == "downloading" && event.RateBytesPerSecond > 0 {
+				reportedDownloadRate = true
+			}
+		},
 	}); err != nil {
 		t.Fatal(err)
+	}
+	if !reportedDownloadRate {
+		t.Fatal("compressed image pull did not report a download rate")
 	}
 	image, err := store.Open("neuro")
 	if err != nil {

--- a/internal/oci/stargzrepack.go
+++ b/internal/oci/stargzrepack.go
@@ -1,0 +1,327 @@
+package oci
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/containerd/stargz-snapshotter/estargz"
+)
+
+const stargzDeltaIndexVersion = 1
+
+type stargzDeltaMember struct {
+	Digest string `json:"digest"`
+	Offset int64  `json:"offset"`
+	Size   int64  `json:"size"`
+}
+
+type stargzDeltaIndex struct {
+	Version int                 `json:"version"`
+	Members []stargzDeltaMember `json:"members"`
+}
+
+type stargzTOCDocument struct {
+	Version   int                 `json:"version"`
+	Entries   []*estargz.TOCEntry `json:"entries"`
+	VMSHDelta *stargzDeltaIndex   `json:"vmshDelta,omitempty"`
+}
+
+type StargzRepackResult struct {
+	BlobDigest    string
+	DiffID        string
+	TOCJSONDigest string
+	BlobSize      int64
+	Members       int
+}
+
+// RepackStargzLayerFile converts a tar or compressed tar OCI layer to a
+// deterministic, standard-compatible eStargz blob with a vmsh member index.
+// The output is replaced atomically only after the complete blob and DiffID
+// have been calculated successfully.
+func RepackStargzLayerFile(ctx context.Context, inputPath, outputPath string, chunkSize, minChunkSize int) (StargzRepackResult, error) {
+	if ctx == nil {
+		return StargzRepackResult{}, fmt.Errorf("repack context is required")
+	}
+	if chunkSize <= 0 {
+		chunkSize = 256 << 10
+	}
+	if minChunkSize < 0 {
+		return StargzRepackResult{}, fmt.Errorf("minimum chunk size cannot be negative")
+	}
+	input, err := os.Open(inputPath)
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	defer input.Close()
+	info, err := input.Stat()
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	outputDir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return StargzRepackResult{}, err
+	}
+	baseBlob, err := os.CreateTemp(outputDir, ".estargz-base-")
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	basePath := baseBlob.Name()
+	defer os.Remove(basePath)
+
+	built, err := estargz.Build(
+		io.NewSectionReader(input, 0, info.Size()),
+		estargz.WithContext(ctx),
+		estargz.WithChunkSize(chunkSize),
+		estargz.WithMinChunkSize(minChunkSize),
+		estargz.WithCompressionLevel(gzip.DefaultCompression),
+	)
+	if err != nil {
+		baseBlob.Close()
+		return StargzRepackResult{}, err
+	}
+	_, copyErr := io.Copy(baseBlob, built)
+	closeBuiltErr := built.Close()
+	closeBaseErr := baseBlob.Close()
+	if err := errorsJoin(copyErr, closeBuiltErr, closeBaseErr); err != nil {
+		return StargzRepackResult{}, err
+	}
+
+	document, tocOffset, err := readStargzTOCDocument(basePath)
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	members, err := hashStargzPayloadMembers(basePath, document.Entries, tocOffset)
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	document.VMSHDelta = &stargzDeltaIndex{Version: stargzDeltaIndexVersion, Members: members}
+
+	tmpOutput, err := os.CreateTemp(outputDir, ".estargz-final-")
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	tmpPath := tmpOutput.Name()
+	defer os.Remove(tmpPath)
+	result, err := writeEnhancedStargz(basePath, tocOffset, tmpOutput, document)
+	if err != nil {
+		tmpOutput.Close()
+		return StargzRepackResult{}, err
+	}
+	if err := tmpOutput.Close(); err != nil {
+		return StargzRepackResult{}, err
+	}
+	diffID, err := stargzDiffID(tmpPath)
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	result.DiffID = diffID
+	result.Members = len(members)
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		return StargzRepackResult{}, err
+	}
+	return result, nil
+}
+
+func readStargzTOCDocument(blobPath string) (*stargzTOCDocument, int64, error) {
+	file, err := os.Open(blobPath)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	tocOffset, _, err := estargz.OpenFooter(io.NewSectionReader(file, 0, info.Size()))
+	if err != nil || tocOffset < 0 || tocOffset >= info.Size() {
+		return nil, 0, errNotStargzLayer
+	}
+	document, err := decodeStargzTOCDocument(io.NewSectionReader(file, tocOffset, info.Size()-tocOffset))
+	return document, tocOffset, err
+}
+
+func decodeStargzTOCDocument(compressed io.Reader) (*stargzTOCDocument, error) {
+	gzr, err := gzip.NewReader(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("open eStargz TOC gzip member: %w", err)
+	}
+	defer gzr.Close()
+	tr := tar.NewReader(gzr)
+	hdr, err := tr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("read eStargz TOC tar header: %w", err)
+	}
+	if hdr.Name != estargz.TOCTarName || hdr.Size < 0 || hdr.Size > maxStargzTOCJSONBytes {
+		return nil, fmt.Errorf("invalid eStargz TOC entry %q with size %d", hdr.Name, hdr.Size)
+	}
+	data, err := io.ReadAll(io.LimitReader(tr, hdr.Size+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) != hdr.Size {
+		return nil, fmt.Errorf("eStargz TOC length mismatch: expected %d, got %d", hdr.Size, len(data))
+	}
+	var document stargzTOCDocument
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, err
+	}
+	if document.Version != 1 {
+		return nil, fmt.Errorf("unsupported eStargz TOC version %d", document.Version)
+	}
+	return &document, nil
+}
+
+func hashStargzPayloadMembers(blobPath string, entries []*estargz.TOCEntry, tocOffset int64) ([]stargzDeltaMember, error) {
+	offsets := []int64{0}
+	seen := map[int64]bool{0: true}
+	for _, entry := range entries {
+		if entry == nil || (entry.Type != "reg" && entry.Type != "chunk") {
+			continue
+		}
+		if entry.Offset < 0 || entry.Offset >= tocOffset {
+			return nil, fmt.Errorf("eStargz member offset %d is outside payload", entry.Offset)
+		}
+		if !seen[entry.Offset] {
+			seen[entry.Offset] = true
+			offsets = append(offsets, entry.Offset)
+		}
+	}
+	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+	file, err := os.Open(blobPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	members := make([]stargzDeltaMember, 0, len(offsets))
+	for i, offset := range offsets {
+		end := tocOffset
+		if i+1 < len(offsets) {
+			end = offsets[i+1]
+		}
+		if end <= offset {
+			return nil, fmt.Errorf("invalid eStargz member range %d-%d", offset, end)
+		}
+		hash := sha256.New()
+		if _, err := io.Copy(hash, io.NewSectionReader(file, offset, end-offset)); err != nil {
+			return nil, err
+		}
+		members = append(members, stargzDeltaMember{
+			Digest: "sha256:" + hex.EncodeToString(hash.Sum(nil)),
+			Offset: offset,
+			Size:   end - offset,
+		})
+	}
+	return members, nil
+}
+
+func writeEnhancedStargz(basePath string, tocOffset int64, output *os.File, document *stargzTOCDocument) (StargzRepackResult, error) {
+	base, err := os.Open(basePath)
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	defer base.Close()
+	blobHash := sha256.New()
+	w := io.MultiWriter(output, blobHash)
+	if _, err := io.Copy(w, io.NewSectionReader(base, 0, tocOffset)); err != nil {
+		return StargzRepackResult{}, err
+	}
+	tocJSON, err := json.MarshalIndent(document, "", "\t")
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	gzw, err := gzip.NewWriterLevel(w, gzip.DefaultCompression)
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	gzw.Header.ModTime = time.Unix(0, 0)
+	gzw.Header.OS = 255
+	tw := tar.NewWriter(gzw)
+	if err := tw.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: estargz.TOCTarName, Mode: 0o644, Size: int64(len(tocJSON))}); err != nil {
+		return StargzRepackResult{}, err
+	}
+	if _, err := tw.Write(tocJSON); err != nil {
+		return StargzRepackResult{}, err
+	}
+	if err := tw.Close(); err != nil {
+		return StargzRepackResult{}, err
+	}
+	if err := gzw.Close(); err != nil {
+		return StargzRepackResult{}, err
+	}
+	if _, err := w.Write(stargzFooterBytes(tocOffset)); err != nil {
+		return StargzRepackResult{}, err
+	}
+	if err := output.Sync(); err != nil {
+		return StargzRepackResult{}, err
+	}
+	info, err := output.Stat()
+	if err != nil {
+		return StargzRepackResult{}, err
+	}
+	tocHash := sha256.Sum256(tocJSON)
+	return StargzRepackResult{
+		BlobDigest:    "sha256:" + hex.EncodeToString(blobHash.Sum(nil)),
+		TOCJSONDigest: fmt.Sprintf("sha256:%x", tocHash),
+		BlobSize:      info.Size(),
+	}, nil
+}
+
+func stargzFooterBytes(tocOffset int64) []byte {
+	var out bytesBuffer
+	gzw, _ := gzip.NewWriterLevel(&out, gzip.NoCompression)
+	header := make([]byte, 4)
+	header[0], header[1] = 'S', 'G'
+	subfield := fmt.Sprintf("%016xSTARGZ", tocOffset)
+	binary.LittleEndian.PutUint16(header[2:], uint16(len(subfield)))
+	gzw.Extra = append(header, subfield...)
+	_ = gzw.Close()
+	return out.Bytes()
+}
+
+func stargzDiffID(blobPath string) (string, error) {
+	file, err := os.Open(blobPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	gzr, err := gzip.NewReader(bufio.NewReader(file))
+	if err != nil {
+		return "", err
+	}
+	defer gzr.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, gzr); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+type bytesBuffer struct{ data []byte }
+
+func (b *bytesBuffer) Write(p []byte) (int, error) {
+	b.data = append(b.data, p...)
+	return len(p), nil
+}
+
+func (b *bytesBuffer) Bytes() []byte { return b.data }
+
+func errorsJoin(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What changed

- add enhanced eStargz layer repacking with a custom delta table stored inside standard OCI gzip layers
- reconstruct updated layers with exact HTTP range requests and retain compressed blobs on disk
- add staged image activation support for background application updates
- add a full OCI image-layout converter and command-line tools

## Why

Neurodesk images contain very large layers. Re-downloading whole layers for small changes makes foreground updates slow and storage-heavy. This keeps registry and image compatibility while allowing unchanged compressed byte ranges to be reused locally.

## Impact

Consumers that opt into compressed OCI storage can perform range-based layer updates and atomically activate a staged image. Conventional OCI consumers continue to see ordinary gzip layer media types.

## Validation

- `go test ./...`
- `go vet ./internal/oci ./cmd/estargz-repack ./cmd/estargz-repack-image`
- focused race tests for OCI repacking, eStargz, and enhanced pulls
- real large-layer repack and exact delta reconstruction
- pull, repack, push, and remote validation against a local OCI registry