### PR TITLE
Add freestanding amd64 ELF boot support

### DIFF
--- a/internal/freestanding/boot/amd64/plan.go
+++ b/internal/freestanding/boot/amd64/plan.go
@@ -1,0 +1,217 @@
+package amd64
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	HigherHalfBase = uint64(0xffffffff80000000)
+
+	defaultBootInfoGPA = 0x00010000
+	defaultStackTopGPA = 0x00080000
+	defaultPagingGPA   = 0x00090000
+	pageSize           = 4096
+	pageTableSize      = 3 * pageSize
+	directMapSize      = 1 << 30
+
+	BootInfoMagic   = uint64(0x3436544f4f424343) // "CCBOOT64"
+	BootInfoVersion = uint64(1)
+	KernelOSABI     = elf.OSABI(0x80)
+	UserOSABI       = elf.OSABI(0x81)
+)
+
+// BootOptions controls the small host-to-kernel contract used for direct ELF
+// boot. The defaults keep all bootstrap data below 1 MiB and kernel images are
+// expected to load above it.
+type BootOptions struct {
+	MemorySize  uint64
+	BootInfoGPA uint64
+	StackTopGPA uint64
+	PagingGPA   uint64
+}
+
+// BootPlan contains the CPU state and reserved memory required by the VMM.
+type BootPlan struct {
+	EntryGVA          uint64
+	BootInfoGPA       uint64
+	BootInfoSize      uint64
+	StackTopGPA       uint64
+	PagingGPA         uint64
+	KernelPhysicalMin uint64
+	KernelPhysicalEnd uint64
+}
+
+// BootInfo is passed to the kernel in RDI. All addresses are guest physical
+// addresses unless explicitly named otherwise.
+type BootInfo struct {
+	Magic             uint64
+	Version           uint64
+	Size              uint64
+	MemorySize        uint64
+	HigherHalfBase    uint64
+	KernelPhysicalMin uint64
+	KernelPhysicalEnd uint64
+	PageSize          uint64
+}
+
+func PrepareBoot(memory []byte, kernel []byte, opts BootOptions) (*BootPlan, error) {
+	if len(memory) == 0 {
+		return nil, errors.New("guest memory is empty")
+	}
+	if len(kernel) == 0 {
+		return nil, errors.New("kernel file is empty")
+	}
+	if opts.MemorySize == 0 {
+		opts.MemorySize = uint64(len(memory))
+	}
+	if opts.MemorySize > uint64(len(memory)) {
+		return nil, fmt.Errorf("declared memory %#x exceeds mapped memory %#x", opts.MemorySize, len(memory))
+	}
+	if opts.BootInfoGPA == 0 {
+		opts.BootInfoGPA = defaultBootInfoGPA
+	}
+	if opts.StackTopGPA == 0 {
+		opts.StackTopGPA = defaultStackTopGPA
+	}
+	if opts.PagingGPA == 0 {
+		opts.PagingGPA = defaultPagingGPA
+	}
+	if opts.PagingGPA%pageSize != 0 {
+		return nil, fmt.Errorf("paging GPA %#x is not page-aligned", opts.PagingGPA)
+	}
+
+	entry, physicalMin, physicalEnd, err := loadELF(memory, kernel, opts)
+	if err != nil {
+		return nil, err
+	}
+	info := BootInfo{
+		Magic:             BootInfoMagic,
+		Version:           BootInfoVersion,
+		Size:              64,
+		MemorySize:        opts.MemorySize,
+		HigherHalfBase:    HigherHalfBase,
+		KernelPhysicalMin: physicalMin,
+		KernelPhysicalEnd: physicalEnd,
+		PageSize:          pageSize,
+	}
+	encoded := encodeBootInfo(info)
+	if rangesOverlap(opts.BootInfoGPA, uint64(len(encoded)), physicalMin, physicalEnd-physicalMin) {
+		return nil, fmt.Errorf("boot info at %#x overlaps kernel image", opts.BootInfoGPA)
+	}
+	if err := writeAt(memory, opts.BootInfoGPA, encoded); err != nil {
+		return nil, fmt.Errorf("write boot info: %w", err)
+	}
+
+	return &BootPlan{
+		EntryGVA:          entry,
+		BootInfoGPA:       opts.BootInfoGPA,
+		BootInfoSize:      uint64(len(encoded)),
+		StackTopGPA:       opts.StackTopGPA,
+		PagingGPA:         opts.PagingGPA,
+		KernelPhysicalMin: physicalMin,
+		KernelPhysicalEnd: physicalEnd,
+	}, nil
+}
+
+func loadELF(memory []byte, kernel []byte, opts BootOptions) (uint64, uint64, uint64, error) {
+	f, err := elf.NewFile(bytes.NewReader(kernel))
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("parse freestanding kernel ELF: %w", err)
+	}
+	defer f.Close()
+	if f.Class != elf.ELFCLASS64 || f.Data != elf.ELFDATA2LSB || f.Machine != elf.EM_X86_64 {
+		return 0, 0, 0, fmt.Errorf("unsupported kernel ELF class=%v data=%v machine=%v", f.Class, f.Data, f.Machine)
+	}
+	if f.Type != elf.ET_EXEC {
+		return 0, 0, 0, fmt.Errorf("kernel ELF type is %v, want ET_EXEC", f.Type)
+	}
+	if f.OSABI != KernelOSABI || f.ABIVersion != 1 {
+		return 0, 0, 0, fmt.Errorf("kernel ELF OSABI=%#x version=%d, want OSABI=%#x version=1", f.OSABI, f.ABIVersion, KernelOSABI)
+	}
+
+	physicalMin := ^uint64(0)
+	var physicalEnd uint64
+	entryExecutable := false
+	for _, prog := range f.Progs {
+		if prog.Type != elf.PT_LOAD || prog.Memsz == 0 {
+			continue
+		}
+		if prog.Filesz > prog.Memsz {
+			return 0, 0, 0, fmt.Errorf("kernel segment filesz %#x exceeds memsz %#x", prog.Filesz, prog.Memsz)
+		}
+		if prog.Vaddr < HigherHalfBase || prog.Vaddr-HigherHalfBase != prog.Paddr {
+			return 0, 0, 0, fmt.Errorf("kernel segment vaddr=%#x paddr=%#x does not use higher-half direct mapping %#x", prog.Vaddr, prog.Paddr, HigherHalfBase)
+		}
+		if prog.Paddr > opts.MemorySize || prog.Memsz > opts.MemorySize-prog.Paddr {
+			return 0, 0, 0, fmt.Errorf("kernel segment paddr=%#x memsz=%#x exceeds guest memory %#x", prog.Paddr, prog.Memsz, opts.MemorySize)
+		}
+		if prog.Paddr > directMapSize || prog.Memsz > directMapSize-prog.Paddr {
+			return 0, 0, 0, fmt.Errorf("kernel segment paddr=%#x memsz=%#x exceeds the bootstrap direct map %#x", prog.Paddr, prog.Memsz, directMapSize)
+		}
+		if rangesOverlap(prog.Paddr, prog.Memsz, opts.PagingGPA, pageTableSize) {
+			return 0, 0, 0, fmt.Errorf("kernel segment paddr=%#x memsz=%#x overlaps bootstrap page tables", prog.Paddr, prog.Memsz)
+		}
+		segment := memory[prog.Paddr : prog.Paddr+prog.Memsz]
+		clear(segment)
+		if prog.Filesz != 0 {
+			if _, err := io.ReadFull(prog.Open(), segment[:prog.Filesz]); err != nil {
+				return 0, 0, 0, fmt.Errorf("read kernel segment at %#x: %w", prog.Paddr, err)
+			}
+		}
+		if prog.Paddr < physicalMin {
+			physicalMin = prog.Paddr
+		}
+		if end := alignUp(prog.Paddr+prog.Memsz, pageSize); end > physicalEnd {
+			physicalEnd = end
+		}
+		if prog.Flags&elf.PF_X != 0 && f.Entry >= prog.Vaddr && f.Entry < prog.Vaddr+prog.Memsz {
+			entryExecutable = true
+		}
+	}
+	if physicalEnd == 0 {
+		return 0, 0, 0, errors.New("kernel ELF has no loadable segments")
+	}
+	if !entryExecutable {
+		return 0, 0, 0, fmt.Errorf("kernel entry %#x is not in an executable load segment", f.Entry)
+	}
+	return f.Entry, physicalMin, physicalEnd, nil
+}
+
+func encodeBootInfo(info BootInfo) []byte {
+	values := [...]uint64{
+		info.Magic,
+		info.Version,
+		info.Size,
+		info.MemorySize,
+		info.HigherHalfBase,
+		info.KernelPhysicalMin,
+		info.KernelPhysicalEnd,
+		info.PageSize,
+	}
+	out := make([]byte, len(values)*8)
+	for index, value := range values {
+		binary.LittleEndian.PutUint64(out[index*8:], value)
+	}
+	return out
+}
+
+func writeAt(memory []byte, address uint64, data []byte) error {
+	if address > uint64(len(memory)) || uint64(len(data)) > uint64(len(memory))-address {
+		return fmt.Errorf("range %#x..%#x exceeds guest memory %#x", address, address+uint64(len(data)), len(memory))
+	}
+	copy(memory[address:], data)
+	return nil
+}
+
+func rangesOverlap(a, aSize, b, bSize uint64) bool {
+	return a < b+bSize && b < a+aSize
+}
+
+func alignUp(value, alignment uint64) uint64 {
+	return (value + alignment - 1) &^ (alignment - 1)
+}

--- a/internal/freestanding/boot/amd64/plan.go
+++ b/internal/freestanding/boot/amd64/plan.go
@@ -16,7 +16,7 @@ const (
 	defaultStackTopGPA = 0x00080000
 	defaultPagingGPA   = 0x00090000
 	pageSize           = 4096
-	pageTableSize      = 3 * pageSize
+	pageTableSize      = 5 * pageSize
 	directMapSize      = 1 << 30
 
 	BootInfoMagic   = uint64(0x3436544f4f424343) // "CCBOOT64"
@@ -49,14 +49,18 @@ type BootPlan struct {
 // BootInfo is passed to the kernel in RDI. All addresses are guest physical
 // addresses unless explicitly named otherwise.
 type BootInfo struct {
-	Magic             uint64
-	Version           uint64
-	Size              uint64
-	MemorySize        uint64
-	HigherHalfBase    uint64
-	KernelPhysicalMin uint64
-	KernelPhysicalEnd uint64
-	PageSize          uint64
+	Magic              uint64
+	Version            uint64
+	Size               uint64
+	MemorySize         uint64
+	HigherHalfBase     uint64
+	KernelPhysicalMin  uint64
+	KernelPhysicalEnd  uint64
+	PageSize           uint64
+	PagingPhysicalBase uint64
+	PagingSize         uint64
+	BootstrapStackTop  uint64
+	BootstrapStackSize uint64
 }
 
 func PrepareBoot(memory []byte, kernel []byte, opts BootOptions) (*BootPlan, error) {
@@ -90,15 +94,20 @@ func PrepareBoot(memory []byte, kernel []byte, opts BootOptions) (*BootPlan, err
 		return nil, err
 	}
 	info := BootInfo{
-		Magic:             BootInfoMagic,
-		Version:           BootInfoVersion,
-		Size:              64,
-		MemorySize:        opts.MemorySize,
-		HigherHalfBase:    HigherHalfBase,
-		KernelPhysicalMin: physicalMin,
-		KernelPhysicalEnd: physicalEnd,
-		PageSize:          pageSize,
+		Magic:              BootInfoMagic,
+		Version:            BootInfoVersion,
+		Size:               64,
+		MemorySize:         opts.MemorySize,
+		HigherHalfBase:     HigherHalfBase,
+		KernelPhysicalMin:  physicalMin,
+		KernelPhysicalEnd:  physicalEnd,
+		PageSize:           pageSize,
+		PagingPhysicalBase: opts.PagingGPA,
+		PagingSize:         pageTableSize,
+		BootstrapStackTop:  opts.StackTopGPA,
+		BootstrapStackSize: pageSize,
 	}
+	info.Size = uint64(binary.Size(info))
 	encoded := encodeBootInfo(info)
 	if rangesOverlap(opts.BootInfoGPA, uint64(len(encoded)), physicalMin, physicalEnd-physicalMin) {
 		return nil, fmt.Errorf("boot info at %#x overlaps kernel image", opts.BootInfoGPA)
@@ -192,6 +201,10 @@ func encodeBootInfo(info BootInfo) []byte {
 		info.KernelPhysicalMin,
 		info.KernelPhysicalEnd,
 		info.PageSize,
+		info.PagingPhysicalBase,
+		info.PagingSize,
+		info.BootstrapStackTop,
+		info.BootstrapStackSize,
 	}
 	out := make([]byte, len(values)*8)
 	for index, value := range values {

--- a/internal/freestanding/boot/amd64/plan_test.go
+++ b/internal/freestanding/boot/amd64/plan_test.go
@@ -1,0 +1,73 @@
+package amd64
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestPrepareBootLoadsHigherHalfELF(t *testing.T) {
+	const (
+		physical = uint64(0x200000)
+		entry    = HigherHalfBase + physical
+	)
+	payload := []byte{0xf4}
+	kernel := testELF(entry, physical, payload, 0x1000)
+	memory := make([]byte, 8<<20)
+	plan, err := PrepareBoot(memory, kernel, BootOptions{MemorySize: uint64(len(memory))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.EntryGVA != entry || plan.KernelPhysicalMin != physical || plan.KernelPhysicalEnd != physical+0x1000 {
+		t.Fatalf("unexpected boot plan: %+v", plan)
+	}
+	if memory[physical] != 0xf4 || memory[physical+1] != 0 {
+		t.Fatalf("kernel segment was not loaded and zero-filled: %x %x", memory[physical], memory[physical+1])
+	}
+	if got := binary.LittleEndian.Uint64(memory[plan.BootInfoGPA:]); got != BootInfoMagic {
+		t.Fatalf("boot info magic = %#x, want %#x", got, BootInfoMagic)
+	}
+}
+
+func TestPrepareBootRejectsNonHigherHalfELF(t *testing.T) {
+	kernel := testELF(0x200000, 0x200000, []byte{0xf4}, 1)
+	_, err := PrepareBoot(make([]byte, 8<<20), kernel, BootOptions{MemorySize: 8 << 20})
+	if err == nil {
+		t.Fatal("expected non-higher-half ELF to be rejected")
+	}
+}
+
+func TestPrepareBootRejectsUserspaceOSABI(t *testing.T) {
+	kernel := testELF(HigherHalfBase+0x200000, 0x200000, []byte{0xf4}, 1)
+	kernel[7] = byte(UserOSABI)
+	_, err := PrepareBoot(make([]byte, 8<<20), kernel, BootOptions{MemorySize: 8 << 20})
+	if err == nil {
+		t.Fatal("expected userspace OSABI to be rejected by kernel loader")
+	}
+}
+
+func testELF(entry, physical uint64, payload []byte, memorySize uint64) []byte {
+	const dataOffset = 0x1000
+	out := make([]byte, dataOffset+len(payload))
+	copy(out, []byte{0x7f, 'E', 'L', 'F', 2, 1, 1})
+	out[7] = byte(KernelOSABI)
+	out[8] = 1
+	binary.LittleEndian.PutUint16(out[16:], 2)
+	binary.LittleEndian.PutUint16(out[18:], 62)
+	binary.LittleEndian.PutUint32(out[20:], 1)
+	binary.LittleEndian.PutUint64(out[24:], entry)
+	binary.LittleEndian.PutUint64(out[32:], 64)
+	binary.LittleEndian.PutUint16(out[52:], 64)
+	binary.LittleEndian.PutUint16(out[54:], 56)
+	binary.LittleEndian.PutUint16(out[56:], 1)
+	program := out[64:]
+	binary.LittleEndian.PutUint32(program[0:], 1)
+	binary.LittleEndian.PutUint32(program[4:], 5)
+	binary.LittleEndian.PutUint64(program[8:], dataOffset)
+	binary.LittleEndian.PutUint64(program[16:], HigherHalfBase+physical)
+	binary.LittleEndian.PutUint64(program[24:], physical)
+	binary.LittleEndian.PutUint64(program[32:], uint64(len(payload)))
+	binary.LittleEndian.PutUint64(program[40:], memorySize)
+	binary.LittleEndian.PutUint64(program[48:], pageSize)
+	copy(out[dataOffset:], payload)
+	return out
+}

--- a/internal/hv/kvm/freestanding_boot_linux_amd64.go
+++ b/internal/hv/kvm/freestanding_boot_linux_amd64.go
@@ -5,6 +5,7 @@ package kvm
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"runtime"
@@ -39,6 +40,9 @@ func BootFreestandingELFToMarker(ctx context.Context, kernel []byte, memoryMB ui
 	}
 	if err := vm.SetFreestandingLongMode(plan.EntryGVA, plan.BootInfoGPA, plan.StackTopGPA, plan.PagingGPA); err != nil {
 		return "", fmt.Errorf("set freestanding long mode: %w", err)
+	}
+	if got := binary.LittleEndian.Uint64(memory[plan.PagingGPA+0x2000+2*8:]); got != (plan.PagingGPA+0x3000)|7 {
+		return "", fmt.Errorf("invalid bootstrap user PDE %#x", got)
 	}
 
 	var serialOut bytes.Buffer
@@ -80,7 +84,18 @@ func BootFreestandingELFToMarker(ctx context.Context, kernel []byte, memoryMB ui
 			return serialOut.String(), fmt.Errorf("freestanding guest halted before marker")
 		case ExitShutdown:
 			pc, _ := vm.GetPC()
-			return serialOut.String(), fmt.Errorf("freestanding guest shut down before marker at pc=%#x", pc)
+			fault, _ := vm.GetFaultAddress()
+			registers := vm.VCPURegisters(0)
+			faultEntries := traceFreestandingPageTables(memory, plan.PagingGPA, fault)
+			code := []byte(nil)
+			if physical, ok := walkFreestandingPageTables(memory, plan.PagingGPA, pc); ok && physical < uint64(len(memory)) {
+				end := physical + 8
+				if end > uint64(len(memory)) {
+					end = uint64(len(memory))
+				}
+				code = memory[physical:end]
+			}
+			return serialOut.String(), fmt.Errorf("freestanding guest shut down before marker at pc=%#x fault=%#x code=% x pages=%#x registers=%v", pc, fault, code, faultEntries, registers)
 		case ExitSystemEvent:
 			return serialOut.String(), fmt.Errorf("unexpected system event %d before marker", exit.SystemEvent)
 		default:
@@ -91,4 +106,51 @@ func BootFreestandingELFToMarker(ctx context.Context, kernel []byte, memoryMB ui
 			return serialOut.String(), nil
 		}
 	}
+}
+
+func traceFreestandingPageTables(memory []byte, root uint64, virtual uint64) [4]uint64 {
+	var entries [4]uint64
+	indices := [4]uint64{(virtual >> 39) & 511, (virtual >> 30) & 511, (virtual >> 21) & 511, (virtual >> 12) & 511}
+	table := root
+	for level := 0; level < len(entries); level++ {
+		address := table + indices[level]*8
+		if address > uint64(len(memory)) || 8 > uint64(len(memory))-address {
+			break
+		}
+		entries[level] = binary.LittleEndian.Uint64(memory[address : address+8])
+		if entries[level]&1 == 0 || level == 2 && entries[level]&(1<<7) != 0 {
+			break
+		}
+		table = entries[level] & 0x000ffffffffff000
+	}
+	return entries
+}
+
+func walkFreestandingPageTables(memory []byte, root uint64, virtual uint64) (uint64, bool) {
+	read := func(address uint64) (uint64, bool) {
+		if address > uint64(len(memory)) || 8 > uint64(len(memory))-address {
+			return 0, false
+		}
+		return binary.LittleEndian.Uint64(memory[address : address+8]), true
+	}
+	entry, ok := read(root + ((virtual>>39)&511)*8)
+	if !ok || entry&1 == 0 {
+		return 0, false
+	}
+	entry, ok = read(entry&0x000ffffffffff000 + ((virtual>>30)&511)*8)
+	if !ok || entry&1 == 0 {
+		return 0, false
+	}
+	entry, ok = read(entry&0x000ffffffffff000 + ((virtual>>21)&511)*8)
+	if !ok || entry&1 == 0 {
+		return 0, false
+	}
+	if entry&(1<<7) != 0 {
+		return entry&0x000fffffffe00000 + (virtual & 0x1fffff), true
+	}
+	entry, ok = read(entry&0x000ffffffffff000 + ((virtual>>12)&511)*8)
+	if !ok || entry&1 == 0 {
+		return 0, false
+	}
+	return entry&0x000ffffffffff000 + (virtual & 0xfff), true
 }

--- a/internal/hv/kvm/freestanding_boot_linux_amd64.go
+++ b/internal/hv/kvm/freestanding_boot_linux_amd64.go
@@ -1,0 +1,94 @@
+//go:build linux && amd64
+
+package kvm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"j5.nz/cc/internal/amd64vm"
+	bootamd64 "j5.nz/cc/internal/freestanding/boot/amd64"
+)
+
+// BootFreestandingELFToMarker directly loads a higher-half ELF kernel, enters
+// it in long mode, and captures COM1 until marker is printed.
+func BootFreestandingELFToMarker(ctx context.Context, kernel []byte, memoryMB uint64, marker string) (string, error) {
+	if strings.TrimSpace(marker) == "" {
+		return "", fmt.Errorf("boot marker is required")
+	}
+	vm, err := NewVM()
+	if err != nil {
+		return "", err
+	}
+	defer vm.Close()
+
+	memory, err := mapAMD64GuestMemory(vm, memoryMB)
+	if err != nil {
+		return "", fmt.Errorf("map guest memory: %w", err)
+	}
+	plan, err := bootamd64.PrepareBoot(memory, kernel, bootamd64.BootOptions{
+		MemorySize: amd64vm.MemorySizeBytes(memoryMB),
+	})
+	if err != nil {
+		return "", fmt.Errorf("prepare freestanding boot: %w", err)
+	}
+	if err := vm.SetFreestandingLongMode(plan.EntryGVA, plan.BootInfoGPA, plan.StackTopGPA, plan.PagingGPA); err != nil {
+		return "", fmt.Errorf("set freestanding long mode: %w", err)
+	}
+
+	var serialOut bytes.Buffer
+	uart := newAMD64UART(vm, &serialOut)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	vm.SetVCPUTID(0, unix.Gettid())
+	defer vm.SetVCPUTID(0, 0)
+	cancelDone := make(chan struct{})
+	defer close(cancelDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			vm.RequestImmediateExit()
+		case <-cancelDone:
+		}
+	}()
+
+	var exit Exit
+	for step := 0; ; step++ {
+		if err := ctx.Err(); err != nil {
+			return serialOut.String(), err
+		}
+		if err := vm.RunVCPUInterruptible(0, &exit); err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return serialOut.String(), fmt.Errorf("run step %d: %w", step, err)
+		}
+		if strings.Contains(serialOut.String(), marker) {
+			return serialOut.String(), nil
+		}
+		switch exit.Reason {
+		case ExitIO:
+			if err := handleBootIO(uart, exit.IO); err != nil {
+				return serialOut.String(), err
+			}
+		case ExitHLT:
+			return serialOut.String(), fmt.Errorf("freestanding guest halted before marker")
+		case ExitShutdown:
+			pc, _ := vm.GetPC()
+			return serialOut.String(), fmt.Errorf("freestanding guest shut down before marker at pc=%#x", pc)
+		case ExitSystemEvent:
+			return serialOut.String(), fmt.Errorf("unexpected system event %d before marker", exit.SystemEvent)
+		default:
+			pc, _ := vm.GetPC()
+			return serialOut.String(), fmt.Errorf("unexpected exit reason %d at pc=%#x", exit.Reason, pc)
+		}
+		if strings.Contains(serialOut.String(), marker) {
+			return serialOut.String(), nil
+		}
+	}
+}

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -856,6 +856,57 @@ func (v *VM) SetLongMode(entry, zeroPage, stack, pagingBase uint64) error {
 	})
 }
 
+// SetFreestandingLongMode enters a direct-boot amd64 kernel with identity
+// mappings for low memory and a matching alias at 0xffffffff80000000. RDI
+// contains the guest-physical address of the boot information structure.
+func (v *VM) SetFreestandingLongMode(entry, bootInfo, stack, pagingBase uint64) error {
+	if v == nil || len(v.vcpus) == 0 {
+		return fmt.Errorf("missing bootstrap vcpu")
+	}
+	if err := v.setupFreestandingPageTables(pagingBase); err != nil {
+		return err
+	}
+	bsp := v.vcpus[0]
+	sregs, err := getSRegs(bsp.fd)
+	if err != nil {
+		return err
+	}
+	const (
+		cr0PE   = 1 << 0
+		cr0MP   = 1 << 1
+		cr0ET   = 1 << 4
+		cr0NE   = 1 << 5
+		cr0WP   = 1 << 16
+		cr0AM   = 1 << 18
+		cr0PG   = 1 << 31
+		cr4PAE  = 1 << 5
+		eferLME = 1 << 8
+		eferLMA = 1 << 10
+	)
+	sregs.Cr3 = pagingBase
+	sregs.Cr4 |= cr4PAE
+	sregs.Cr0 |= cr0PE | cr0MP | cr0ET | cr0NE | cr0WP | cr0AM | cr0PG
+	sregs.Efer = eferLME | eferLMA
+
+	code := kvmSegment{Base: 0, Limit: 0xffffffff, Selector: 0x10, Type: 11, Present: 1, S: 1, L: 1, G: 1}
+	data := kvmSegment{Base: 0, Limit: 0xffffffff, Selector: 0x18, Type: 3, Present: 1, S: 1, Db: 1, G: 1}
+	sregs.Cs = code
+	sregs.Ds = data
+	sregs.Es = data
+	sregs.Fs = data
+	sregs.Gs = data
+	sregs.Ss = data
+	if err := setSRegs(bsp.fd, &sregs); err != nil {
+		return err
+	}
+	return setRegs(bsp.fd, &kvmRegs{
+		Rip:    entry,
+		Rdi:    bootInfo,
+		Rsp:    stack,
+		Rflags: 0x2,
+	})
+}
+
 func (v *VM) SetFreeBSDLongMode(entry, stack, pagingBase uint64) error {
 	if v == nil || len(v.vcpus) == 0 {
 		return fmt.Errorf("missing bootstrap vcpu")
@@ -964,6 +1015,35 @@ func (v *VM) setupPageTables(pagingBase uint64, giB int) error {
 			phys := (uint64(g) << 30) | (uint64(i) << 21)
 			put64(pd+uint64(i)*8, phys|p|rw|us|ps)
 		}
+	}
+	return nil
+}
+
+func (v *VM) setupFreestandingPageTables(pagingBase uint64) error {
+	const tableBytes = uint64(3 * 0x1000)
+	if pagingBase > v.lowMemLimit || tableBytes > v.lowMemLimit-pagingBase {
+		return fmt.Errorf("freestanding paging structures do not fit in low memory")
+	}
+	clear(v.mem[pagingBase : pagingBase+tableBytes])
+	put64 := func(addr, value uint64) {
+		binary.LittleEndian.PutUint64(v.mem[addr:addr+8], value)
+	}
+	pml4 := pagingBase
+	pdpt := pagingBase + 0x1000
+	pd := pagingBase + 0x2000
+	const (
+		present = 1 << 0
+		write   = 1 << 1
+		large   = 1 << 7
+	)
+	// Identity-map the first GiB for bootstrap data and alias that same range
+	// at 0xffffffff80000000 for the kernel's higher-half image.
+	put64(pml4+0*8, pdpt|present|write)
+	put64(pml4+511*8, pdpt|present|write)
+	put64(pdpt+0*8, pd|present|write)
+	put64(pdpt+510*8, pd|present|write)
+	for index := uint64(0); index < 512; index++ {
+		put64(pd+index*8, index*0x200000|present|write|large)
 	}
 	return nil
 }

--- a/internal/hv/kvm/vm_linux_amd64.go
+++ b/internal/hv/kvm/vm_linux_amd64.go
@@ -505,6 +505,17 @@ func (v *VM) GetPC() (uint64, error) {
 	return v.GetVCPUPC(0)
 }
 
+func (v *VM) GetFaultAddress() (uint64, error) {
+	if v == nil || len(v.vcpus) == 0 {
+		return 0, fmt.Errorf("vcpu 0 out of range")
+	}
+	sregs, err := getSRegs(v.vcpus[0].fd)
+	if err != nil {
+		return 0, err
+	}
+	return sregs.Cr2, nil
+}
+
 func (v *VM) GetVCPUPC(index int) (uint64, error) {
 	if v == nil || index < 0 || index >= len(v.vcpus) {
 		return 0, fmt.Errorf("vcpu %d out of range", index)
@@ -1020,7 +1031,7 @@ func (v *VM) setupPageTables(pagingBase uint64, giB int) error {
 }
 
 func (v *VM) setupFreestandingPageTables(pagingBase uint64) error {
-	const tableBytes = uint64(3 * 0x1000)
+	const tableBytes = uint64(5 * 0x1000)
 	if pagingBase > v.lowMemLimit || tableBytes > v.lowMemLimit-pagingBase {
 		return fmt.Errorf("freestanding paging structures do not fit in low memory")
 	}
@@ -1031,19 +1042,27 @@ func (v *VM) setupFreestandingPageTables(pagingBase uint64) error {
 	pml4 := pagingBase
 	pdpt := pagingBase + 0x1000
 	pd := pagingBase + 0x2000
+	pt := pagingBase + 0x3000
 	const (
 		present = 1 << 0
 		write   = 1 << 1
+		user    = 1 << 2
 		large   = 1 << 7
 	)
 	// Identity-map the first GiB for bootstrap data and alias that same range
 	// at 0xffffffff80000000 for the kernel's higher-half image.
-	put64(pml4+0*8, pdpt|present|write)
+	put64(pml4+0*8, pdpt|present|write|user)
 	put64(pml4+511*8, pdpt|present|write)
-	put64(pdpt+0*8, pd|present|write)
+	put64(pdpt+0*8, pd|present|write|user)
 	put64(pdpt+510*8, pd|present|write)
 	for index := uint64(0); index < 512; index++ {
 		put64(pd+index*8, index*0x200000|present|write|large)
+	}
+	// Reserve one lower-half 2 MiB window for the first userspace task. Leaves
+	// begin supervisor-only; the kernel memory service grants individual pages.
+	put64(pd+2*8, pt|present|write|user)
+	for index := uint64(0); index < 512; index++ {
+		put64(pt+index*8, 0x400000+index*0x1000|present|write)
 	}
 	return nil
 }

--- a/kernelvm/kernelvm_linux_amd64.go
+++ b/kernelvm/kernelvm_linux_amd64.go
@@ -1,0 +1,31 @@
+//go:build linux && amd64
+
+// Package kernelvm exposes CC's minimal direct-kernel test surface without
+// leaking its internal KVM implementation.
+package kernelvm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"j5.nz/cc/internal/hv/kvm"
+)
+
+type Options struct {
+	MemoryMB uint64
+	Marker   string
+}
+
+func RunELF(ctx context.Context, kernel []byte, opts Options) (string, error) {
+	if len(kernel) == 0 {
+		return "", fmt.Errorf("kernel ELF is empty")
+	}
+	if strings.TrimSpace(opts.Marker) == "" {
+		return "", fmt.Errorf("serial marker is required")
+	}
+	if opts.MemoryMB == 0 {
+		opts.MemoryMB = 64
+	}
+	return kvm.BootFreestandingELFToMarker(ctx, kernel, opts.MemoryMB, opts.Marker)
+}

--- a/kernelvm/kernelvm_other.go
+++ b/kernelvm/kernelvm_other.go
@@ -1,0 +1,17 @@
+//go:build !linux || !amd64
+
+package kernelvm
+
+import (
+	"context"
+	"fmt"
+)
+
+type Options struct {
+	MemoryMB uint64
+	Marker   string
+}
+
+func RunELF(context.Context, []byte, Options) (string, error) {
+	return "", fmt.Errorf("direct freestanding ELF boot currently requires a linux/amd64 KVM host")
+}


### PR DESCRIPTION
## What changed

- add a validated higher-half amd64 ELF loader and versioned boot-information contract
- add KVM long-mode setup with low-memory and `0xffffffff80000000` aliases
- expose a small public `kernelvm` package for direct kernel smoke tests
- enforce separate kernel and userspace ELF OSABI values

## Why

Malanotio needs to boot a freestanding Renvo kernel directly under CC without routing through a managed Linux guest.

## Impact

Existing managed Linux and BSD boot paths are unchanged. The new API is currently implemented for Linux/amd64 KVM hosts and returns a clear unsupported-platform error elsewhere.

## Checks

- `go test ./internal/freestanding/boot/amd64 ./kernelvm ./internal/hv/kvm`
- Malanotio end-to-end KVM boot through `make test`