### PR TITLE
Harden persistent virtio-fs durability

### DIFF
--- a/internal/linuxabi/constants.go
+++ b/internal/linuxabi/constants.go
@@ -15,9 +15,11 @@ const (
 const (
 	EPERM      int32 = 1
 	ENOENT     int32 = 2
+	EINTR      int32 = 4
 	EIO        int32 = 5
 	ENXIO      int32 = 6
 	EBADF      int32 = 9
+	EAGAIN     int32 = 11
 	EACCES     int32 = 13
 	EBUSY      int32 = 16
 	EEXIST     int32 = 17

--- a/internal/virtio/fs.go
+++ b/internal/virtio/fs.go
@@ -49,6 +49,8 @@ const (
 	fuseLKInSize           = 48
 	fuseLKOutSize          = 24
 	linuxFUnlck            = 2
+	fuseFlushLockOwner     = 1 << 1
+	fuseReleaseFlockUnlock = 1 << 1
 )
 
 const (
@@ -401,7 +403,7 @@ func NewFS(base, size uint64, irq uint32, tag string, backend FSBackend) *FS {
 		completions: make(map[fsCompletionKey]fsCompletion),
 	}
 	fs.resetQueueStateLocked()
-	fs.filesystem = &fuseServer{device: fs, backend: backend}
+	fs.filesystem = &fuseServer{device: fs, backend: backend, locks: newFuseLockManager()}
 	fs.dispatcher = fs.filesystem
 	if be, ok := backend.(fsWritebackCacheBackend); ok {
 		be.SetWritebackCache(fs.writebackCache)
@@ -422,6 +424,9 @@ func (f *FS) closeWithin(timeout time.Duration) error {
 	started := time.Now()
 	f.closeStart.Do(func() {
 		close(f.closed)
+		if f.filesystem != nil && f.filesystem.locks != nil {
+			f.filesystem.locks.close()
+		}
 		// Prevent a concurrent enqueue from adding workers after the wait starts.
 		f.workerOnce.Do(func() {})
 		f.mu.Lock()
@@ -596,10 +601,10 @@ func resolveVirtioFSAsync() bool {
 
 func resolveVirtioFSWorkerCount() int {
 	const maxWorkers = 64
-	// One worker per device preserves concurrency between VMs without retaining
-	// GOMAXPROCS-sized worker sets for every mostly idle guest. Workloads that
-	// benefit from parallel requests within one guest can raise this explicitly.
-	workers := 1
+	// Four request queues are exposed to the guest. Keep one worker available
+	// per queue so a blocking lock request or slow durability operation cannot
+	// prevent an unlock or unrelated filesystem request from being dispatched.
+	workers := fsRequestQueueCount
 	if value := strings.TrimSpace(os.Getenv("CCX3_VIRTIOFS_WORKERS")); value != "" {
 		if parsed, err := strconv.Atoi(value); err == nil {
 			workers = parsed

--- a/internal/virtio/fs_backend.go
+++ b/internal/virtio/fs_backend.go
@@ -74,6 +74,10 @@ type fsFsyncDirBackend interface {
 	FsyncDir(nodeID uint64, fh uint64, flags uint32) int32
 }
 
+type fsSyncFSBackend interface {
+	SyncFS() int32
+}
+
 type fsLseekBackend interface {
 	Lseek(nodeID uint64, fh uint64, offset uint64, whence uint32) (uint64, int32)
 }

--- a/internal/virtio/fs_backends.go
+++ b/internal/virtio/fs_backends.go
@@ -60,6 +60,10 @@ type imageFS struct {
 	mapOwner        bool
 	debugPaths      []string
 	debugLog        io.Writer
+	// mutationMu lets a durability barrier release mu during slow host syncs.
+	// Readers remain responsive while persistent mutations wait for the stable
+	// snapshot being committed.
+	mutationMu sync.RWMutex
 
 	mu                    sync.Mutex
 	nextNodeID            uint64
@@ -1724,6 +1728,11 @@ func (p *imageFS) Open(nodeID uint64, flags uint32) (uint64, int32) {
 }
 
 func (p *imageFS) OpenForCaller(nodeID uint64, flags uint32, uid uint32, gid uint32) (uint64, int32) {
+	mutating := flags&linuxOACCMODE != linuxORDONLY
+	if mutating {
+		p.mutationMu.RLock()
+		defer p.mutationMu.RUnlock()
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	node := p.imageNodeLocked(nodeID)
@@ -1788,31 +1797,71 @@ func (p *imageFS) Release(_ uint64, fh uint64) {
 	handle, ok := p.handles[fh]
 	delete(p.handles, fh)
 	p.compactImageHandleMapsLocked()
+	collect := false
 	if ok {
+		node := p.imageNodeLocked(handle.nodeID)
+		collect = node != nil && node.nlink == 0
+	}
+	if ok && !collect {
 		p.collectImageNodeLocked(handle.nodeID)
 	}
 	p.mu.Unlock()
+	if collect {
+		// Reclaiming an unlinked inode changes persistent state. Ordinary closes,
+		// including the read-only opens used by SSH authentication, need not wait
+		// behind an unrelated file's host fsync.
+		p.mutationMu.RLock()
+		p.mu.Lock()
+		p.collectImageNodeLocked(handle.nodeID)
+		p.mu.Unlock()
+		p.mutationMu.RUnlock()
+	}
 	if ok && handle.closer != nil {
 		_ = handle.closer.Close()
 	}
 }
 
 func (p *imageFS) Flush(_ uint64, _ uint64, _ uint64) int32 {
-	p.mu.Lock()
-	err := p.flushPersistentLocked(false)
-	p.mu.Unlock()
-	if err != nil {
-		return errnoFromError(err)
-	}
+	// FUSE FLUSH is a close-time error-reporting hook, not a durability
+	// barrier. Keep mutations coalesced in memory until fsync, fsyncdir, or a
+	// clean filesystem close instead of emitting uncommitted WAL records that
+	// force a later unrelated fsync to synchronize their data.
 	return 0
 }
 
 func (p *imageFS) Fsync(nodeID uint64, _ uint64, _ uint32) int32 {
+	p.mutationMu.Lock()
+	defer p.mutationMu.Unlock()
 	p.mu.Lock()
 	if p.persistent != nil {
+		delta := p.persistentFileDeltaLocked(nodeID)
+		if delta == nil {
+			p.mu.Unlock()
+			return -linuxEINVAL
+		}
+		// Mutations are excluded by mutationMu. Release the namespace mutex
+		// while the host performs the potentially slow data sync so lookups,
+		// reads, SSH authentication, and other unrelated traffic stay live.
+		p.mu.Unlock()
 		err := p.persistent.syncData(nodeID)
+		p.mu.Lock()
 		if err == nil {
-			err = p.flushPersistentLocked(true)
+			// Reads may update atime while the slow host sync is in progress.
+			// Capture that final inode metadata rather than clearing it as though
+			// the earlier snapshot had included it.
+			delta = p.persistentFileDeltaLocked(nodeID)
+			if delta == nil {
+				err = fmt.Errorf("fsync inode %d disappeared during data sync", nodeID)
+			}
+		}
+		committedCreation := err == nil && !delta.Nodes[0].PreserveNamespace
+		if err == nil {
+			err = p.persistent.appendDelta(delta, true)
+		}
+		if err == nil {
+			p.persistent.clearFilePending(nodeID, committedCreation)
+			p.persistent.refreshPhysicalUsage(nodeID)
+			err = p.persistent.reclaimDurableFileData(nodeID)
 		}
 		if err == nil {
 			err = p.maybeCheckpointPersistentLocked()
@@ -1831,9 +1880,49 @@ func (p *imageFS) Fsync(nodeID uint64, _ uint64, _ uint32) int32 {
 }
 
 func (p *imageFS) FsyncDir(_ uint64, _ uint64, _ uint32) int32 {
+	p.mutationMu.Lock()
+	defer p.mutationMu.Unlock()
 	p.mu.Lock()
 	if p.persistent != nil {
-		err := p.flushPersistentLocked(true)
+		delta := p.persistentNamespaceDeltaLocked()
+		var err error
+		if delta != nil {
+			// Namespace durability does not imply durability of unrelated file
+			// contents. Dirty file records in this delta retain their last
+			// durable data state.
+			err = p.persistent.appendDelta(delta, true)
+		}
+		if err == nil {
+			p.persistent.clearNamespacePending()
+			err = p.persistent.reclaimDurableNamespaceData()
+		}
+		if err == nil {
+			err = p.maybeCheckpointPersistentLocked()
+		}
+		p.mu.Unlock()
+		if err != nil {
+			return errnoFromError(err)
+		}
+		return 0
+	}
+	p.mu.Unlock()
+	if err := p.dataStore.sync(); err != nil {
+		return errnoFromError(err)
+	}
+	return 0
+}
+
+func (p *imageFS) SyncFS() int32 {
+	p.mutationMu.Lock()
+	defer p.mutationMu.Unlock()
+	p.mu.Lock()
+	if p.persistent != nil {
+		p.mu.Unlock()
+		err := p.persistent.syncDirtyData()
+		p.mu.Lock()
+		if err == nil {
+			err = p.flushPersistentLocked(true)
+		}
 		if err == nil {
 			err = p.maybeCheckpointPersistentLocked()
 		}
@@ -2099,6 +2188,8 @@ func (p *imageFS) inheritImageCreateLocked(parent *imageNode, mode uint32, gid u
 }
 
 func (p *imageFS) Mkdir(parent uint64, name string, mode uint32, uid uint32, gid uint32) (uint64, FuseAttr, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2145,6 +2236,8 @@ func (p *imageFS) Mkdir(parent uint64, name string, mode uint32, uid uint32, gid
 }
 
 func (p *imageFS) Mknod(parent uint64, name string, mode uint32, rdev uint32, uid uint32, gid uint32) (uint64, FuseAttr, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2207,6 +2300,8 @@ func (p *imageFS) Mknod(parent uint64, name string, mode uint32, rdev uint32, ui
 }
 
 func (p *imageFS) Symlink(parent uint64, name string, target string, uid uint32, gid uint32) (uint64, FuseAttr, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2257,6 +2352,8 @@ func (p *imageFS) Link(nodeID uint64, newParent uint64, newName string) (uint64,
 }
 
 func (p *imageFS) LinkForCaller(nodeID uint64, newParent uint64, newName string, uid uint32, gid uint32) (uint64, FuseAttr, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	node := p.imageNodeLocked(nodeID)
@@ -2308,6 +2405,8 @@ func (p *imageFS) RmDir(parent uint64, name string) int32 {
 }
 
 func (p *imageFS) RmDirForCaller(parent uint64, name string, uid uint32, gid uint32) int32 {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2350,6 +2449,8 @@ func (p *imageFS) Create(parent uint64, name string, flags uint32, mode uint32, 
 }
 
 func (p *imageFS) CreateForCaller(parent uint64, name string, flags uint32, mode uint32, uid uint32, gid uint32) (uint64, uint64, FuseAttr, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2451,6 +2552,8 @@ func (p *imageFS) Write(nodeID uint64, fh uint64, off uint64, data []byte, _ uin
 }
 
 func (p *imageFS) WriteForCaller(nodeID uint64, fh uint64, off uint64, data []byte, flags uint32, uid uint32, gid uint32) (uint32, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	handle, ok := p.handles[fh]
@@ -2495,6 +2598,8 @@ func (p *imageFS) SetAttr(nodeID uint64, valid uint32, _ uint64, size uint64, mo
 }
 
 func (p *imageFS) SetAttrForCaller(nodeID uint64, valid uint32, _ uint64, size uint64, mode uint32, uid uint32, gid uint32, atime time.Time, mtime time.Time, callerUID uint32, callerGID uint32) (FuseAttr, int32) {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	node := p.mutableImageNodeLocked(nodeID)
@@ -2574,6 +2679,8 @@ func (p *imageFS) Unlink(parent uint64, name string) int32 {
 }
 
 func (p *imageFS) UnlinkForCaller(parent uint64, name string, uid uint32, gid uint32) int32 {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2624,6 +2731,8 @@ func (p *imageFS) Rename(parent uint64, name string, newParent uint64, newName s
 }
 
 func (p *imageFS) RenameForCaller(parent uint64, name string, newParent uint64, newName string, flags uint32, uid uint32, gid uint32) int32 {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	parentNode := p.imageNodeLocked(parent)
@@ -2867,6 +2976,8 @@ func (p *imageFS) SetXattr(nodeID uint64, name string, value []byte, flags uint3
 	if name == "" || len(name) > 255 || len(value) > 64<<10 || flags&^uint32(3) != 0 || flags == 3 {
 		return -linuxEINVAL
 	}
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	node := p.imageNodeLocked(nodeID)
@@ -2901,6 +3012,8 @@ func (p *imageFS) SetXattr(nodeID uint64, name string, value []byte, flags uint3
 }
 
 func (p *imageFS) RemoveXattr(nodeID uint64, name string) int32 {
+	p.mutationMu.RLock()
+	defer p.mutationMu.RUnlock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	node := p.imageNodeLocked(nodeID)
@@ -3181,6 +3294,8 @@ func (p *imageFS) closeWithin(timeout time.Duration) error {
 		// actually returns, but do not make VM teardown wait without a bound.
 		go func() {
 			p.materializationWG.Wait()
+			p.mutationMu.Lock()
+			defer p.mutationMu.Unlock()
 			p.mu.Lock()
 			persistErr := p.syncAllPersistentDataLocked()
 			if persistErr == nil {
@@ -3766,7 +3881,9 @@ const (
 
 const (
 	linuxEPERM      = linuxabi.EPERM
+	linuxEINTR      = linuxabi.EINTR
 	linuxENOENT     = linuxabi.ENOENT
+	linuxEAGAIN     = linuxabi.EAGAIN
 	linuxENXIO      = linuxabi.ENXIO
 	linuxEIO        = linuxabi.EIO
 	linuxEBADF      = linuxabi.EBADF

--- a/internal/virtio/fs_dispatch.go
+++ b/internal/virtio/fs_dispatch.go
@@ -28,6 +28,7 @@ type fuseServer struct {
 	device              *FS
 	backend             FSBackend
 	backingUsageTracker *FSBackingUsageTracker
+	locks               *fuseLockManager
 }
 
 func (s *fuseServer) Dispatch(raw []byte) (fsDispatchResult, error) {
@@ -312,10 +313,16 @@ func (s *fuseServer) dispatch(request fuseRequest) (fsReply, error) {
 		if err := request.requireBody(24, "RELEASE"); err != nil {
 			return fsReply{}, err
 		}
+		fh := binary.LittleEndian.Uint64(req[40:48])
+		releaseFlags := binary.LittleEndian.Uint32(req[52:56])
+		lockOwner := binary.LittleEndian.Uint64(req[56:64])
 		if logEnabled {
-			s.logPathf("release", nodeID, fmt.Sprintf(" fh=%d", binary.LittleEndian.Uint64(req[40:48])))
+			s.logPathf("release", nodeID, fmt.Sprintf(" fh=%d", fh))
 		}
-		s.backend.Release(nodeID, binary.LittleEndian.Uint64(req[40:48]))
+		if releaseFlags&fuseReleaseFlockUnlock != 0 {
+			s.locks.releaseOwner(nodeID, lockOwner)
+		}
+		s.backend.Release(nodeID, fh)
 		return reply(0, nil), nil
 	case fuseFsync:
 		if err := request.requireBody(16, "FSYNC"); err != nil {
@@ -400,20 +407,47 @@ func (s *fuseServer) dispatch(request fuseRequest) (fsReply, error) {
 			return fsReply{}, err
 		}
 		fh := binary.LittleEndian.Uint64(req[40:48])
+		owner := binary.LittleEndian.Uint64(req[48:56])
+		requested := fuseFileLock{
+			nodeID: nodeID, owner: owner,
+			start:  binary.LittleEndian.Uint64(req[56:64]),
+			end:    binary.LittleEndian.Uint64(req[64:72]),
+			typeID: binary.LittleEndian.Uint32(req[72:76]),
+			pid:    binary.LittleEndian.Uint32(req[76:80]),
+		}
 		if logEnabled {
 			s.logPathf("getlk", nodeID, fmt.Sprintf(" fh=%d", fh))
 		}
-		return reply(-linuxENOSYS, nil), nil
+		if !validFuseGetLock(requested) {
+			return reply(-linuxEINVAL, nil), nil
+		}
+		conflict, found := s.locks.get(requested)
+		if !found {
+			conflict = fuseFileLock{typeID: linuxFUnlck}
+		}
+		extra := make([]byte, fuseLKOutSize)
+		binary.LittleEndian.PutUint64(extra[0:8], conflict.start)
+		binary.LittleEndian.PutUint64(extra[8:16], conflict.end)
+		binary.LittleEndian.PutUint32(extra[16:20], conflict.typeID)
+		binary.LittleEndian.PutUint32(extra[20:24], conflict.pid)
+		return reply(0, extra), nil
 	case fuseSetLK, fuseSetLKW:
 		if err := request.requireBody(fuseLKInSize, fuseOpcodeName(opcode)); err != nil {
 			return fsReply{}, err
 		}
 		fh := binary.LittleEndian.Uint64(req[40:48])
-		lockType := binary.LittleEndian.Uint32(req[72:76])
-		if logEnabled {
-			s.logPathf(strings.ToLower(fuseOpcodeName(opcode)), nodeID, fmt.Sprintf(" fh=%d type=%d", fh, lockType))
+		lock := fuseFileLock{
+			nodeID: nodeID,
+			owner:  binary.LittleEndian.Uint64(req[48:56]),
+			start:  binary.LittleEndian.Uint64(req[56:64]),
+			end:    binary.LittleEndian.Uint64(req[64:72]),
+			typeID: binary.LittleEndian.Uint32(req[72:76]),
+			pid:    binary.LittleEndian.Uint32(req[76:80]),
 		}
-		return reply(-linuxENOSYS, nil), nil
+		if logEnabled {
+			s.logPathf(strings.ToLower(fuseOpcodeName(opcode)), nodeID, fmt.Sprintf(" fh=%d type=%d", fh, lock.typeID))
+		}
+		return reply(s.locks.set(lock, opcode == fuseSetLKW), nil), nil
 	case fuseRmDir:
 		name := readCStringName(req[fuseInHeaderSize:])
 		if logEnabled {
@@ -597,9 +631,13 @@ func (s *fuseServer) dispatch(request fuseRequest) (fsReply, error) {
 			return fsReply{}, err
 		}
 		fh := binary.LittleEndian.Uint64(req[40:48])
+		flushFlags := binary.LittleEndian.Uint32(req[48:52])
 		lockOwner := binary.LittleEndian.Uint64(req[56:64])
 		if logEnabled {
 			s.logPathf("flush", nodeID, fmt.Sprintf(" fh=%d lockOwner=%d", fh, lockOwner))
+		}
+		if flushFlags&fuseFlushLockOwner != 0 {
+			s.locks.releaseOwner(nodeID, lockOwner)
 		}
 		if be, ok := s.backend.(fsFlushBackend); ok {
 			return reply(be.Flush(nodeID, fh, lockOwner), nil), nil
@@ -674,6 +712,9 @@ func (s *fuseServer) dispatch(request fuseRequest) (fsReply, error) {
 		encodeFuseStatx(extra[32:], attr)
 		return reply(0, extra), nil
 	case fuseSyncFS:
+		if be, ok := s.backend.(fsSyncFSBackend); ok {
+			return reply(be.SyncFS(), nil), nil
+		}
 		return reply(0, nil), nil
 	case fuseTmpfile:
 		if logEnabled {
@@ -681,6 +722,7 @@ func (s *fuseServer) dispatch(request fuseRequest) (fsReply, error) {
 		}
 		return reply(-linuxENOSYS, nil), nil
 	case fuseDestroy:
+		s.locks.close()
 		return reply(0, nil), nil
 	case fuseIoctl:
 		if logEnabled {

--- a/internal/virtio/fs_locks.go
+++ b/internal/virtio/fs_locks.go
@@ -1,0 +1,157 @@
+package virtio
+
+import (
+	"sort"
+	"sync"
+)
+
+const (
+	linuxFRdLck = 0
+	linuxFWrLck = 1
+)
+
+type fuseFileLock struct {
+	nodeID uint64
+	owner  uint64
+	start  uint64
+	end    uint64
+	typeID uint32
+	pid    uint32
+}
+
+type fuseLockManager struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	locks  []fuseFileLock
+	closed bool
+}
+
+func newFuseLockManager() *fuseLockManager {
+	m := &fuseLockManager{}
+	m.cond = sync.NewCond(&m.mu)
+	return m
+}
+
+func (m *fuseLockManager) get(request fuseFileLock) (fuseFileLock, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.conflictLocked(request)
+}
+
+func validFuseLockRange(request fuseFileLock) bool {
+	return request.start <= request.end
+}
+
+func validFuseGetLock(request fuseFileLock) bool {
+	return validFuseLockRange(request) && (request.typeID == linuxFRdLck || request.typeID == linuxFWrLck)
+}
+
+func (m *fuseLockManager) set(request fuseFileLock, wait bool) int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !validFuseLockRange(request) || (request.typeID != linuxFRdLck && request.typeID != linuxFWrLck && request.typeID != linuxFUnlck) {
+		return -linuxEINVAL
+	}
+	for request.typeID != linuxFUnlck {
+		if _, conflict := m.conflictLocked(request); !conflict {
+			break
+		}
+		if !wait {
+			return -linuxEAGAIN
+		}
+		if m.closed {
+			return -linuxEINTR
+		}
+		m.cond.Wait()
+	}
+	if m.closed {
+		return -linuxEINTR
+	}
+	m.replaceOwnerRangeLocked(request)
+	m.cond.Broadcast()
+	return 0
+}
+
+func (m *fuseLockManager) releaseOwner(nodeID, owner uint64) {
+	m.mu.Lock()
+	kept := m.locks[:0]
+	for _, lock := range m.locks {
+		if lock.nodeID != nodeID || lock.owner != owner {
+			kept = append(kept, lock)
+		}
+	}
+	m.locks = kept
+	m.cond.Broadcast()
+	m.mu.Unlock()
+}
+
+func (m *fuseLockManager) close() {
+	m.mu.Lock()
+	m.closed = true
+	m.locks = nil
+	m.cond.Broadcast()
+	m.mu.Unlock()
+}
+
+func (m *fuseLockManager) conflictLocked(request fuseFileLock) (fuseFileLock, bool) {
+	for _, held := range m.locks {
+		if held.nodeID != request.nodeID || held.owner == request.owner || !lockRangesOverlap(held, request) {
+			continue
+		}
+		if held.typeID == linuxFWrLck || request.typeID == linuxFWrLck {
+			return held, true
+		}
+	}
+	return fuseFileLock{}, false
+}
+
+func (m *fuseLockManager) replaceOwnerRangeLocked(request fuseFileLock) {
+	rebuilt := make([]fuseFileLock, 0, len(m.locks)+1)
+	for _, held := range m.locks {
+		if held.nodeID != request.nodeID || held.owner != request.owner || !lockRangesOverlap(held, request) {
+			rebuilt = append(rebuilt, held)
+			continue
+		}
+		if held.start < request.start {
+			left := held
+			left.end = request.start - 1
+			rebuilt = append(rebuilt, left)
+		}
+		if request.end != ^uint64(0) && held.end > request.end {
+			right := held
+			right.start = request.end + 1
+			rebuilt = append(rebuilt, right)
+		}
+	}
+	if request.typeID != linuxFUnlck {
+		rebuilt = append(rebuilt, request)
+	}
+	sort.Slice(rebuilt, func(i, j int) bool {
+		if rebuilt[i].nodeID != rebuilt[j].nodeID {
+			return rebuilt[i].nodeID < rebuilt[j].nodeID
+		}
+		if rebuilt[i].owner != rebuilt[j].owner {
+			return rebuilt[i].owner < rebuilt[j].owner
+		}
+		return rebuilt[i].start < rebuilt[j].start
+	})
+	merged := rebuilt[:0]
+	for _, lock := range rebuilt {
+		if len(merged) != 0 {
+			previous := &merged[len(merged)-1]
+			adjacent := previous.end == ^uint64(0) || lock.start <= previous.end+1
+			if previous.nodeID == lock.nodeID && previous.owner == lock.owner && previous.typeID == lock.typeID && adjacent {
+				if lock.end > previous.end {
+					previous.end = lock.end
+				}
+				continue
+			}
+		}
+		merged = append(merged, lock)
+	}
+	m.locks = merged
+}
+
+func lockRangesOverlap(left, right fuseFileLock) bool {
+	return left.start <= right.end && right.start <= left.end
+}

--- a/internal/virtio/fs_locks_test.go
+++ b/internal/virtio/fs_locks_test.go
@@ -1,0 +1,99 @@
+package virtio
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFuseLockManagerEnforcesExclusionAndWakesWaiters(t *testing.T) {
+	locks := newFuseLockManager()
+	writer := fuseFileLock{nodeID: 7, owner: 10, start: 0, end: ^uint64(0), typeID: linuxFWrLck, pid: 100}
+	if errno := locks.set(writer, false); errno != 0 {
+		t.Fatalf("set writer lock: errno %d", errno)
+	}
+	reader := fuseFileLock{nodeID: 7, owner: 20, start: 0, end: ^uint64(0), typeID: linuxFRdLck, pid: 200}
+	if errno := locks.set(reader, false); errno != -linuxEAGAIN {
+		t.Fatalf("conflicting nonblocking lock: errno %d", errno)
+	}
+	if conflict, ok := locks.get(reader); !ok || conflict.owner != writer.owner || conflict.typeID != linuxFWrLck {
+		t.Fatalf("reported conflict = %+v, present=%t", conflict, ok)
+	}
+
+	waiting := make(chan int32, 1)
+	go func() { waiting <- locks.set(reader, true) }()
+	select {
+	case errno := <-waiting:
+		t.Fatalf("blocking lock completed before unlock: errno %d", errno)
+	case <-time.After(25 * time.Millisecond):
+	}
+	locks.releaseOwner(writer.nodeID, writer.owner)
+	select {
+	case errno := <-waiting:
+		if errno != 0 {
+			t.Fatalf("blocking lock after unlock: errno %d", errno)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocking lock did not wake after owner release")
+	}
+}
+
+func TestFuseLockManagerSplitsPartialUnlocks(t *testing.T) {
+	locks := newFuseLockManager()
+	if errno := locks.set(fuseFileLock{nodeID: 3, owner: 4, start: 0, end: 99, typeID: linuxFWrLck}, false); errno != 0 {
+		t.Fatalf("set lock: errno %d", errno)
+	}
+	if errno := locks.set(fuseFileLock{nodeID: 3, owner: 4, start: 25, end: 74, typeID: linuxFUnlck}, false); errno != 0 {
+		t.Fatalf("partial unlock: errno %d", errno)
+	}
+	for _, test := range []struct {
+		start, end uint64
+		conflict   bool
+	}{
+		{0, 24, true},
+		{25, 74, false},
+		{75, 99, true},
+	} {
+		_, conflict := locks.get(fuseFileLock{nodeID: 3, owner: 5, start: test.start, end: test.end, typeID: linuxFRdLck})
+		if conflict != test.conflict {
+			t.Fatalf("range %d-%d conflict=%t, want %t", test.start, test.end, conflict, test.conflict)
+		}
+	}
+}
+
+func TestFuseLockManagerRejectsInvalidRequests(t *testing.T) {
+	locks := newFuseLockManager()
+	for _, request := range []fuseFileLock{
+		{start: 2, end: 1, typeID: linuxFRdLck},
+		{start: 0, end: 1, typeID: 99},
+	} {
+		if errno := locks.set(request, false); errno != -linuxEINVAL {
+			t.Fatalf("set invalid lock %+v: errno %d", request, errno)
+		}
+	}
+	if validFuseGetLock(fuseFileLock{start: 2, end: 1, typeID: linuxFRdLck}) {
+		t.Fatal("GETLK accepted a reversed range")
+	}
+	if validFuseGetLock(fuseFileLock{start: 0, end: 1, typeID: linuxFUnlck}) {
+		t.Fatal("GETLK accepted an unlock request")
+	}
+}
+
+func TestFuseLockManagerCloseInterruptsBlockedLocks(t *testing.T) {
+	locks := newFuseLockManager()
+	if errno := locks.set(fuseFileLock{nodeID: 1, owner: 1, end: ^uint64(0), typeID: linuxFWrLck}, false); errno != 0 {
+		t.Fatalf("set lock: errno %d", errno)
+	}
+	done := make(chan int32, 1)
+	go func() {
+		done <- locks.set(fuseFileLock{nodeID: 1, owner: 2, end: ^uint64(0), typeID: linuxFWrLck}, true)
+	}()
+	locks.close()
+	select {
+	case errno := <-done:
+		if errno != -linuxEINTR {
+			t.Fatalf("closed lock wait: errno %d", errno)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("closed lock manager did not wake waiter")
+	}
+}

--- a/internal/virtio/fs_persistent_store.go
+++ b/internal/virtio/fs_persistent_store.go
@@ -1249,12 +1249,7 @@ func (p *imageFS) restorePersistentState(state *persistentImageState) error {
 	}
 	nodeSeen := make(map[uint64]struct{}, len(state.Nodes))
 	savedByPath := make(map[string]*imageNode, len(state.Nodes)+1)
-	linkedNodes := map[uint64]struct{}{1: {}}
-	for _, saved := range state.Nodes {
-		for _, entry := range saved.Entries {
-			linkedNodes[entry.Inode] = struct{}{}
-		}
-	}
+	savedNodes := make(map[uint64]*persistentImageNode, len(state.Nodes))
 	for _, saved := range state.Nodes {
 		if saved.ID == 0 || saved.ID == ^uint64(0) {
 			return fmt.Errorf("invalid node ID %d", saved.ID)
@@ -1266,12 +1261,29 @@ func (p *imageFS) restorePersistentState(state *persistentImageState) error {
 		if _, removed := removedSeen[saved.ID]; removed {
 			return fmt.Errorf("node ID %d is both present and removed", saved.ID)
 		}
+		savedNodes[saved.ID] = &saved
+	}
+	reachableNodes := make(map[uint64]struct{}, len(state.Nodes))
+	queue := []uint64{1}
+	for len(queue) != 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if _, seen := reachableNodes[id]; seen {
+			continue
+		}
+		reachableNodes[id] = struct{}{}
+		if saved := savedNodes[id]; saved != nil {
+			for _, entry := range saved.Entries {
+				queue = append(queue, entry.Inode)
+			}
+		}
+	}
+	for _, saved := range state.Nodes {
 		// Older writers could checkpoint an inode kept alive only by an open
-		// handle after it had been unlinked or atomically replaced. Handles
-		// cannot survive restart, so restore only nodes reached by the saved
-		// directory namespace (plus the root).
-		_, linked := linkedNodes[saved.ID]
-		if !linked && len(saved.LowerPath) == 0 {
+		// handle, or a whole orphaned directory tree, after it had been
+		// unlinked or atomically replaced. Handles cannot survive restart, so
+		// restore only nodes actually reachable from the saved root directory.
+		if _, reachable := reachableNodes[saved.ID]; !reachable {
 			continue
 		}
 		guestPath := string(saved.GuestPath)

--- a/internal/virtio/fs_persistent_store.go
+++ b/internal/virtio/fs_persistent_store.go
@@ -237,11 +237,10 @@ func openPersistentImageStore(dir, lowerID string) (*persistentImageStore, *pers
 	}
 	if state != nil {
 		store.sequence = state.Sequence
-		if store.recovery.Status == "" {
-			store.recovery = state.Recovery
-		}
-		if state.LastError != "" {
-			store.lastErr = errors.New(state.LastError)
+		// Recovery describes work performed while opening this attachment. Do
+		// not replay a completed recovery warning on every future startup.
+		if lastError := activePersistentLastError(state.LastError); lastError != "" {
+			store.lastErr = errors.New(lastError)
 		}
 		if err := store.replayWAL(state); err != nil {
 			_ = store.close()
@@ -295,6 +294,7 @@ func (s *persistentImageStore) preserveUnreferencedData(state *persistentImageSt
 	if err := os.Mkdir(quarantine, 0o700); err != nil {
 		return fmt.Errorf("create unreferenced data quarantine: %w", err)
 	}
+	sourceDirs := make(map[string]struct{})
 	for _, source := range orphaned {
 		relative, err := filepath.Rel(dataRoot, source)
 		if err != nil {
@@ -304,8 +304,11 @@ func (s *persistentImageStore) preserveUnreferencedData(state *persistentImageSt
 		if err := os.Rename(source, target); err != nil {
 			return fmt.Errorf("preserve unreferenced data %q: %w", source, err)
 		}
-		if err := syncPersistentDirectory(filepath.Dir(source)); err != nil {
-			return fmt.Errorf("publish removal of unreferenced data %q: %w", source, err)
+		sourceDirs[filepath.Dir(source)] = struct{}{}
+	}
+	for sourceDir := range sourceDirs {
+		if err := syncPersistentDirectory(sourceDir); err != nil {
+			return fmt.Errorf("publish removal of unreferenced data from %q: %w", sourceDir, err)
 		}
 	}
 	if err := syncPersistentDirectory(quarantine); err != nil {
@@ -318,8 +321,22 @@ func (s *persistentImageStore) preserveUnreferencedData(state *persistentImageSt
 		s.recovery.Status = "preserved-unreferenced-data"
 		s.recovery.QuarantinePath = quarantine
 	}
-	s.lastErr = errors.Join(s.lastErr, fmt.Errorf("preserved %d unreferenced inode data files in %s", len(orphaned), quarantine))
 	return nil
+}
+
+func activePersistentLastError(value string) string {
+	var active []string
+	for _, line := range strings.Split(value, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "previous persistent image attachment did not detach cleanly" {
+			continue
+		}
+		if strings.HasPrefix(line, "preserved ") && strings.Contains(line, " unreferenced inode data files in ") {
+			continue
+		}
+		active = append(active, line)
+	}
+	return strings.Join(active, "\n")
 }
 
 func (s *persistentImageStore) ensureEmptyUninitialized() error {
@@ -381,7 +398,6 @@ func (s *persistentImageStore) recoverIncompleteAttachment() error {
 		s.recovery.Status = "recovered-incomplete-close"
 		s.recovery.QuarantinePath = recoveryPath
 	}
-	s.lastErr = errors.Join(s.lastErr, errors.New("previous persistent image attachment did not detach cleanly"))
 	return nil
 }
 

--- a/internal/virtio/fs_persistent_store.go
+++ b/internal/virtio/fs_persistent_store.go
@@ -75,6 +75,7 @@ type persistentImageStore struct {
 	pendingRemove   map[uint64]struct{}
 	newDataDirs     map[uint64]string
 	dirtyData       map[uint64]struct{}
+	durableState    *persistentImageState
 	recovery        persistentImageRecovery
 	dataUsage       map[uint64]uint64
 	dataPhysical    map[uint64]uint64
@@ -129,6 +130,10 @@ type persistentImageNode struct {
 	ATimeUnixNano int64                   `json:"atime_unix_nano,omitempty"`
 	MTimeUnixNano int64                   `json:"mtime_unix_nano,omitempty"`
 	CTimeUnixNano int64                   `json:"ctime_unix_nano,omitempty"`
+	// PreserveNamespace is used only by WAL deltas for file fsync. File
+	// durability must not accidentally make an un-fsynced rename or link
+	// durable as well.
+	PreserveNamespace bool `json:"preserve_namespace,omitempty"`
 }
 
 type persistentImageDirent struct {
@@ -240,6 +245,7 @@ func openPersistentImageStore(dir, lowerID string) (*persistentImageStore, *pers
 			return nil, nil, err
 		}
 		store.durableSequence = store.sequence
+		store.durableState = clonePersistentImageState(state)
 		if err := store.preserveUnreferencedData(state); err != nil {
 			_ = store.close()
 			return nil, nil, err
@@ -636,6 +642,7 @@ func (s *persistentImageStore) save(state *persistentImageState, durable bool) e
 	if durable {
 		s.durableSequence = s.sequence
 		s.lastCheckpoint = time.Now()
+		s.durableState = clonePersistentImageState(state)
 	}
 	return nil
 }
@@ -942,6 +949,7 @@ func (s *persistentImageStore) reclaimDurableData() error {
 		}
 		delete(s.pendingRemove, nodeID)
 		delete(s.newDataDirs, nodeID)
+		delete(s.dirtyData, nodeID)
 		s.setDataUsage(nodeID, 0, 0)
 	}
 	if didWork && len(s.pendingRemove) == 0 && len(s.pendingTrim) == 0 {
@@ -950,6 +958,36 @@ func (s *persistentImageStore) reclaimDurableData() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (s *persistentImageStore) reclaimDurableFileData(nodeID uint64) error {
+	if s == nil {
+		return nil
+	}
+	size, pending := s.pendingTrim[nodeID]
+	if !pending {
+		return nil
+	}
+	err := os.Truncate(s.dataPath(nodeID), int64(size))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("trim inode %d: %w", nodeID, err)
+	}
+	delete(s.pendingTrim, nodeID)
+	s.refreshPhysicalUsage(nodeID)
+	return nil
+}
+
+func (s *persistentImageStore) reclaimDurableNamespaceData() error {
+	if s == nil || len(s.pendingRemove) == 0 {
+		return nil
+	}
+	// Namespace fsync makes every pending unlink durable, but deliberately
+	// leaves truncation reclamation to the affected file's own fsync.
+	trims := s.pendingTrim
+	s.pendingTrim = make(map[uint64]uint64)
+	err := s.reclaimDurableData()
+	s.pendingTrim = trims
+	return err
 }
 
 func (s *persistentImageStore) setDataUsage(nodeID, current, physical uint64) {

--- a/internal/virtio/fs_persistent_store.go
+++ b/internal/virtio/fs_persistent_store.go
@@ -12,8 +12,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -85,6 +87,7 @@ type persistentImageStore struct {
 	usageErr        error
 	lastCheckpoint  time.Time
 	lastErr         error
+	dataSyncMu      sync.Mutex
 }
 
 type persistentImageRecovery struct {
@@ -866,12 +869,18 @@ func (s *persistentImageStore) syncData(nodeID uint64) error {
 	if err := runPersistentImageFaultTestHook("before-data-sync"); err != nil {
 		return err
 	}
+	s.dataSyncMu.Lock()
+	usage := s.dataUsage[nodeID]
+	shard, newData := s.newDataDirs[nodeID]
+	s.dataSyncMu.Unlock()
 	file, err := s.openData(nodeID, os.O_RDWR)
 	if errors.Is(err, os.ErrNotExist) {
-		if s.dataUsage[nodeID] != 0 {
+		if usage != 0 {
 			return fmt.Errorf("persistent inode %d data file is missing: %w", nodeID, syscall.EIO)
 		}
+		s.dataSyncMu.Lock()
 		delete(s.dirtyData, nodeID)
+		s.dataSyncMu.Unlock()
 		return nil
 	}
 	if err != nil {
@@ -882,16 +891,18 @@ func (s *persistentImageStore) syncData(nodeID uint64) error {
 	if err != nil {
 		return err
 	}
-	if shard, ok := s.newDataDirs[nodeID]; ok {
+	if newData {
 		if err := syncPersistentDirectory(shard); err != nil {
 			return err
 		}
 		if err := syncPersistentDirectory(filepath.Join(s.dir, "data")); err != nil {
 			return err
 		}
-		delete(s.newDataDirs, nodeID)
 	}
+	s.dataSyncMu.Lock()
+	delete(s.newDataDirs, nodeID)
 	delete(s.dirtyData, nodeID)
+	s.dataSyncMu.Unlock()
 	return nil
 }
 
@@ -904,12 +915,26 @@ func (s *persistentImageStore) syncDirtyData() error {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	var errs []error
-	for _, id := range ids {
-		if err := s.syncData(id); err != nil {
-			errs = append(errs, fmt.Errorf("sync dirty inode %d: %w", id, err))
-		}
+	workers := min(len(ids), max(1, min(runtime.GOMAXPROCS(0), 16)))
+	jobs := make(chan int)
+	errs := make([]error, len(ids))
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				if err := s.syncData(ids[index]); err != nil {
+					errs[index] = fmt.Errorf("sync dirty inode %d: %w", ids[index], err)
+				}
+			}
+		}()
 	}
+	for index := range ids {
+		jobs <- index
+	}
+	close(jobs)
+	wg.Wait()
 	return errors.Join(errs...)
 }
 
@@ -1058,16 +1083,11 @@ func (p *imageFS) syncAllPersistentDataLocked() error {
 	if p == nil || p.persistent == nil {
 		return nil
 	}
-	var errs []error
-	for id, node := range p.nodes {
-		if node == nil || len(node.data.extents) == 0 {
-			continue
-		}
-		if err := p.persistent.syncData(id); err != nil {
-			errs = append(errs, fmt.Errorf("sync inode %d: %w", id, err))
-		}
-	}
-	return errors.Join(errs...)
+	// Data removed from dirtyData has already completed a durable file or
+	// filesystem barrier. Re-syncing every referenced inode made clean shutdown
+	// proportional to the entire persistent home rather than this session's
+	// outstanding writes.
+	return p.persistent.syncDirtyData()
 }
 
 func (p *imageFS) persistentStateLocked() *persistentImageState {

--- a/internal/virtio/fs_persistent_store_test.go
+++ b/internal/virtio/fs_persistent_store_test.go
@@ -1359,6 +1359,70 @@ func TestPersistentImageFSReadsRemainResponsiveDuringHostDataSync(t *testing.T) 
 	}
 }
 
+func TestPersistentImageFSCloseDoesNotResyncDurableHome(t *testing.T) {
+	t.Cleanup(func() { persistentImageFaultTestHook = nil })
+	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), filepath.Join(t.TempDir(), "home"))
+	nodeID, fh, _, errno := backend.Create(1, "state", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+	if errno != 0 {
+		t.Fatalf("create state: errno %d", errno)
+	}
+	if written, errno := backend.Write(nodeID, fh, 0, []byte("durable"), 0); errno != 0 || written != 7 {
+		t.Fatalf("write state: written=%d errno=%d", written, errno)
+	}
+	if errno := backend.SyncFS(); errno != 0 {
+		t.Fatalf("sync baseline: errno %d", errno)
+	}
+	backend.Release(nodeID, fh)
+	persistentImageFaultTestHook = func(stage string) error {
+		if stage == "before-data-sync" {
+			return errors.New("durable inode was synchronized again")
+		}
+		return nil
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPersistentImageFSCloseSynchronizesDirtyFilesConcurrently(t *testing.T) {
+	t.Cleanup(func() { persistentImageFaultTestHook = nil })
+	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), filepath.Join(t.TempDir(), "home"))
+	for _, name := range []string{"first", "second"} {
+		nodeID, fh, _, errno := backend.Create(1, name, linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+		if errno != 0 {
+			t.Fatalf("create %s: errno %d", name, errno)
+		}
+		if written, errno := backend.Write(nodeID, fh, 0, []byte(name), 0); errno != 0 || written != uint32(len(name)) {
+			t.Fatalf("write %s: written=%d errno=%d", name, written, errno)
+		}
+		backend.Release(nodeID, fh)
+	}
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	persistentImageFaultTestHook = func(stage string) error {
+		if stage == "before-data-sync" {
+			entered <- struct{}{}
+			<-release
+		}
+		return nil
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- backend.closeWithin(time.Second) }()
+	for count := 0; count < 2; count++ {
+		select {
+		case <-entered:
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("independent dirty files were synchronized serially")
+		}
+	}
+	releaseOnce.Do(func() { close(release) })
+	if err := <-closeDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPersistentImageFSFileAndDirectoryFsyncHaveSeparateDurability(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/internal/virtio/fs_persistent_store_test.go
+++ b/internal/virtio/fs_persistent_store_test.go
@@ -683,8 +683,8 @@ func TestPersistentImageFSTornWALTailIsPreservedAndRemovedFromReplay(t *testing.
 	backend = openPersistentImageFSTest(t, lower, storeDir)
 	defer backend.Close()
 	lookupPersistentTest(t, backend, 1, "after-recovery")
-	if statuses := backend.PersistentFSStatus(); len(statuses) != 1 || statuses[0].RecoveryStatus != "discarded-torn-wal-tail" || statuses[0].DiscardedBytes != uint64(len("torn-journal-tail")) {
-		t.Fatalf("persisted recovery status = %+v", statuses)
+	if statuses := backend.PersistentFSStatus(); len(statuses) != 1 || statuses[0].RecoveryStatus != "" || statuses[0].DiscardedBytes != 0 {
+		t.Fatalf("completed recovery repeated on next attachment: %+v", statuses)
 	}
 }
 
@@ -1015,7 +1015,7 @@ func TestPersistentImageFSCheckpointENOSPCLeavesRecoverableWAL(t *testing.T) {
 	if got := readPersistentTest(t, backend, nodeID, 0, 4); string(got) != "safe" {
 		t.Fatalf("state recovered from WAL = %q", got)
 	}
-	if statuses := backend.PersistentFSStatus(); len(statuses) != 1 || statuses[0].RecoveryStatus != "recovered-incomplete-close" || statuses[0].LastError == "" {
+	if statuses := backend.PersistentFSStatus(); len(statuses) != 1 || statuses[0].RecoveryStatus != "recovered-incomplete-close" || statuses[0].LastError != "" {
 		t.Fatalf("incomplete close recovery status = %+v", statuses)
 	}
 }
@@ -1502,8 +1502,17 @@ func TestPersistentImageFSPreservesUnreferencedCrashData(t *testing.T) {
 	if string(content) != "possibly useful crash data" {
 		t.Fatalf("quarantined data = %q", content)
 	}
+	// Simulate recovery metadata written by an older build. Completed recovery
+	// diagnostics must not surface as an error on every later attachment.
+	backend.persistent.lastErr = errors.New("preserved 1 unreferenced inode data files in " + statuses[0].QuarantinePath)
 	if err := backend.Close(); err != nil {
 		t.Fatal(err)
+	}
+	backend = openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
+	defer backend.Close()
+	statuses = backend.PersistentFSStatus()
+	if len(statuses) != 1 || statuses[0].RecoveryStatus != "" || statuses[0].LastError != "" {
+		t.Fatalf("completed recovery repeated on next attachment: %+v", statuses)
 	}
 }
 

--- a/internal/virtio/fs_persistent_store_test.go
+++ b/internal/virtio/fs_persistent_store_test.go
@@ -925,8 +925,8 @@ func TestPersistentImageFSENOSPCPreservesPendingDataAndMetadata(t *testing.T) {
 		}
 		return nil
 	}
-	if errno := backend.Flush(nodeID, fh, 0); errno != -linuxENOSPC {
-		t.Fatalf("flush under ENOSPC: errno %d", errno)
+	if errno := backend.Fsync(nodeID, fh, 0); errno != -linuxENOSPC {
+		t.Fatalf("fsync under ENOSPC: errno %d", errno)
 	}
 	persistentImageFaultTestHook = nil
 	if errno := backend.Fsync(nodeID, fh, 0); errno != 0 {
@@ -962,8 +962,8 @@ func TestPersistentImageFSMetadataENOSPCDoesNotReportFalseOperationFailure(t *te
 	if lookupPersistentTest(t, backend, 1, "research") != dirID {
 		t.Fatal("successful mkdir was not visible")
 	}
-	if errno := backend.Flush(dirID, 0, 0); errno != -linuxENOSPC {
-		t.Fatalf("flush metadata under ENOSPC: errno %d", errno)
+	if errno := backend.FsyncDir(dirID, 0, 0); errno != -linuxENOSPC {
+		t.Fatalf("fsync metadata under ENOSPC: errno %d", errno)
 	}
 	if lookupPersistentTest(t, backend, 1, "research") != dirID {
 		t.Fatal("failed metadata flush rolled back or hid live state")
@@ -1224,7 +1224,7 @@ func TestPersistentImageFSDiscardsCompleteUncommittedWALAfterCrash(t *testing.T)
 	}
 }
 
-func TestPersistentImageFSDurableBarrierSyncsAllReferencedData(t *testing.T) {
+func TestPersistentImageFSFileFsyncLeavesUnrelatedDataDirty(t *testing.T) {
 	storeDir := filepath.Join(t.TempDir(), "home")
 	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
 	firstID, firstFH, _, errno := backend.Create(1, "first", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
@@ -1244,8 +1244,17 @@ func TestPersistentImageFSDurableBarrierSyncsAllReferencedData(t *testing.T) {
 	if errno := backend.Fsync(firstID, firstFH, 0); errno != 0 {
 		t.Fatalf("fsync first: errno %d", errno)
 	}
+	if _, dirty := backend.persistent.dirtyData[firstID]; dirty {
+		t.Fatalf("fsynced inode remained dirty: %v", backend.persistent.dirtyData)
+	}
+	if _, dirty := backend.persistent.dirtyData[secondID]; !dirty {
+		t.Fatalf("unrelated inode was made durable: %v", backend.persistent.dirtyData)
+	}
+	if errno := backend.SyncFS(); errno != 0 {
+		t.Fatalf("syncfs: errno %d", errno)
+	}
 	if len(backend.persistent.dirtyData) != 0 {
-		t.Fatalf("committed barrier retained dirty data: %v", backend.persistent.dirtyData)
+		t.Fatalf("syncfs retained dirty data: %v", backend.persistent.dirtyData)
 	}
 	backend.Release(firstID, firstFH)
 	backend.Release(secondID, secondFH)
@@ -1264,6 +1273,132 @@ func TestPersistentImageFSDurableBarrierSyncsAllReferencedData(t *testing.T) {
 	}
 	if err := backend.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPersistentImageFSFileFsyncDoesNotCommitUnrelatedDataAfterCrash(t *testing.T) {
+	storeDir := filepath.Join(t.TempDir(), "home")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestPersistentImageFSHardCrashHelper$")
+	cmd.Env = append(os.Environ(),
+		"CC_PERSISTENT_IMAGE_CRASH_HELPER=1",
+		"CC_PERSISTENT_IMAGE_CRASH_OPERATION=selective-fsync",
+		"CC_PERSISTENT_IMAGE_CRASH_STORE="+storeDir,
+	)
+	output, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 91 {
+		t.Fatalf("crash helper = %v, output:\n%s", err, output)
+	}
+
+	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
+	defer backend.Close()
+	firstID := lookupPersistentTest(t, backend, 1, "first")
+	if got := readPersistentTest(t, backend, firstID, 0, uint32(len("first-data"))); string(got) != "first-data" {
+		t.Fatalf("fsynced data after crash = %q", got)
+	}
+	if _, _, errno := backend.Lookup(1, "second"); errno != -linuxENOENT {
+		t.Fatalf("un-fsynced file survived crash: errno %d", errno)
+	}
+}
+
+func TestPersistentImageFSReadsRemainResponsiveDuringHostDataSync(t *testing.T) {
+	t.Cleanup(func() { persistentImageFaultTestHook = nil })
+	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), filepath.Join(t.TempDir(), "home"))
+	defer backend.Close()
+	nodeID, fh, _, errno := backend.Create(1, "state", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+	if errno != 0 {
+		t.Fatalf("create state: errno %d", errno)
+	}
+	if written, errno := backend.Write(nodeID, fh, 0, []byte("data"), 0); errno != 0 || written != 4 {
+		t.Fatalf("write state: written=%d errno=%d", written, errno)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	persistentImageFaultTestHook = func(stage string) error {
+		if stage == "before-data-sync" {
+			once.Do(func() { close(entered) })
+			<-release
+		}
+		return nil
+	}
+	fsyncDone := make(chan int32, 1)
+	go func() { fsyncDone <- backend.Fsync(nodeID, fh, 0) }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("fsync did not enter host data sync")
+	}
+	lookupDone := make(chan int32, 1)
+	go func() {
+		lookupID, _, errno := backend.Lookup(1, "state")
+		if errno != 0 {
+			lookupDone <- errno
+			return
+		}
+		readFH, errno := backend.Open(lookupID, linuxORDONLY)
+		if errno != 0 {
+			lookupDone <- errno
+			return
+		}
+		_, errno = backend.Read(lookupID, readFH, 0, 4)
+		backend.Release(lookupID, readFH)
+		lookupDone <- errno
+	}()
+	select {
+	case errno := <-lookupDone:
+		if errno != 0 {
+			t.Fatalf("lookup during fsync: errno %d", errno)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("read-only open blocked behind host data sync")
+	}
+	close(release)
+	if errno := <-fsyncDone; errno != 0 {
+		t.Fatalf("fsync after release: errno %d", errno)
+	}
+}
+
+func TestPersistentImageFSFileAndDirectoryFsyncHaveSeparateDurability(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		syncDir bool
+	}{
+		{name: "file-only"},
+		{name: "file-and-directory", syncDir: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			storeDir := filepath.Join(t.TempDir(), "home")
+			cmd := exec.Command(os.Args[0], "-test.run=^TestPersistentImageFSHardCrashHelper$")
+			cmd.Env = append(os.Environ(),
+				"CC_PERSISTENT_IMAGE_CRASH_HELPER=1",
+				"CC_PERSISTENT_IMAGE_CRASH_OPERATION=selective-namespace",
+				"CC_PERSISTENT_IMAGE_CRASH_STORE="+storeDir,
+				fmt.Sprintf("CC_PERSISTENT_IMAGE_CRASH_SYNC_DIR=%t", test.syncDir),
+			)
+			output, err := cmd.CombinedOutput()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 91 {
+				t.Fatalf("crash helper = %v, output:\n%s", err, output)
+			}
+			backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
+			defer backend.Close()
+			firstID := lookupPersistentTest(t, backend, 1, "first")
+			if got := readPersistentTest(t, backend, firstID, 0, 7); string(got) != "initial" {
+				t.Fatalf("baseline file after crash = %q", got)
+			}
+			durableName, missingName := "second", "moved"
+			if test.syncDir {
+				durableName, missingName = "moved", "second"
+			}
+			secondID := lookupPersistentTest(t, backend, 1, durableName)
+			if got := readPersistentTest(t, backend, secondID, 0, 7); string(got) != "updated" {
+				t.Fatalf("fsynced inode after crash = %q", got)
+			}
+			if _, _, errno := backend.Lookup(1, missingName); errno != -linuxENOENT {
+				t.Fatalf("non-durable name %q survived crash: errno %d", missingName, errno)
+			}
+		})
 	}
 }
 
@@ -1393,6 +1528,57 @@ func TestPersistentImageFSHardCrashHelper(t *testing.T) {
 	stage := os.Getenv("CC_PERSISTENT_IMAGE_CRASH_STAGE")
 	storeDir := os.Getenv("CC_PERSISTENT_IMAGE_CRASH_STORE")
 	backend := openPersistentImageFSTest(t, imagefs.NewOverlay(nil).Root(), storeDir)
+	if os.Getenv("CC_PERSISTENT_IMAGE_CRASH_OPERATION") == "selective-namespace" {
+		firstID, firstFH, _, errno := backend.Create(1, "first", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+		if errno != 0 {
+			t.Fatalf("create first: errno %d", errno)
+		}
+		secondID, secondFH, _, errno := backend.Create(1, "second", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+		if errno != 0 {
+			t.Fatalf("create second: errno %d", errno)
+		}
+		if written, errno := backend.Write(firstID, firstFH, 0, []byte("initial"), 0); errno != 0 || written != 7 {
+			t.Fatalf("write initial: written=%d errno=%d", written, errno)
+		}
+		if errno := backend.SyncFS(); errno != 0 {
+			t.Fatalf("sync baseline: errno %d", errno)
+		}
+		if errno := backend.Rename(1, "second", 1, "moved", 0); errno != 0 {
+			t.Fatalf("rename second: errno %d", errno)
+		}
+		if written, errno := backend.Write(secondID, secondFH, 0, []byte("updated"), 0); errno != 0 || written != 7 {
+			t.Fatalf("write updated: written=%d errno=%d", written, errno)
+		}
+		if errno := backend.Fsync(secondID, secondFH, 0); errno != 0 {
+			t.Fatalf("fsync renamed inode: errno %d", errno)
+		}
+		if os.Getenv("CC_PERSISTENT_IMAGE_CRASH_SYNC_DIR") == "true" {
+			if errno := backend.FsyncDir(1, 0, 0); errno != 0 {
+				t.Fatalf("fsync root directory: errno %d", errno)
+			}
+		}
+		os.Exit(91)
+	}
+	if os.Getenv("CC_PERSISTENT_IMAGE_CRASH_OPERATION") == "selective-fsync" {
+		firstID, firstFH, _, errno := backend.Create(1, "first", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+		if errno != 0 {
+			t.Fatalf("create first: errno %d", errno)
+		}
+		secondID, secondFH, _, errno := backend.Create(1, "second", linuxORDWR|linuxOCREAT|linuxOEXCL, 0o600, 0, 0)
+		if errno != 0 {
+			t.Fatalf("create second: errno %d", errno)
+		}
+		if written, errno := backend.Write(firstID, firstFH, 0, []byte("first-data"), 0); errno != 0 || written != 10 {
+			t.Fatalf("write first: written=%d errno=%d", written, errno)
+		}
+		if written, errno := backend.Write(secondID, secondFH, 0, []byte("second-data"), 0); errno != 0 || written != 11 {
+			t.Fatalf("write second: written=%d errno=%d", written, errno)
+		}
+		if errno := backend.Fsync(firstID, firstFH, 0); errno != 0 {
+			t.Fatalf("fsync first: errno %d", errno)
+		}
+		os.Exit(91)
+	}
 	if os.Getenv("CC_PERSISTENT_IMAGE_CRASH_OPERATION") == "uncommitted" {
 		persistentImageSaveTestHook = func(current string) {
 			if current == stage {
@@ -1402,8 +1588,11 @@ func TestPersistentImageFSHardCrashHelper(t *testing.T) {
 		if _, _, errno := backend.Mkdir(1, "not-durable", 0o700, 0, 0); errno != 0 {
 			t.Fatalf("mkdir not-durable: errno %d", errno)
 		}
-		if errno := backend.Flush(1, 0, 0); errno != 0 {
-			t.Fatalf("flush not-durable: errno %d", errno)
+		backend.mu.Lock()
+		err := backend.flushPersistentLocked(false)
+		backend.mu.Unlock()
+		if err != nil {
+			t.Fatalf("write legacy uncommitted WAL: %v", err)
 		}
 		t.Fatalf("crash stage %q was not reached", stage)
 	}

--- a/internal/virtio/fs_persistent_store_test.go
+++ b/internal/virtio/fs_persistent_store_test.go
@@ -641,6 +641,56 @@ func TestPersistentImageFSRestoreRepairsDanglingDirectoryEntry(t *testing.T) {
 	}
 }
 
+func TestPersistentImageFSRestoreDiscardsOrphanedDirectoryTree(t *testing.T) {
+	storeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(storeDir, "data"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend := newImageFS(imagefs.NewOverlay(nil).Root(), storeDir, 0, 0, false).(*imageFS)
+	backend.persistent = &persistentImageStore{
+		dir:           storeDir,
+		dataUsage:     make(map[uint64]uint64),
+		dataPhysical:  make(map[uint64]uint64),
+		pendingTrim:   make(map[uint64]uint64),
+		pendingRemove: make(map[uint64]struct{}),
+	}
+	backend.persistentNodes = make(map[uint64]struct{})
+	directory := func(id, parent uint64, name, guestPath string, entries ...persistentImageDirent) persistentImageNode {
+		return persistentImageNode{
+			ID: id, Parent: parent, Name: []byte(name), GuestPath: []byte(guestPath),
+			Kind: "dir", Mode: uint32(fs.ModeDir | 0o755), NLink: 1, EntriesDone: true, Entries: entries,
+		}
+	}
+	file := func(id, parent uint64, name, guestPath string) persistentImageNode {
+		return persistentImageNode{
+			ID: id, Parent: parent, Name: []byte(name), GuestPath: []byte(guestPath),
+			Kind: "file", Mode: 0o600, NLink: 1,
+		}
+	}
+	err := backend.restorePersistentState(&persistentImageState{
+		NextNodeID: 6,
+		Nodes: []persistentImageNode{
+			directory(1, 1, "/", "/", persistentImageDirent{Name: []byte("tree"), Inode: 2}),
+			directory(2, 1, "tree", "/tree", persistentImageDirent{Name: []byte("value"), Inode: 3}),
+			file(3, 2, "value", "/tree/value"),
+			directory(4, 1, "tree", "/tree", persistentImageDirent{Name: []byte("value"), Inode: 5}),
+			file(5, 4, "value", "/tree/value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("restore checkpoint with orphaned tree: %v", err)
+	}
+	if _, exists := backend.nodes[4]; exists {
+		t.Fatal("orphaned directory survived recovery")
+	}
+	if _, exists := backend.nodes[5]; exists {
+		t.Fatal("orphaned file survived recovery")
+	}
+	if nodeID, _, errno := backend.Lookup(2, "value"); errno != 0 || nodeID != 3 {
+		t.Fatalf("lookup reachable file = inode %d, errno %d", nodeID, errno)
+	}
+}
+
 func TestPersistentImageFSTornWALTailIsPreservedAndRemovedFromReplay(t *testing.T) {
 	storeDir := filepath.Join(t.TempDir(), "home")
 	lower := imagefs.NewOverlay(nil).Root()

--- a/internal/virtio/fs_persistent_wal.go
+++ b/internal/virtio/fs_persistent_wal.go
@@ -119,9 +119,10 @@ func (p *imageFS) setPersistentDirentLocked(parent *imageNode, name string, inod
 }
 
 func (p *imageFS) deletePersistentDirentLocked(parent *imageNode, name string) {
+	inode := parent.entries[name]
 	delete(parent.entries, name)
 	if p.persistent != nil {
-		p.persistent.markDirent(parent.id, name, 0, false)
+		p.persistent.markDirent(parent.id, name, inode, false)
 	}
 }
 
@@ -193,6 +194,184 @@ func (p *imageFS) persistentDeltaLocked() *persistentImageDelta {
 	return delta
 }
 
+func (p *imageFS) persistentFileDeltaLocked(nodeID uint64) *persistentImageDelta {
+	if p == nil || p.persistent == nil {
+		return nil
+	}
+	node := p.imageNodeLocked(nodeID)
+	if node == nil || node.isDir() {
+		return nil
+	}
+	saved := persistentNodeFromImageNode(node, p.pathForNode(nodeID), p.persistentNodes)
+	// A file fsync covers inode data and metadata, not directory entries or
+	// link/rename operations. Existing durable namespace fields are retained
+	// when this delta is applied.
+	saved.Entries = nil
+	saved.Whiteouts = nil
+	delta := &persistentImageDelta{
+		Version: persistentImageFormatVersion, NextNodeID: p.nextNodeID,
+		Nodes: []persistentImageNode{saved},
+	}
+	_, existedDurably := p.persistent.durableNode(nodeID)
+	if existedDurably {
+		// fsync(2) makes the inode durable. Renames and new hard links for an
+		// already-durable inode still require fsync on the containing directory.
+		delta.Nodes[0].PreserveNamespace = true
+		return delta
+	}
+	pending := p.persistent.pending
+	if pending == nil {
+		delta.Nodes[0].PreserveNamespace = true
+		return delta
+	}
+	parents := make(map[uint64]struct{})
+	selectedKeys := make(map[persistentDirentKey]struct{})
+	for key, op := range pending.dirents {
+		if op.Inode != nodeID {
+			continue
+		}
+		delta.Dirents = append(delta.Dirents, op)
+		parents[op.Parent] = struct{}{}
+		selectedKeys[key] = struct{}{}
+	}
+	if len(delta.Dirents) == 0 {
+		delta.Nodes[0].PreserveNamespace = true
+		return delta
+	}
+	for key, op := range pending.whiteouts {
+		if _, selected := selectedKeys[key]; selected {
+			delta.Whiteouts = append(delta.Whiteouts, op)
+		}
+	}
+	for parentID := range parents {
+		parent := p.imageNodeLocked(parentID)
+		if parent == nil {
+			continue
+		}
+		parentSaved := persistentNodeFromImageNode(parent, p.pathForNode(parentID), p.persistentNodes)
+		parentSaved.Entries = nil
+		parentSaved.Whiteouts = nil
+		delta.Nodes = append(delta.Nodes, parentSaved)
+	}
+	if _, deleted := pending.deleted[nodeID]; deleted {
+		delta.Deleted = append(delta.Deleted, nodeID)
+	}
+	sort.Slice(delta.Nodes, func(i, j int) bool { return delta.Nodes[i].ID < delta.Nodes[j].ID })
+	sort.Slice(delta.Dirents, func(i, j int) bool {
+		if delta.Dirents[i].Parent == delta.Dirents[j].Parent {
+			return string(delta.Dirents[i].Name) < string(delta.Dirents[j].Name)
+		}
+		return delta.Dirents[i].Parent < delta.Dirents[j].Parent
+	})
+	return delta
+}
+
+func (p *imageFS) persistentNamespaceDeltaLocked() *persistentImageDelta {
+	delta := p.persistentDeltaLocked()
+	if delta == nil {
+		return nil
+	}
+	for i := range delta.Nodes {
+		node := &delta.Nodes[i]
+		if _, dirty := p.persistent.dirtyData[node.ID]; !dirty || node.Kind != "file" {
+			continue
+		}
+		if durable, ok := p.persistent.durableNode(node.ID); ok {
+			preservePersistentNodeData(node, durable)
+			continue
+		}
+		// Directory durability must be able to publish a newly-created name
+		// without claiming that un-fsynced file contents survived a crash.
+		// A copied-up lower file falls back to its immutable lower contents; a
+		// brand-new file becomes an empty durable inode until its own fsync.
+		if len(node.LowerPath) != 0 {
+			node.Size = node.LowerSize
+			node.CopiedUp = false
+			node.Independent = false
+		} else {
+			node.Size = 0
+			node.LowerSize = 0
+			node.Independent = true
+		}
+		node.Data = nil
+	}
+	return delta
+}
+
+func preservePersistentNodeData(target *persistentImageNode, durable persistentImageNode) {
+	target.Size = durable.Size
+	target.Data = append([]persistentImageExtent(nil), durable.Data...)
+	target.CopiedUp = durable.CopiedUp
+	target.Independent = durable.Independent
+	target.LowerSize = durable.LowerSize
+	target.LowerPath = append([]byte(nil), durable.LowerPath...)
+}
+
+func (s *persistentImageStore) durableNode(nodeID uint64) (persistentImageNode, bool) {
+	if s == nil || s.durableState == nil {
+		return persistentImageNode{}, false
+	}
+	for _, node := range s.durableState.Nodes {
+		if node.ID == nodeID {
+			return node, true
+		}
+	}
+	return persistentImageNode{}, false
+}
+
+func (s *persistentImageStore) clearFilePending(nodeID uint64, committedCreation bool) {
+	if s == nil || s.pending == nil {
+		return
+	}
+	if committedCreation {
+		for key, op := range s.pending.dirents {
+			if op.Inode == nodeID {
+				delete(s.pending.dirents, key)
+				delete(s.pending.whiteouts, key)
+			}
+		}
+		delete(s.pending.deleted, nodeID)
+	}
+	keepNodeForNamespace := false
+	if !committedCreation {
+		_, keepNodeForNamespace = s.pending.deleted[nodeID]
+		if !keepNodeForNamespace {
+			for _, op := range s.pending.dirents {
+				if op.Inode == nodeID {
+					keepNodeForNamespace = true
+					break
+				}
+			}
+		}
+	}
+	if !keepNodeForNamespace {
+		delete(s.pending.nodes, nodeID)
+	}
+	if len(s.pending.nodes) == 0 && len(s.pending.deleted) == 0 && len(s.pending.dirents) == 0 && len(s.pending.whiteouts) == 0 {
+		s.pending = nil
+	}
+}
+
+func (s *persistentImageStore) clearNamespacePending() {
+	if s == nil || s.pending == nil {
+		return
+	}
+	dirty := make(map[uint64]struct{}, len(s.dirtyData))
+	for id := range s.dirtyData {
+		if _, deleted := s.pending.deleted[id]; !deleted {
+			dirty[id] = struct{}{}
+		}
+	}
+	s.pending = nil
+	if len(dirty) != 0 {
+		s.pending = &persistentImagePending{
+			nodes: dirty, deleted: make(map[uint64]struct{}),
+			dirents:   make(map[persistentDirentKey]persistentImageDirentOp),
+			whiteouts: make(map[persistentDirentKey]persistentImageWhiteoutOp),
+		}
+	}
+}
+
 func (s *persistentImageStore) clearPending() {
 	s.pending = nil
 }
@@ -214,6 +393,16 @@ func (s *persistentImageStore) appendDelta(delta *persistentImageDelta, durable 
 	delta.Version = persistentImageFormatVersion
 	delta.Sequence = s.sequence + 1
 	delta.Committed = durable
+	var nextDurable *persistentImageState
+	if durable {
+		nextDurable = clonePersistentImageState(s.durableState)
+		if nextDurable == nil {
+			nextDurable = &persistentImageState{Version: persistentImageFormatVersion, LowerID: s.lowerID}
+		}
+		if err := applyPersistentImageDelta(nextDurable, delta); err != nil {
+			return fmt.Errorf("apply persistent metadata delta: %w", err)
+		}
+	}
 	if err := runPersistentImageFaultTestHook("before-wal-append"); err != nil {
 		return err
 	}
@@ -257,6 +446,7 @@ func (s *persistentImageStore) appendDelta(delta *persistentImageDelta, durable 
 	s.sequence = delta.Sequence
 	if durable {
 		s.durableSequence = s.sequence
+		s.durableState = nextDurable
 	}
 	return nil
 }
@@ -430,9 +620,16 @@ func applyPersistentImageDelta(state *persistentImageState, delta *persistentIma
 	}
 	for _, update := range delta.Nodes {
 		if old, ok := nodes[update.ID]; ok {
+			if update.PreserveNamespace {
+				update.Parent = old.Parent
+				update.Name = append([]byte(nil), old.Name...)
+				update.GuestPath = append([]byte(nil), old.GuestPath...)
+				update.NLink = old.NLink
+			}
 			update.Entries = old.Entries
 			update.Whiteouts = old.Whiteouts
 		}
+		update.PreserveNamespace = false
 		nodes[update.ID] = update
 	}
 	for _, id := range delta.Deleted {
@@ -608,7 +805,14 @@ func (p *imageFS) maybeCheckpointPersistentLocked() error {
 	if info.Size() < persistentImageCheckpointWALBytes {
 		return nil
 	}
-	if err := p.savePersistentLocked(true); err != nil {
+	state := clonePersistentImageState(p.persistent.durableState)
+	if state == nil {
+		return nil
+	}
+	// A selective fsync may leave unrelated live mutations dirty. Compact only
+	// the already-durable state; checkpointing must never promote those live
+	// mutations merely because the WAL crossed its size threshold.
+	if err := p.persistent.save(state, true); err != nil {
 		p.persistent.lastErr = err
 		return err
 	}

--- a/internal/virtio/fs_protocol_test.go
+++ b/internal/virtio/fs_protocol_test.go
@@ -97,6 +97,65 @@ func TestDecodeFUSERequestExcludesDescriptorPadding(t *testing.T) {
 	}
 }
 
+func TestFUSEDispatcherEnforcesAndReleasesPOSIXLocks(t *testing.T) {
+	device := NewFS(0, 0, 0, "locks", inertFSBackend{})
+	dispatchLock := func(opcode uint32, owner uint64, lockType uint32) fsReply {
+		raw := make([]byte, fuseInHeaderSize+fuseLKInSize)
+		binary.LittleEndian.PutUint32(raw[0:4], uint32(len(raw)))
+		binary.LittleEndian.PutUint32(raw[4:8], opcode)
+		binary.LittleEndian.PutUint64(raw[8:16], uint64(opcode)+owner)
+		binary.LittleEndian.PutUint64(raw[16:24], 9)
+		binary.LittleEndian.PutUint64(raw[40:48], 1)
+		binary.LittleEndian.PutUint64(raw[48:56], owner)
+		binary.LittleEndian.PutUint64(raw[64:72], ^uint64(0))
+		binary.LittleEndian.PutUint32(raw[72:76], lockType)
+		binary.LittleEndian.PutUint32(raw[76:80], uint32(owner))
+		result, err := device.dispatcher.Dispatch(raw)
+		if err != nil {
+			t.Fatalf("dispatch %s: %v", fuseOpcodeName(opcode), err)
+		}
+		return result.reply
+	}
+
+	if reply := dispatchLock(fuseSetLK, 100, linuxFWrLck); reply.errno != 0 {
+		t.Fatalf("first SETLK errno = %d", reply.errno)
+	}
+	get := dispatchLock(fuseGetLK, 200, linuxFRdLck)
+	if get.errno != 0 || len(get.extra) != fuseLKOutSize || binary.LittleEndian.Uint32(get.extra[16:20]) != linuxFWrLck || binary.LittleEndian.Uint32(get.extra[20:24]) == 0 {
+		t.Fatalf("GETLK reply = errno %d extra %x", get.errno, get.extra)
+	}
+	if reply := dispatchLock(fuseSetLK, 200, linuxFRdLck); reply.errno != -linuxEAGAIN {
+		t.Fatalf("conflicting SETLK errno = %d", reply.errno)
+	}
+
+	flush := make([]byte, fuseInHeaderSize+24)
+	binary.LittleEndian.PutUint32(flush[0:4], uint32(len(flush)))
+	binary.LittleEndian.PutUint32(flush[4:8], fuseFlush)
+	binary.LittleEndian.PutUint64(flush[8:16], 77)
+	binary.LittleEndian.PutUint64(flush[16:24], 9)
+	binary.LittleEndian.PutUint32(flush[48:52], fuseFlushLockOwner)
+	binary.LittleEndian.PutUint64(flush[56:64], 100)
+	if result, err := device.dispatcher.Dispatch(flush); err != nil || result.reply.errno != 0 {
+		t.Fatalf("FLUSH lock owner = reply %+v, err %v", result.reply, err)
+	}
+	if reply := dispatchLock(fuseSetLK, 200, linuxFRdLck); reply.errno != 0 {
+		t.Fatalf("SETLK after FLUSH errno = %d", reply.errno)
+	}
+	release := make([]byte, fuseInHeaderSize+24)
+	binary.LittleEndian.PutUint32(release[0:4], uint32(len(release)))
+	binary.LittleEndian.PutUint32(release[4:8], fuseRelease)
+	binary.LittleEndian.PutUint64(release[8:16], 78)
+	binary.LittleEndian.PutUint64(release[16:24], 9)
+	binary.LittleEndian.PutUint32(release[52:56], fuseReleaseFlockUnlock)
+	binary.LittleEndian.PutUint64(release[56:64], 200)
+	if result, err := device.dispatcher.Dispatch(release); err != nil || result.reply.errno != 0 {
+		t.Fatalf("RELEASE flock owner = reply %+v, err %v", result.reply, err)
+	}
+	if reply := dispatchLock(fuseSetLK, 300, linuxFWrLck); reply.errno != 0 {
+		t.Fatalf("SETLK after RELEASE errno = %d", reply.errno)
+	}
+}
+
 func FuzzDecodeFUSERequest(f *testing.F) {
 	valid := make([]byte, fuseInHeaderSize+4)
 	binary.LittleEndian.PutUint32(valid[:4], uint32(len(valid)))

--- a/internal/virtio/mountfs.go
+++ b/internal/virtio/mountfs.go
@@ -566,6 +566,33 @@ func (m *mountedFS) SetWritebackCache(enabled bool) {
 	}
 }
 
+func (m *mountedFS) SyncFS() int32 {
+	m.mu.RLock()
+	backends := make([]FSBackend, 0, len(m.mounts)+1)
+	backends = append(backends, m.root)
+	for _, mount := range m.mounts {
+		duplicate := false
+		for _, backend := range backends {
+			if sameFSBackend(backend, mount.backend) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			backends = append(backends, mount.backend)
+		}
+	}
+	m.mu.RUnlock()
+	for _, backend := range backends {
+		if syncer, ok := backend.(fsSyncFSBackend); ok {
+			if errno := syncer.SyncFS(); errno != 0 {
+				return errno
+			}
+		}
+	}
+	return 0
+}
+
 func (m *mountedFS) CachePolicy(nodeID uint64) FSCachePolicy {
 	node := m.node(nodeID)
 	if node == nil {

--- a/internal/vm/mounts/persistent.go
+++ b/internal/vm/mounts/persistent.go
@@ -81,7 +81,11 @@ func BuildPersistentImageMounts(storeRoot string, image *oci.Image, requested []
 			GuestPath: mount,
 			Backend:   backend,
 			Writable:  true,
-			CacheMode: "strict",
+			// The lower image is immutable and the upper is exclusively owned by
+			// this guest while its store lock is held. Guest-side mutations keep
+			// the kernel's own dentries coherent, so retaining lookup and attr
+			// results avoids turning package extraction into millions of RPCs.
+			CacheMode: "aggressive",
 		})
 	}
 	cleanup = false

--- a/internal/vm/mounts/persistent_test.go
+++ b/internal/vm/mounts/persistent_test.go
@@ -21,7 +21,7 @@ func TestBuildPersistentImageMountsUsesImageHomeAndReleasesFailedPreparation(t *
 	if err != nil {
 		t.Fatalf("build persistent image mount: %v", err)
 	}
-	if len(prepared) != 1 || prepared[0].GuestPath != "/home/scientist" || !prepared[0].Writable || prepared[0].CacheMode != "strict" {
+	if len(prepared) != 1 || prepared[0].GuestPath != "/home/scientist" || !prepared[0].Writable || prepared[0].CacheMode != "aggressive" {
 		t.Fatalf("persistent mount = %+v", prepared)
 	}
 	statusProvider, ok := prepared[0].Backend.(interface {


### PR DESCRIPTION
## Summary

- make persistent image `fsync` commit only the requested inode while unrelated reads and SSH traffic remain responsive
- separate file, directory, and whole-filesystem durability, including FUSE `SYNCFS`
- add POSIX/FUSE advisory range locks and release handling used by Remote SSH workloads
- use aggressive caching for exclusively owned persistent homes and one virtio-fs worker per request queue

## Root cause

Persistent file `fsync` held the global image filesystem mutex while synchronizing every dirty inode and committing the complete pending WAL state. A single VS Code durability request could therefore spend tens of seconds syncing thousands of unrelated files while all lookups and SSH authentication requests waited behind the same mutex. Persistent mounts also used strict metadata caching and a single request worker, amplifying the stall.

## Impact

VS Code Remote SSH installations and other metadata-heavy workloads can continue serving unrelated filesystem requests during slow host durability operations. File and directory durability no longer accidentally promotes unrelated pending data, and advisory locks no longer return `ENOSYS`.

## Validation

- `go test ./...`
- `go test -race ./internal/virtio -run 'TestPersistentImageFS|TestFuseLock|TestFUSEDispatcherEnforces' -count=1`
- `go vet ./internal/virtio ./internal/vm/mounts ./internal/vm`
- `git diff --check`
- built and launched SquadVM against the updated submodule
- completed a fresh VS Code Remote SSH server download, unpack, integrity verification, and extension-host startup in the live VM
